### PR TITLE
feat: select sibling nodes

### DIFF
--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -30,6 +30,7 @@ import setGeoJSONMeta from './helpers/setGeoJSONMeta';
 import getNodeMetaUid from 'reducers/helpers/getNodeMetaUid';
 import { getSingleMapDimensionWarning } from 'reducers/helpers/getMapDimensionsWarnings';
 import getProfileLink from 'utils/getProfileLink';
+import isNodeColumnVisible from 'utils/isNodeColumnVisible';
 
 export function resetState(refilter = true) {
   return (dispatch) => {
@@ -517,18 +518,15 @@ export function selectExpandedNode(param) {
         if (tool.selectedNodesIds.length === 1 && tool.selectedNodesIds.includes(nodeId)) {
           dispatch(resetState());
         } else {
-          // check if we need to swap column
           const node = tool.nodesDict[nodeId];
           if (!node) {
             console.warn(`requested node ${nodeId} does not exist in nodesDict`);
             return;
           }
 
-          const columnGroup = node.columnGroup;
-          const currentColumnAtPos = tool.selectedColumnsIds[columnGroup];
-
-          if (currentColumnAtPos !== node.columnId) {
-            dispatch(selectColumn(columnGroup, node.columnId, false));
+          // check if we need to swap column
+          if (!isNodeColumnVisible(node, tool.selectedColumnsIds)) {
+            dispatch(selectColumn(node.columnGroup, node.columnId, false));
           }
 
           const currentSelectedNodesIds = getState().tool.selectedNodesIds;

--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -461,30 +461,33 @@ function getSelectedNodeIds(currentSelectedNodesIds, changedNodeId) {
   return selectedNodesIds;
 }
 
-export function selectNode(nodeId, isAggregated = false) {
+export function selectNode(param, isAggregated = false) {
+  const ids = Array.isArray(param) ? param : [param];
   return (dispatch, getState) => {
-    if (isAggregated) {
-      dispatch(selectView(true));
-    } else {
-      const currentSelectedNodesIds = getState().tool.selectedNodesIds;
-      // we are unselecting the node that is currently expanded: just shrink it and bail
-      if (getState().tool.areNodesExpanded && currentSelectedNodesIds.length === 1 && currentSelectedNodesIds.indexOf(nodeId) > -1) {
-        dispatch(toggleNodesExpand());
+    ids.forEach((nodeId) => {
+      if (isAggregated) {
+        dispatch(selectView(true));
+      } else {
+        const currentSelectedNodesIds = getState().tool.selectedNodesIds;
+        // we are unselecting the node that is currently expanded: just shrink it and bail
+        if (getState().tool.areNodesExpanded && currentSelectedNodesIds.length === 1 && currentSelectedNodesIds.indexOf(nodeId) > -1) {
+          dispatch(toggleNodesExpand());
+        }
+
+        const selectedNodesIds = getSelectedNodeIds(currentSelectedNodesIds, nodeId);
+
+        // send to state the new node selection along with new data, geoIds, etc
+        dispatch(updateNodes(selectedNodesIds));
+
+        // refilter links by selected nodes
+        dispatch({
+          type: actions.FILTER_LINKS_BY_NODES
+        });
+
+        // load related geoIds to show on the map
+        dispatch(loadLinkedGeoIDs());
       }
-
-      const selectedNodesIds = getSelectedNodeIds(currentSelectedNodesIds, nodeId);
-
-      // send to state the new node selection along with new data, geoIds, etc
-      dispatch(updateNodes(selectedNodesIds));
-
-      // refilter links by selected nodes
-      dispatch({
-        type: actions.FILTER_LINKS_BY_NODES
-      });
-
-      // load related geoIds to show on the map
-      dispatch(loadLinkedGeoIDs());
-    }
+    });
   };
 }
 
@@ -505,34 +508,37 @@ export function selectNodeFromGeoId(geoId) {
   };
 }
 
-export function selectExpandedNode(nodeId) {
+export function selectExpandedNode(param) {
+  const ids = Array.isArray(param) ? param : [param];
   return (dispatch, getState) => {
-    if (!_isNodeVisible(getState, nodeId)) {
-      const { tool } = getState();
-      if (tool.selectedNodesIds.length === 1 && tool.selectedNodesIds.includes(nodeId)) {
-        dispatch(resetState());
+    ids.forEach((nodeId) => {
+      if (!_isNodeVisible(getState, nodeId)) {
+        const { tool } = getState();
+        if (tool.selectedNodesIds.length === 1 && tool.selectedNodesIds.includes(nodeId)) {
+          dispatch(resetState());
+        } else {
+          // check if we need to swap column
+          const node = tool.nodesDict[nodeId];
+          if (!node) {
+            console.warn(`requested node ${nodeId} does not exist in nodesDict`);
+            return;
+          }
+
+          const columnGroup = node.columnGroup;
+          const currentColumnAtPos = tool.selectedColumnsIds[columnGroup];
+
+          if (currentColumnAtPos !== node.columnId) {
+            dispatch(selectColumn(columnGroup, node.columnId, false));
+          }
+
+          const currentSelectedNodesIds = getState().tool.selectedNodesIds;
+          const selectedNodesIds = getSelectedNodeIds(currentSelectedNodesIds, nodeId);
+          dispatch(toggleNodesExpand(true, selectedNodesIds));
+        }
       } else {
-        // check if we need to swap column
-        const node = tool.nodesDict[nodeId];
-        if (!node) {
-          console.warn(`requested node ${nodeId} does not exist in nodesDict`);
-          return;
-        }
-
-        const columnGroup = node.columnGroup;
-        const currentColumnAtPos = tool.selectedColumnsIds[columnGroup];
-
-        if (currentColumnAtPos !== node.columnId) {
-          dispatch(selectColumn(columnGroup, node.columnId, false));
-        }
-
-        const currentSelectedNodesIds = getState().tool.selectedNodesIds;
-        const selectedNodesIds = getSelectedNodeIds(currentSelectedNodesIds, nodeId);
-        dispatch(toggleNodesExpand(true, selectedNodesIds));
+        dispatch(selectNode(nodeId, false));
       }
-    } else {
-      dispatch(selectNode(nodeId, false));
-    }
+    });
   };
 }
 

--- a/frontend/scripts/react-components/shared/search.component.js
+++ b/frontend/scripts/react-components/shared/search.component.js
@@ -10,10 +10,12 @@ import SearchResult from './search-result.component';
 
 export default class Search extends Component {
 
-  static getNodeId(selectedItem) {
-    // TODO: implement dual selection, for now just displays importer
+  static getNodeIds(selectedItem) {
     const parts = (selectedItem.id + '').split('_');
-    return parts.length > 1 ? parseInt(parts[0]) : selectedItem.id;
+    if (parts.length > 1) {
+      return [parseInt(parts[0], 10), parseInt(parts[1], 10)];
+    }
+    return [selectedItem.id];
   }
 
   static isValidChar(key) {
@@ -69,19 +71,19 @@ export default class Search extends Component {
 
   onSelected(selectedItem) {
     if (this.isNodeSelected(selectedItem)) return this.downshift.clearSelection();
-    const id = Search.getNodeId(selectedItem);
+    const ids = Search.getNodeIds(selectedItem);
     if (selectedItem.selected) {
-      this.props.onRemoveNode(id);
+      this.props.onRemoveNode(ids);
     } else {
-      this.props.onAddNode(id);
+      this.props.onAddNode(ids);
     }
     this.onCloseClicked();
   }
 
   onAddNode(e, selectedItem) {
     if (e) e.stopPropagation();
-    const id = Search.getNodeId(selectedItem);
-    this.props.onAddNode(id);
+    const ids = Search.getNodeIds(selectedItem);
+    this.props.onAddNode(ids);
     this.downshift.reset();
     this.input.focus();
   }

--- a/frontend/scripts/utils/isNodeColumnVisible.js
+++ b/frontend/scripts/utils/isNodeColumnVisible.js
@@ -1,0 +1,5 @@
+export default (node, selectedColumnsIds = []) => {
+  const columnGroup = node.columnGroup;
+  const currentColumnAtPos = selectedColumnsIds[columnGroup];
+  return currentColumnAtPos === node.columnId;
+};


### PR DESCRIPTION
This PR includes:
- Enables `importer / exporter` selection on search.
- Separates sibling nodes selection when one of the nodes is not in a visible column. 