### PR TITLE
fix: prevents cc-selector reloading on selected double-click

### DIFF
--- a/frontend/scripts/react-components/tool/nav/dimensional-selector.component.js
+++ b/frontend/scripts/react-components/tool/nav/dimensional-selector.component.js
@@ -68,7 +68,7 @@ export default class DimensionalSelector extends Component {
     const { selectedDimensions } = this.state;
     const current = selectedDimensions.find(dimension => dimension.order === i);
     return current && current.id === el.id;
-  };
+  }
 
   render() {
     const { dimensions = [], getFooterText, getElement } = this.props;

--- a/frontend/scripts/react-components/tool/nav/dimensional-selector.component.js
+++ b/frontend/scripts/react-components/tool/nav/dimensional-selector.component.js
@@ -39,7 +39,6 @@ export default class DimensionalSelector extends Component {
   }
 
   selectDimension(e, status, index, el) {
-    console.log(status);
     if (e) e.stopPropagation();
     if (['disabled', 'selected'].includes(status)) return this.resetSelection();
     this.setState(state => {


### PR DESCRIPTION
This PR includes:
- Refactors a little bit the `<DimensionalSelector />` cause DRY.
- Prevents sankey reloading when selecting twice the same list item.

Fixes: #105 