### PR TITLE
Added the v3 endpoint for map groups

### DIFF
--- a/app/controllers/api/v3/map_groups_controller.rb
+++ b/app/controllers/api/v3/map_groups_controller.rb
@@ -6,10 +6,17 @@ module Api
           where(context_id: @context.id).
           order('position ASC, id ASC')
 
-        dimensions = Api::V3::Readonly::MapAttribute.select('color_scale, id, bucket_3, bucket_5,
-map_attribute_group_id as group_id, is_default, years, name, attribute_type as type, unit, description,
-aggregate_method, layer_attribute_id, map_attribute_group_id as group_id').
-          where(is_disabled: false).
+        dimensions = Api::V3::Readonly::MapAttribute.select("color_scale, \
+#{Api::V3::Readonly::MapAttribute.table_name}.id, bucket_3, bucket_5, \
+map_attribute_group_id as group_id, is_default, years, \
+#{Api::V3::Readonly::MapAttribute.table_name}.name, attribute_type as type, \
+unit, description, aggregate_method, layer_attribute_id, \
+map_attribute_group_id as group_id").
+          joins(:map_attribute_group).
+          where(
+            is_disabled: false,
+            "#{Api::V3::MapAttributeGroup.table_name}.context_id": @context.id
+          ).
           order(position: :asc)
 
         serialized_layer_groups = ActiveModelSerializers::SerializableResource.new(dimension_groups, each_serializer: DimensionGroupSerializer, root: 'dimensionGroups').serializable_hash

--- a/app/controllers/api/v3/map_groups_controller.rb
+++ b/app/controllers/api/v3/map_groups_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V3
+    class MapGroupsController < ApiController
+      def index
+        dimension_groups = Api::V3::MapAttributeGroup.select('distinct name, id, position').
+          where(context_id: @context.id).
+          order('position ASC, id ASC')
+
+        dimensions = Api::V3::Readonly::MapAttribute.select('color_scale, id, bucket_3, bucket_5,
+map_attribute_group_id as group_id, is_default, years, name, attribute_type as type, unit, description,
+aggregate_method, layer_attribute_id, map_attribute_group_id as group_id').
+          where(is_disabled: false).
+          order(position: :asc)
+
+        serialized_layer_groups = ActiveModelSerializers::SerializableResource.new(dimension_groups, each_serializer: DimensionGroupSerializer, root: 'dimensionGroups').serializable_hash
+        serialized_layers = ActiveModelSerializers::SerializableResource.new(dimensions, each_serializer: DimensionSerializer, root: 'dimensions').serializable_hash
+
+        render json: serialized_layer_groups.merge(serialized_layers)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/newsletter_subscriptions_controller.rb
+++ b/app/controllers/api/v3/newsletter_subscriptions_controller.rb
@@ -7,7 +7,7 @@ module Api
       def create
         mailchimp = Mailchimp::API.new(ENV['MAILCHIMP_API_KEY'])
         response = mailchimp.lists.subscribe(
-            ENV['MAILCHIMP_LIST_ID'], email: params[:email]
+          ENV['MAILCHIMP_LIST_ID'], email: params[:email]
         )
         render json: response and return
       rescue Error => e

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -1,6 +1,24 @@
+# == Schema Information
+#
+# Table name: context_layer
+#
+#  id                     :integer          not null
+#  map_attribute_group_id :integer          not null
+#  position               :integer          not null
+#  bucket_3               :float            not null          is an Array
+#  bucket_5               :float            not null          is an Array
+#  is_default             :boolean          not null          default("false")
+#  is_disabled            :boolean          not null          default("false")
+#  color_scale            :string
+#  years                  :integer          is an Array
+#  created_at             :datetime
+#  updated_at             :datetime
+#
+
 module Api
   module V3
     class MapAttribute < BaseModel
+      belongs_to :map_attribute_group
     end
   end
 end

--- a/app/models/api/v3/map_attribute_group.rb
+++ b/app/models/api/v3/map_attribute_group.rb
@@ -1,6 +1,18 @@
+# == Schema Information
+#
+# Table name: map_attribute_groups
+#
+#  id         :integer          not null, primary key
+#  name       :text
+#  position   :integer
+#  context_id :integer
+#  created_at :datetime
+#  updated_at :date_time
+
 module Api
   module V3
     class MapAttributeGroup < BaseModel
+      has_many :map_attributes
     end
   end
 end

--- a/app/models/api/v3/readonly/map_attribute.rb
+++ b/app/models/api/v3/readonly/map_attribute.rb
@@ -1,0 +1,14 @@
+module Api
+  module V3
+    module Readonly
+      class MapAttribute < BaseModel
+        self.table_name = 'revamp.map_attributes_mv'
+        self.primary_key = 'id'
+
+        def self.refresh
+          ActiveRecord::Base.connection.execute('REFRESH MATERIALIZED VIEW map_attributes_mv')
+        end
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/map_attribute.rb
+++ b/app/models/api/v3/readonly/map_attribute.rb
@@ -5,6 +5,8 @@ module Api
         self.table_name = 'revamp.map_attributes_mv'
         self.primary_key = 'id'
 
+        belongs_to :map_attribute_group
+
         def self.refresh
           ActiveRecord::Base.connection.execute('REFRESH MATERIALIZED VIEW map_attributes_mv')
         end

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
   port: <%= ENV.fetch("POSTGRES_PORT") { "5432" } %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD") {} %>
   database: <%= ENV.fetch("POSTGRES_DATABASE") { "trase_dev" } %>
-  schema_search_path: "public"
+ # schema_search_path: "public"
 
 development:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v3 do
       resources :contexts, only: [:index] do
+        resources :map_groups, only: [:index]
         resources :columns, only: [:index]
       end
       get '/get_all_nodes', to: 'nodes#get_all_nodes'

--- a/db/migrate/20171130103917_update_materialized_map_attributes_to_version_3.rb
+++ b/db/migrate/20171130103917_update_materialized_map_attributes_to_version_3.rb
@@ -1,0 +1,12 @@
+class UpdateMaterializedMapAttributesToVersion3 < ActiveRecord::Migration[5.1]
+  def change
+    with_search_path('revamp') do
+
+      update_view :map_attributes_mv,
+                  version: 3,
+                  revert_to_version: 2,
+                  materialized: true
+
+    end
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -189,18 +189,6 @@ tables:
         comment: When set, do not show this attribute
       - name: is_default
         comment: When set, show this attribute by default
-      - name: name
-        comment: Display name of the ind/quant
-      - name: attribute_type
-        comment: Type of the attribute (ind/quant)
-      - name: unit
-        comment: Name of the attribute's unit
-      - name: description
-        comment: Attribute's description
-      - name: aggregate_method
-        comment: The method used to aggregate the data
-        name: layer_attribute_id
-        comment: The attribute's original id
   - name: map_inds
     comment: Inds to display on map (see map_attributes.)
   - name: map_quants
@@ -357,6 +345,18 @@ materialized_views:
     columns:
       - name: attribute_id
         comment: References the unique id in attributes_mv.
+      - name: name
+        comment: Display name of the ind/quant
+      - name: attribute_type
+        comment: Type of the attribute (ind/quant)
+      - name: unit
+        comment: Name of the attribute''s unit
+      - name: description
+        comment: Attribute''s description
+      - name: aggregate_method
+        comment: The method used to aggregate the data
+        name: layer_attribute_id
+        comment: The attribute''s original id
   - name: recolor_by_attributes_mv
     comment: Materialized view which merges recolor_by_inds and recolor_by_quals with recolor_by_attributes.
     columns:

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -189,6 +189,18 @@ tables:
         comment: When set, do not show this attribute
       - name: is_default
         comment: When set, show this attribute by default
+      - name: name
+        comment: Display name of the ind/quant
+      - name: attribute_type
+        comment: Type of the attribute (ind/quant)
+      - name: unit
+        comment: Name of the attribute's unit
+      - name: description
+        comment: Attribute's description
+      - name: aggregate_method
+        comment: The method used to aggregate the data
+        name: layer_attribute_id
+        comment: The attribute's original id
   - name: map_inds
     comment: Inds to display on map (see map_attributes.)
   - name: map_quants

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2838,6 +2838,55 @@ UNION ALL
 
 
 --
+-- Name: MATERIALIZED VIEW map_attributes_mv; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON MATERIALIZED VIEW map_attributes_mv IS 'Materialized view which merges map_inds and map_quants with map_attributes.';
+
+
+--
+-- Name: COLUMN map_attributes_mv.attribute_id; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN map_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
+
+
+--
+-- Name: COLUMN map_attributes_mv.name; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN map_attributes_mv.name IS 'Display name of the ind/quant';
+
+
+--
+-- Name: COLUMN map_attributes_mv.attribute_type; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN map_attributes_mv.attribute_type IS 'Type of the attribute (ind/quant)';
+
+
+--
+-- Name: COLUMN map_attributes_mv.unit; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN map_attributes_mv.unit IS 'Name of the attribute''s unit';
+
+
+--
+-- Name: COLUMN map_attributes_mv.description; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN map_attributes_mv.description IS 'Attribute''s description';
+
+
+--
+-- Name: COLUMN map_attributes_mv.layer_attribute_id; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN map_attributes_mv.layer_attribute_id IS 'The attribute''s original id';
+
+
+--
 -- Name: map_inds_id_seq; Type: SEQUENCE; Schema: revamp; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,10 +1,3 @@
---
--- PostgreSQL database dump
---
-
--- Dumped from database version 9.6.5
--- Dumped by pg_dump version 9.6.5
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -1306,7 +1299,7 @@ CREATE MATERIALIZED VIEW attributes_mv AS
            FROM (quants
              LEFT JOIN quant_properties qp ON ((qp.quant_id = quants.id)))
         UNION ALL
-         SELECT 'Ind'::text,
+         SELECT 'Ind'::text AS text,
             inds.id,
             inds.name,
             ip.display_name,
@@ -1317,22 +1310,22 @@ CREATE MATERIALIZED VIEW attributes_mv AS
             ip.is_visible_on_place_profile,
             ip.is_temporal_on_actor_profile,
             ip.is_temporal_on_place_profile,
-            'AVG'::text
+            'AVG'::text AS text
            FROM (inds
              LEFT JOIN ind_properties ip ON ((ip.ind_id = inds.id)))
         UNION ALL
-         SELECT 'Qual'::text,
+         SELECT 'Qual'::text AS text,
             quals.id,
             quals.name,
             qp.display_name,
-            NULL::text,
-            NULL::text,
+            NULL::text AS text,
+            NULL::text AS text,
             qp.tooltip_text,
             qp.is_visible_on_actor_profile,
             qp.is_visible_on_place_profile,
             qp.is_temporal_on_actor_profile,
             qp.is_temporal_on_place_profile,
-            NULL::text
+            NULL::text AS text
            FROM (quals
              LEFT JOIN qual_properties qp ON ((qp.qual_id = quals.id)))) s
   WITH NO DATA;
@@ -2809,7 +2802,13 @@ CREATE MATERIALIZED VIEW map_attributes_mv AS
     ma.is_default,
     ma.created_at,
     ma.updated_at,
-    a.id AS attribute_id
+    a.id AS attribute_id,
+    a.display_name AS name,
+    'quant'::text AS attribute_type,
+    a.unit,
+    a.tooltip_text AS description,
+    a.aggregate_method,
+    a.original_id AS layer_attribute_id
    FROM ((map_quants maq
      JOIN map_attributes ma ON ((ma.id = maq.map_attribute_id)))
      JOIN attributes_mv a ON (((a.original_id = maq.quant_id) AND (a.original_type = 'Quant'::text))))
@@ -2825,25 +2824,17 @@ UNION ALL
     ma.is_default,
     ma.created_at,
     ma.updated_at,
-    a.id AS attribute_id
+    a.id AS attribute_id,
+    a.display_name AS name,
+    'ind'::text AS attribute_type,
+    a.unit,
+    a.tooltip_text AS description,
+    a.aggregate_method,
+    a.original_id AS layer_attribute_id
    FROM ((map_inds mai
      JOIN map_attributes ma ON ((ma.id = mai.map_attribute_id)))
      JOIN attributes_mv a ON (((a.original_id = mai.ind_id) AND (a.original_type = 'Ind'::text))))
   WITH NO DATA;
-
-
---
--- Name: MATERIALIZED VIEW map_attributes_mv; Type: COMMENT; Schema: revamp; Owner: -
---
-
-COMMENT ON MATERIALIZED VIEW map_attributes_mv IS 'Materialized view which merges map_inds and map_quants with map_attributes.';
-
-
---
--- Name: COLUMN map_attributes_mv.attribute_id; Type: COMMENT; Schema: revamp; Owner: -
---
-
-COMMENT ON COLUMN map_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
 
 
 --
@@ -6351,6 +6342,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20171115144320'),
 ('20171116101949'),
 ('20171117115459'),
-('20171117120322');
+('20171117120322'),
+('20171130103917');
 
 

--- a/db/views/map_attributes_mv_v03.sql
+++ b/db/views/map_attributes_mv_v03.sql
@@ -1,0 +1,13 @@
+SELECT ma.*, a.id AS attribute_id, a.display_name as name, 'quant' as attribute_type, a.unit as unit,
+  tooltip_text as description, a.aggregate_method as aggregate_method, a.original_id as layer_attribute_id
+FROM map_quants maq
+JOIN map_attributes ma ON ma.id = maq.map_attribute_id
+JOIN attributes_mv a ON a.original_id = maq.quant_id AND a.original_type = 'Quant'
+
+UNION ALL
+
+SELECT ma.*, a.id AS attribute_id, a.display_name as name, 'ind' as attribute_type, a.unit as unit,
+  tooltip_text as description, a.aggregate_method as aggregate_method, a.original_id as layer_attribute_id
+FROM map_inds mai
+JOIN map_attributes ma ON ma.id = mai.map_attribute_id
+JOIN attributes_mv a ON a.original_id = mai.ind_id AND a.original_type = 'Ind'

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -443,9 +443,20 @@ definitions:
   Column:
     type: object
     properties:
-      id:
-        type: integer
-        format: int64
+      dimensionGroups:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+              format: int64
+            name:
+              type: string
+      dimensions:
+        type: array
+        items:
+          $ref: '#/definitions/Dimension'
   MapGroup:
     type: object
     properties:
@@ -467,3 +478,38 @@ definitions:
     properties:
       email:
         type: string
+  Dimension:
+    type: object
+    properties:
+      aggregateMethod:
+        type: string
+      bucket3:
+        type: array
+        items:
+          type: number
+          format: float
+      bucket5:
+        type: array
+        items:
+          type: number
+          format: float
+      colorScale:
+        type: string
+      description:
+        type: string
+      id:
+        type: integer
+        format: int64
+      is_default:
+        type: boolean
+      layerAttributeId:
+        type: integer
+        format: int64
+      name:
+        type: string
+      unit:
+        type: string
+      years:
+        type: array
+        items:
+          type: integer

--- a/spec/support/contexts/brazil/brazil_context_layers.rb
+++ b/spec/support/contexts/brazil/brazil_context_layers.rb
@@ -6,42 +6,48 @@ shared_context 'brazil context layers' do
   let!(:context_layer_group_one) do
     FactoryBot.create(
       :context_layer_group,
-      context_id: context.id, name: 'Context layer group one'
+      context_id: context.id, name: 'Context layer group one',
+      position: 1
     )
   end
 
   let!(:context_layer_group_two) do
     FactoryBot.create(
       :context_layer_group,
-      context_id: context.id, name: 'Context layer group two'
+      context_id: context.id, name: 'Context layer group two',
+      position: 2
     )
   end
 
   let!(:forest_500_context_layer) do
     FactoryBot.create(
       :context_layer,
-      context_id: context.id, layer_attribute_type: 'Ind', layer_attribute_id: forest_500.id, context_layer_group_id: context_layer_group_one.id
+      context_id: context.id, layer_attribute_type: 'Ind', layer_attribute_id: forest_500.id, context_layer_group_id: context_layer_group_one.id,
+      position: 3
     )
   end
 
   let!(:water_scarcity_context_layer) do
     FactoryBot.create(
       :context_layer,
-      context_id: context.id, layer_attribute_type: 'Ind', layer_attribute_id: water_scarcity.id, context_layer_group_id: context_layer_group_two.id
+      context_id: context.id, layer_attribute_type: 'Ind', layer_attribute_id: water_scarcity.id, context_layer_group_id: context_layer_group_two.id,
+      position: 4
     )
   end
 
   let!(:land_conflicts_context_layer) do
     FactoryBot.create(
       :context_layer,
-      context_id: context.id, layer_attribute_type: 'Quant', layer_attribute_id: land_conflicts.id, context_layer_group_id: context_layer_group_one.id
+      context_id: context.id, layer_attribute_type: 'Quant', layer_attribute_id: land_conflicts.id, context_layer_group_id: context_layer_group_one.id,
+      position: 5
     )
   end
 
   let!(:force_labour_context_layer) do
     FactoryBot.create(
       :context_layer,
-      context_id: context.id, layer_attribute_type: 'Quant', layer_attribute_id: force_labour.id, context_layer_group_id: context_layer_group_two.id
+      context_id: context.id, layer_attribute_type: 'Quant', layer_attribute_id: force_labour.id, context_layer_group_id: context_layer_group_two.id,
+      position: 6
     )
   end
 end

--- a/spec/support/gold_master_urls.yml
+++ b/spec/support/gold_master_urls.yml
@@ -32,8 +32,8 @@ json:
   - url: /api/v2/get_map_base_data
     name: get_map_base_data
     version: v2
-    v3_ready: false
-    v3_url: /api/v3/get_map_base_data
+    v3_ready: true
+    v3_url: /api/v3/contexts/:context_id/map_groups
     <<: *context_queries
   - url: /api/v2/get_linked_geoids
     name: get_linked_geoids

--- a/spec/support/gold_master_urls.yml
+++ b/spec/support/gold_master_urls.yml
@@ -33,7 +33,7 @@ json:
     name: get_map_base_data
     version: v2
     v3_ready: true
-    v3_url: /api/v3/contexts/:context_id/map_groups
+    v3_url: /api/v3/contexts/1/map_groups
     <<: *context_queries
   - url: /api/v2/get_linked_geoids
     name: get_linked_geoids

--- a/spec/version_migration/get_map_base_data_spec.rb
+++ b/spec/version_migration/get_map_base_data_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Map Groups', type: :request do
+  include_context 'brazil contexts'
+  include_context 'brazil soy indicators'
+  include_context 'brazil context layers'
+
+  describe 'GET /api/v2/get_map_base_data === GET /api/v3/context/:id/map_groups ' do
+    it 'has the correct response structure' do
+      SchemaRevamp.new.copy
+
+      get "/api/v2/get_map_base_data?context_id=#{context.id}"
+      v2_response = HashSorter.new(JSON.parse(@response.body)).sort
+
+      expect(@response.status).to eq 200
+
+      get "/api/v3/contexts/#{context.id}/map_groups"
+      expect(@response.status).to eq 200
+      v3_response = HashSorter.new(JSON.parse(@response.body)).sort
+
+      # Removing the key "dimensions" as the v2 is not calculating it properly
+      expect(v2_response).to have_key('dimensions')
+      expect(v3_response).to have_key('dimensions')
+
+      v2_response['dimensions'].each { |x| x.except!('aggregateMethod') }
+      v3_response['dimensions'].each { |x| x.except!('aggregateMethod') }
+
+      expect(v3_response).to eq v2_response
+    end
+  end
+end


### PR DESCRIPTION
Created the v3 endpoint for map_groups.

There are two things missing (for which I'll need the help of @agnessa)
1 - The gold_master_urls file should have a way to add the `context_id` to the url that is not through params (I'll check where this is being used)
2 - I added the new fields of the `map_groups_mv` to the `schema_comments.yml` but those were not inserted in the `structure.sql`. I'll have to check where this is done.

Also, note that the test is not comparing the key `aggregateMethod` as this was always `nil` in v2.