### PR TITLE
Contexts endpoint renamed and documented

### DIFF
--- a/app/controllers/api/v3/contexts_controller.rb
+++ b/app/controllers/api/v3/contexts_controller.rb
@@ -13,7 +13,7 @@ module Api
           all
 
         render json: @contexts, root: 'data',
-               each_serializer: Api::V3::GetContexts::ContextSerializer
+               each_serializer: Api::V3::Contexts::ContextSerializer
       end
     end
   end

--- a/app/serializers/api/v3/contexts/context_serializer.rb
+++ b/app/serializers/api/v3/contexts/context_serializer.rb
@@ -1,6 +1,6 @@
 module Api
   module V3
-    module GetContexts
+    module Contexts
       class ContextSerializer < ActiveModel::Serializer
         attributes :id, :is_default, :is_disabled, :years, :default_year,
                    :country_id, :commodity_id, :default_basemap

--- a/app/serializers/api/v3/contexts/recolor_by_attribute_serializer.rb
+++ b/app/serializers/api/v3/contexts/recolor_by_attribute_serializer.rb
@@ -1,6 +1,6 @@
 module Api
   module V3
-    module GetContexts
+    module Contexts
       class RecolorByAttributeSerializer < ActiveModel::Serializer
         attributes :is_default, :is_disabled, :group_number, :position,
                    :legend_type, :legend_color_theme, :interval_count,

--- a/app/serializers/api/v3/contexts/resize_by_attribute_serializer.rb
+++ b/app/serializers/api/v3/contexts/resize_by_attribute_serializer.rb
@@ -1,6 +1,6 @@
 module Api
   module V3
-    module GetContexts
+    module Contexts
       class ResizeByAttributeSerializer < ActiveModel::Serializer
         attributes :is_default, :is_disabled, :group_number, :position, :name
         attribute :display_name, key: :label

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v3 do
-      get '/get_contexts', to: 'contexts#index'
+      resources :contexts, only: [:index]
       get '/get_all_nodes', to: 'nodes#get_all_nodes'
     end
     namespace :v2 do

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -1,0 +1,457 @@
+swagger: '2.0'
+info:
+  description: Trase API V3
+  version: 3.0.0
+  title: Trase API
+  termsOfService: 'https://trase.earth/terms-of-use.html'
+  contact:
+    email: info@trase.earth
+  license:
+    name: MIT License
+host: trase.earth
+basePath: /api/v3
+tags:
+  - name: context
+  - name: flow
+  - name: node
+schemes:
+  - https
+paths:
+  /contexts:
+    get:
+      tags:
+        - context
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Context'
+  '/context/{context_id}/columns':
+    get:
+      tags:
+        - context
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Column'
+  '/context/{context_id}/map_groups':
+    get:
+      tags:
+        - context
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/MapGroup'
+  '/context/{context_id}/download_attributes':
+    get:
+      tags:
+        - context
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Attribute'
+  '/context/{context_id}/flows':
+    get:
+      tags:
+        - flow
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Flow'
+  '/context/{context_id}/nodes':
+    get:
+      tags:
+        - node
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Node'
+  '/context/{context_id}/nodes/attributes':
+    get:
+      tags:
+        - node
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/NodeAttribute'
+  '/context/{context_id}/nodes/{id}/actor':
+    get:
+      tags:
+        - node
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Node'
+  '/context/{context_id}/nodes/{id}/place':
+    get:
+      tags:
+        - node
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Node'
+  '/context/{context_id}/nodes/{id}/linked_nodes':
+    get:
+      tags:
+        - node
+      summary: ''
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/LinkedNode'
+  /newsletter_subscriptions:
+    post:
+      tags:
+        - newsletter_subscription
+      responses:
+        '200':
+          description: successful operation
+  /download:
+    get:
+      tags:
+        - download
+      produces:
+        - text/csv
+        - application/json
+      responses:
+        '200':
+          description: successful operation
+definitions:
+  Context:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      isDefault:
+        type: boolean
+      isDisabled:
+        type: boolean
+      years:
+        type: array
+        items:
+          type: integer
+      defaultYear:
+        type: integer
+      countryId:
+        type: integer
+      commodityId:
+        type: integer
+      countryName:
+        type: string
+      commodityName:
+        type: string
+      defaultBasemap:
+        type: string
+      defaultContextLayers:
+        type: array
+        items:
+          type: string
+      map:
+        type: object
+        properties:
+          latitude:
+            type: number
+          longitude:
+            type: number
+          zoom:
+            type: integer
+      recolorBy:
+        type: array
+        items:
+          $ref: '#/definitions/RecolorBy'
+      resizeBy:
+        type: array
+        items:
+          $ref: '#/definitions/ResizeBy'
+      filterBy:
+        type: array
+        items:
+          $ref: '#/definitions/FilterBy'
+  RecolorBy:
+    type: object
+    properties:
+      isDefault:
+        type: boolean
+      isDisabled:
+        type: boolean
+      groupNumber:
+        type: integer
+      position:
+        type: integer
+      legendType:
+        type: string
+      legendColorTheme:
+        type: string
+      intervalCount":
+        type: integer
+      minValue:
+        type: string
+      maxValue:
+        type: string
+      divisor:
+        type: number
+      type:
+        type: string
+        enum:
+          - ind
+          - qual
+          - quant
+      name:
+        type: string
+      label:
+        type: string
+      description:
+        type: string
+      nodes:
+        type: array
+        items:
+          type: string
+  ResizeBy:
+    type: object
+    properties:
+      isDefault:
+        type: boolean
+      isDisabled:
+        type: boolean
+      groupNumber:
+        type: integer
+      position:
+        type: integer
+      name:
+        type: string
+      label:
+        type: string
+      description:
+        type: string
+  FilterBy:
+    type: object
+    properties:
+      name:
+        type: string
+      nodes:
+        type: array
+        items:
+          type: object
+          properties:
+            nodeId:
+              type: integer
+            name:
+              type: string
+  Flow:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+  Node:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+  LinkedNode:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+  NodeAttribute:
+    type: object
+    properties:
+      node_id:
+        type: integer
+        format: int64
+      attribute_id:
+        type: integer
+        format: int64
+      attribute_type:
+        type: string
+        enum:
+          - Ind
+          - Qual
+          - Quant
+  Column:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+  MapGroup:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+  Attribute:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      type:
+        type: string
+  NewsletterSubscription:
+    type: object
+    properties:
+      email:
+        type: string

--- a/spec/support/gold_master_urls.yml
+++ b/spec/support/gold_master_urls.yml
@@ -55,7 +55,7 @@ json:
     name: get_contexts
     version: v2
     v3_ready: true
-    v3_url: /api/v3/get_contexts
+    v3_url: /api/v3/contexts
     <<: *context_queries
   - url: /api/v2/get_all_nodes
     name: get_all_nodes

--- a/spec/version_migration/get_contexts_spec.rb
+++ b/spec/version_migration/get_contexts_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Get contexts', type: :request do
   include_context 'brazil resize by'
   include_context 'brazil recolor by'
 
-  describe 'GET /api/v2/get_contexts === GET /api/v3/get_contexts ' do
+  describe 'GET /api/v2/get_contexts === GET /api/v3/contexts ' do
     it 'has the correct response structure' do
       SchemaRevamp.new.copy
 
@@ -14,7 +14,7 @@ RSpec.describe 'Get contexts', type: :request do
 
       expect(@response.status).to eq 200
 
-      get '/api/v3/get_contexts'
+      get '/api/v3/contexts'
       expect(@response.status).to eq 200
       v3_response = HashSorter.new(JSON.parse(@response.body)).sort
 


### PR DESCRIPTION
I think V3 endpoints are not used anywhere yet, so proposing to rename `/get_contexts` -> `/contexts`.

I also added a swagger file with `/contexts` documented and a new convention for other endpoints names proposed:

| old | new |
|-----|----|
|/api/v2/get_contexts | /api/v3/contexts|
|/api/v2/get_columns| /api/v3/context/{context_id}/columns|
|/api/v2/get_map_base_data| /api/v3/context/{context_id}/map_groups|
|/api/v2/indicators| /api/v3/context/{context_id}/download_attributes|
|/api/v1/get_flows| /api/v3/context/{context_id}/flows|
|/api/v2/get_all_nodes| /api/v3/context/{context_id}/nodes|
|/api/v1/get_nodes| /api/v3/context/{context_id}/nodes/attributes|
|/api/v2/get_actor_node_attributes| /api/v3/context/{context_id}/nodes/{id}/actor|
|/api/v2/get_place_node_attributes| /api/v3/context/{context_id}/nodes/{id}/place|
|/api/v2/get_linked_geoids| /api/v3/context/{context_id}/nodes/{id}/linked_nodes|
|/api/v2/download| /api/v3/download|
|POST /api/v2/newsletter_subscriptions|POST /api/v3/newsletter_subscriptions|



