### PR TITLE
fix: removes Land use [Ha] from scatterplot legend

### DIFF
--- a/frontend/html/profile-actor.ejs
+++ b/frontend/html/profile-actor.ejs
@@ -147,7 +147,6 @@
             <div class="small-12 columns" style="position: relative">
               <h3 class="js-scatterplot-title title -small">-</h3>
               <div class="js-companies-exporting-y-axis axis-legend"></div>
-              <div class="js-companies-exporting-x-axis axis-legend axis-legend-x"></div>
               <div class="js-companies-exporting"></div>
               <ul class="c-scatterplot-switcher js-scatterplot-switcher"></ul>
             </div>

--- a/frontend/scripts/components/profiles/scatterplot.component.js
+++ b/frontend/scripts/components/profiles/scatterplot.component.js
@@ -59,9 +59,6 @@ export default class {
         return abbreviateNumber(value, 3);
       });
 
-    const firstTab = this.xDimension[0];
-    document.querySelector('.js-companies-exporting-x-axis').innerHTML = `${firstTab.name} (${firstTab.unit})`;
-
     this.yAxis = d3_axis_left(this.y)
       .ticks(7)
       .tickSize(-this.width, 0)

--- a/frontend/styles/components/profiles/scatterplot.scss
+++ b/frontend/styles/components/profiles/scatterplot.scss
@@ -5,7 +5,7 @@
 
 
   .title {
-    margin-bottom: 46px;
+    margin-bottom: 23px;
   }
 
   path {


### PR DESCRIPTION
This PR includes:
- Addresses the first of the issues mentioned in #138 .
