### PR TITLE
Feature/missing specs for api endpoints

### DIFF
--- a/app/controllers/api/v3/nodes/nodes_attributes_controller.rb
+++ b/app/controllers/api/v3/nodes/nodes_attributes_controller.rb
@@ -3,16 +3,8 @@ module Api
     module Nodes
       class NodesAttributesController < ApiController
         def index
-          # TODO: use ensure_required_param_present when merged
-          unless params[:start_year].present?
-            raise ActionController::ParameterMissing,
-                  'Required param start_year missing'
-          end
-          # TODO: use ensure_required_param_present when merged
-          unless params[:end_year].present?
-            raise ActionController::ParameterMissing,
-                  'Required param end_year missing'
-          end
+          ensure_required_param_present(:start_year)
+          ensure_required_param_present(:end_year)
 
           result = Api::V3::NodeAttributes::Filter.new(
             @context, params[:start_year].to_i, params[:end_year].to_i

--- a/app/models/api/v3/map_ind.rb
+++ b/app/models/api/v3/map_ind.rb
@@ -1,6 +1,8 @@
 module Api
   module V3
     class MapInd < BaseModel
+      belongs_to :map_attribute
+      belongs_to :ind
     end
   end
 end

--- a/app/models/api/v3/map_quant.rb
+++ b/app/models/api/v3/map_quant.rb
@@ -1,6 +1,8 @@
 module Api
   module V3
     class MapQuant < BaseModel
+      belongs_to :map_attribute
+      belongs_to :quant
     end
   end
 end

--- a/frontend/scripts/utils/getURLFromParams.js
+++ b/frontend/scripts/utils/getURLFromParams.js
@@ -38,12 +38,12 @@ const API_ENDPOINTS = {
   [GET_CSV_DATA_DOWNLOAD_FILE]: { api: 3, endpoint: '/contexts/$context_id$/download.csv' },
   [GET_JSON_DATA_DOWNLOAD_FILE]: { api: 3, endpoint: '/contexts/$context_id$/download.json' },
   [GET_LINKED_GEO_IDS]: { api: 3, endpoint: '/contexts/$context_id$/linked_nodes' },
+  [POST_SUBSCRIBE_NEWSLETTER]: { api: 3, endpoint: '/newsletter_subscriptions' },
   [GET_SITE_DIVE]: { api: 'content', endpoint: '/site_dive' },
   [GET_POSTS]: { api: 'content', endpoint: '/posts' },
   [GET_TWEETS]: { api: 'content', endpoint: '/tweets' },
   [GET_DISCLAIMER]: { api: 'local', endpoint: 'disclaimer.json' },
-  [GET_TOOLTIPS]: { api: 'local', endpoint: 'tooltips.json' },
-  [POST_SUBSCRIBE_NEWSLETTER]: { api: 2, endpoint: '/newsletter_subscriptions' }
+  [GET_TOOLTIPS]: { api: 'local', endpoint: 'tooltips.json' }
 };
 
 function getURLForV3(endpoint, paramsArg = {}) {

--- a/spec/controllers/api/v3/download_controller_spec.rb
+++ b/spec/controllers/api/v3/download_controller_spec.rb
@@ -8,12 +8,13 @@ RSpec.describe Api::V3::DownloadController, type: :controller do
     before(:each) do
       Api::V3::Readonly::DownloadFlow.refresh
       ActiveRecord::Base.connection.execute('COMMIT')
-      FactoryBot.create(
-        :api_v3_download_version,
-        symbol: 'v1.0',
-        is_current: true,
-        context_id: api_v3_context.id
-      )
+      Api::V3::DownloadVersion.current_version_symbol(api_v3_context) ||
+        FactoryBot.create(
+          :api_v3_download_version,
+          symbol: 'v1.0',
+          is_current: true,
+          context_id: api_v3_context.id
+        )
     end
     it 'returns a zipped csv file' do
       get :index, params: {context_id: api_v3_context.id}, format: :csv

--- a/spec/models/api/v3/download/flow_download_query_builder_spec.rb
+++ b/spec/models/api/v3/download/flow_download_query_builder_spec.rb
@@ -7,9 +7,13 @@ RSpec.describe Api::V3::Download::FlowDownloadQueryBuilder, type: :model do
       Api::V3::Readonly::DownloadFlow.refresh
       ActiveRecord::Base.connection.execute('COMMIT')
     end
+    after(:each) do
+      Api::V3::Flow.delete_all # no idea why db cleaner doesn't do that ;(
+    end
 
     it 'should return all flows when no filter applied' do
       qb = Api::V3::Download::FlowDownloadQueryBuilder.new(api_v3_context, {})
+
       expected = [
         [2015, 'Nova Ubirata', 'MATO GROSSO', 'AMAZONIA', 'Imbituba', 'Afg Brasil', 'Unknown Customer', 'Russian Federation', 'DEFORESTATION', '10'],
         [2015, 'Nova Ubirata', 'MATO GROSSO', 'AMAZONIA', 'Paranagua', 'Afg Brasil 2', 'Chinatex Grains & Oils Imp Exp Co', 'China', 'DEFORESTATION', '5'],
@@ -34,6 +38,7 @@ RSpec.describe Api::V3::Download::FlowDownloadQueryBuilder, type: :model do
 
     it 'should filter rows when filter applied' do
       qb = Api::V3::Download::FlowDownloadQueryBuilder.new(api_v3_context, exporters_ids: [api_v3_exporter1_node.id])
+
       expected = [
         [2015, 'Nova Ubirata', 'MATO GROSSO', 'AMAZONIA', 'Imbituba', 'Afg Brasil', 'Unknown Customer', 'Russian Federation', 'DEFORESTATION', '10']
       ]

--- a/spec/responses/api/v3/columns_spec.rb
+++ b/spec/responses/api/v3/columns_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Columns', type: :request do
+  include_context 'api v3 brazil soy indicators'
+  include_context 'api v3 brazil context nodes'
+
+  describe 'GET /api/v3/contexts/:context_id/columns' do
+    it 'has the correct response structure' do
+      get "/api/v3/contexts/#{api_v3_context.id}/columns"
+
+      expect(@response.status).to eq 200
+      expect(@response).to match_response_schema('columns')
+    end
+  end
+end

--- a/spec/responses/api/v3/columns_spec.rb
+++ b/spec/responses/api/v3/columns_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Columns', type: :request do
-  include_context 'api v3 brazil soy indicators'
-  include_context 'api v3 brazil context nodes'
+  include_context 'api v3 brazil download attributes'
+  include_context 'api v3 brazil context node types'
 
   describe 'GET /api/v3/contexts/:context_id/columns' do
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/contexts_spec.rb
+++ b/spec/responses/api/v3/contexts_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Get contexts', type: :request do
   include_context 'api v3 brazil soy nodes'
-  include_context 'api v3 brazil soy indicators'
+  include_context 'api v3 brazil download attributes'
   include_context 'api v3 brazil resize by'
   include_context 'api v3 brazil recolor by'
 

--- a/spec/responses/api/v3/contexts_spec.rb
+++ b/spec/responses/api/v3/contexts_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Get contexts', type: :request do
+  include_context 'api v3 brazil soy nodes'
   include_context 'api v3 brazil soy indicators'
   include_context 'api v3 brazil resize by'
   include_context 'api v3 brazil recolor by'

--- a/spec/responses/api/v3/download_attributes_spec.rb
+++ b/spec/responses/api/v3/download_attributes_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Download Attributes', type: :request do
-  include_context 'api v3 brazil soy indicators'
+  include_context 'api v3 brazil download attributes'
 
   describe 'GET /api/v3/contexts/:context_id/download_attributes' do
     before(:each) do

--- a/spec/responses/api/v3/exporter_profile_spec.rb
+++ b/spec/responses/api/v3/exporter_profile_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Get exporter node attributes', type: :request do
+RSpec.describe 'Exporter profile', type: :request do
   include_context 'api v3 brazil exporter quant values'
   include_context 'api v3 brazil exporter qual values'
   include_context 'api v3 brazil exporter ind values'
@@ -10,7 +10,7 @@ RSpec.describe 'Get exporter node attributes', type: :request do
   include_context 'api v3 brazil flows'
   include_context 'api v3 brazil flows quants'
 
-  describe 'GET /api/v3/contexts/:context_id/nodes/:node_id/actor' do
+  describe 'GET /api/v3/contexts/:context_id/nodes/:id/actor' do
     it 'validates node types' do
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_country_of_destination1_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_port1_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
@@ -20,10 +20,6 @@ RSpec.describe 'Get exporter node attributes', type: :request do
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_state_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
 
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_exporter1_node.id}/actor" }.to_not raise_error
-    end
-
-    it 'returns 404 on non-existent context_id' do
-      expect { get "/api/v3/contexts/#{api_v3_context.id - 100}/nodes/#{api_v3_exporter1_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/importer_profile_spec.rb
+++ b/spec/responses/api/v3/importer_profile_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Get importer node attributes', type: :request do
+RSpec.describe 'Importer profile', type: :request do
   include_context 'api v3 brazil importer quant values'
   include_context 'api v3 brazil importer qual values'
   include_context 'api v3 brazil importer ind values'
@@ -10,7 +10,7 @@ RSpec.describe 'Get importer node attributes', type: :request do
   include_context 'api v3 brazil flows'
   include_context 'api v3 brazil flows quants'
 
-  describe 'GET /api/v3/contexts/:context_id/nodes/:node_id/actor' do
+  describe 'GET /api/v3/contexts/:context_id/nodes/:id/actor' do
     it 'validates node types' do
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_country_of_destination1_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_port1_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
@@ -20,10 +20,6 @@ RSpec.describe 'Get importer node attributes', type: :request do
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_state_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
 
       expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_importer1_node.id}/actor" }.to_not raise_error
-    end
-
-    it 'returns 404 on non-existent context_id' do
-      expect { get "/api/v3/contexts/#{api_v3_context.id - 100}/nodes/#{api_v3_importer1_node.id}/actor" }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/map_groups_spec.rb
+++ b/spec/responses/api/v3/map_groups_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe 'Map groups', type: :request do
+  include_context 'api v3 brazil context layers'
+
+  describe 'GET /api/v3/contexts/:context_id/map_groups' do
+    before(:each) do
+      SchemaRevamp.new.refresh
+    end
+
+    it 'has the correct response structure' do
+      get "/api/v3/contexts/#{api_v3_context.id}/map_groups"
+
+      expect(@response.status).to eq 200
+      expect(@response).to match_response_schema('map_base_data')
+    end
+  end
+end

--- a/spec/responses/api/v3/map_groups_spec.rb
+++ b/spec/responses/api/v3/map_groups_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Map groups', type: :request do
-  include_context 'api v3 brazil context layers'
+  include_context 'api v3 brazil map attributes'
 
   describe 'GET /api/v3/contexts/:context_id/map_groups' do
     before(:each) do

--- a/spec/responses/api/v3/nodes_attributes_spec.rb
+++ b/spec/responses/api/v3/nodes_attributes_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'Nodes attributes', type: :request do
-  include_context 'api v3 brazil context nodes'
-  include_context 'api v3 brazil context layers'
+  include_context 'api v3 brazil context node types'
+  include_context 'api v3 brazil map attributes'
   include_context 'api v3 brazil municipality quant values'
   include_context 'api v3 brazil municipality ind values'
 

--- a/spec/responses/api/v3/nodes_attributes_spec.rb
+++ b/spec/responses/api/v3/nodes_attributes_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Nodes attributes', type: :request do
+  include_context 'api v3 brazil context nodes'
+  include_context 'api v3 brazil context layers'
+  include_context 'api v3 brazil municipality quant values'
+  include_context 'api v3 brazil municipality ind values'
+
+  describe 'GET /api/v3/contexts/:context_id/nodes/attributes' do
+    it 'requires a start_year' do
+      get "/api/v3/contexts/#{api_v3_context.id}/nodes/attributes"
+
+      expect(@response.status).to eq 500
+      expect(JSON.parse(@response.body)).to eq('error' => 'param is missing or the value is empty: Required param start_year missing')
+    end
+
+    it 'requires a end_year' do
+      get "/api/v3/contexts/#{api_v3_context.id}/nodes/attributes", params: {start_year: 2015}
+
+      expect(@response.status).to eq 500
+      expect(JSON.parse(@response.body)).to eq('error' => 'param is missing or the value is empty: Required param end_year missing')
+    end
+
+    it 'has the correct response structure' do
+      get "/api/v3/contexts/#{api_v3_context.id}/nodes/attributes", params: {start_year: 2015, end_year: 2015}
+
+      expect(@response.status).to eq 200
+      expect(@response).to match_response_schema('node_attributes')
+    end
+  end
+end

--- a/spec/responses/api/v3/nodes_spec.rb
+++ b/spec/responses/api/v3/nodes_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe 'Nodes', type: :request do
+  include_context 'api v3 brazil context nodes'
+  include_context 'api v3 brazil flows'
+
+  describe 'GET /api/v3/contexts/:context_id/nodes' do
+    it 'has the correct response structure' do
+      get "/api/v3/contexts/#{api_v3_context.id}/nodes"
+
+      expect(@response.status).to eq 200
+      expect(@response).to match_response_schema('all_nodes')
+    end
+  end
+end

--- a/spec/responses/api/v3/nodes_spec.rb
+++ b/spec/responses/api/v3/nodes_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Nodes', type: :request do
-  include_context 'api v3 brazil context nodes'
+  include_context 'api v3 brazil context node types'
   include_context 'api v3 brazil flows'
 
   describe 'GET /api/v3/contexts/:context_id/nodes' do

--- a/spec/responses/api/v3/place_profile_spec.rb
+++ b/spec/responses/api/v3/place_profile_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Place profile', type: :request do
+  include_context 'api v3 brazil municipality ind values'
+  include_context 'api v3 brazil municipality qual values'
+  include_context 'api v3 brazil municipality quant values'
+
+  describe 'GET /api/v3/contexts/:context_id/nodes/:id/place' do
+    it 'validates node types' do
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_country_of_destination1_node.id}/place" }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_exporter1_node.id}/place" }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_importer1_node.id}/place" }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_port1_node.id}/place" }.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_municipality_node.id}/place" }.to_not raise_error
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_logistics_hub_node.id}/place" }.to_not raise_error
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_biome_node.id}/place" }.to_not raise_error
+      expect { get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_state_node.id}/place" }.to_not raise_error
+    end
+
+    it 'has the correct response structure' do
+      get "/api/v3/contexts/#{api_v3_context.id}/nodes/#{api_v3_municipality_node.id}/place"
+
+      expect(@response.status).to eq 200
+      expect(@response).to match_response_schema('place_profile')
+    end
+  end
+end

--- a/spec/support/contexts/api/v3/brazil/brazil_context_layers.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_context_layers.rb
@@ -1,0 +1,129 @@
+shared_context 'api v3 brazil context layers' do
+  include_context 'api v3 brazil contexts'
+  include_context 'api v3 inds'
+  include_context 'api v3 quants'
+
+  let!(:api_v3_map_attribute_group1) do
+    Api::V3::MapAttributeGroup.where(
+      context_id: api_v3_context.id, position: 1
+    ).first ||
+      FactoryBot.create(
+        :api_v3_map_attribute_group,
+        context_id: api_v3_context.id,
+        name: 'Context layer group one',
+        position: 1
+      )
+  end
+
+  let!(:api_v3_map_attribute_group2) do
+    Api::V3::MapAttributeGroup.where(
+      context_id: api_v3_context.id, position: 2
+    ).first ||
+      FactoryBot.create(
+        :api_v3_map_attribute_group,
+        context_id: api_v3_context.id,
+        name: 'Context layer group two',
+        position: 2
+      )
+  end
+
+  let!(:api_v3_water_scarcity_map_attribute) do
+    map_attribute = Api::V3::MapInd.
+      includes(:map_attribute).
+      where(
+        'map_attributes.map_attribute_group_id' => api_v3_map_attribute_group1.id,
+        ind_id: api_v3_water_scarcity.id
+      ).first&.map_attribute
+    unless map_attribute
+      map_attribute = FactoryBot.create(
+        :api_v3_map_attribute,
+        map_attribute_group: api_v3_map_attribute_group1,
+        position: 8,
+        bucket_3: [4,6],
+        bucket_5: [3,4,5,6],
+        color_scale: 'bluered'
+      )
+      FactoryBot.create(
+        :api_v3_map_ind,
+        map_attribute: map_attribute,
+        ind: api_v3_water_scarcity
+      )
+    end
+    map_attribute
+  end
+
+  let!(:api_v3_gdp_per_capita_map_attribute) do
+    map_attribute = Api::V3::MapInd.
+      includes(:map_attribute).
+      where(
+        'map_attributes.map_attribute_group_id' => api_v3_map_attribute_group2.id,
+        ind_id: api_v3_gdp_per_capita.id
+      ).first&.map_attribute
+    unless map_attribute
+      map_attribute = FactoryBot.create(
+        :api_v3_map_attribute,
+        map_attribute_group: api_v3_map_attribute_group2,
+        position: 17,
+        bucket_3: [10000,50000],
+        bucket_5: [10000,20000,50000,100000],
+        color_scale: 'blue'
+      )
+      FactoryBot.create(
+        :api_v3_map_ind,
+        map_attribute: map_attribute,
+        ind: api_v3_gdp_per_capita
+      )
+    end
+    map_attribute
+  end
+
+  let!(:api_v3_land_conflicts_map_attribute) do
+    map_attribute = Api::V3::MapQuant.
+      includes(:map_attribute).
+      where(
+        'map_attributes.map_attribute_group_id' => api_v3_map_attribute_group1.id,
+        quant_id: api_v3_land_conflicts.id
+      ).first&.map_attribute
+    unless map_attribute
+      map_attribute = FactoryBot.create(
+        :api_v3_map_attribute,
+        map_attribute_group: api_v3_map_attribute_group1,
+        position: 21,
+        bucket_3: [6,15],
+        bucket_5: [1,3,7,15],
+        color_scale: 'red'
+      )
+      FactoryBot.create(
+        :api_v3_map_quant,
+        map_attribute: map_attribute,
+        quant: api_v3_land_conflicts
+      )
+    end
+    map_attribute
+  end
+
+  let!(:api_v3_force_labour_map_attribute) do
+    map_attribute = Api::V3::MapQuant.
+      includes(:map_attribute).
+      where(
+        'map_attributes.map_attribute_group_id' => api_v3_map_attribute_group2.id,
+        quant_id: api_v3_force_labour.id
+      ).first&.map_attribute
+    unless map_attribute
+      map_attribute = FactoryBot.create(
+        :api_v3_map_attribute,
+        map_attribute_group: api_v3_map_attribute_group2,
+        position: 20,
+        bucket_3: [2,5],
+        bucket_5: [1,2,4,5],
+        color_scale: 'red'
+      )
+      FactoryBot.create(
+        :api_v3_map_quant,
+        map_attribute: map_attribute,
+        quant: api_v3_force_labour
+      )
+    end
+    map_attribute
+  end
+end

--- a/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
@@ -1,4 +1,4 @@
-shared_context 'api v3 brazil context nodes' do
+shared_context 'api v3 brazil context node types' do
   include_context 'api v3 brazil contexts'
   include_context 'api v3 node types'
 

--- a/spec/support/contexts/api/v3/brazil/brazil_context_nodes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_context_nodes.rb
@@ -3,116 +3,156 @@ shared_context 'api v3 brazil context nodes' do
   include_context 'api v3 node types'
 
   let!(:api_v3_biome_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_biome_node_type,
-      column_position: 0
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 0
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_biome_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_biome_node_type,
+        column_position: 0
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 0
+      )
+    end
     cnt
   end
   let!(:api_v3_state_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_state_node_type,
-      column_position: 1
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 0
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_state_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_state_node_type,
+        column_position: 1
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 0
+      )
+    end
     cnt
   end
   let!(:municipality_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_municipality_node_type,
-      column_position: 2
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 0,
-      is_default: true
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_municipality_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_municipality_node_type,
+        column_position: 2
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 0,
+        is_default: true
+      )
+    end
     cnt
   end
   let!(:api_v3_logistics_hub_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_logistics_hub_node_type,
-      column_position: 3
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 0
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_logistics_hub_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_logistics_hub_node_type,
+        column_position: 3
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 0
+      )
+    end
     cnt
   end
   let!(:api_v3_port1_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_port_node_type,
-      column_position: 4
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 1
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_port_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_port_node_type,
+        column_position: 4
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 1
+      )
+    end
     cnt
   end
   let!(:api_v3_exporter1_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_exporter_node_type,
-      column_position: 5
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 1
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_exporter_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_exporter_node_type,
+        column_position: 5
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 1
+      )
+    end
     cnt
   end
   let!(:api_v3_importer1_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_importer_node_type,
-      column_position: 6
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 2
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_importer_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_importer_node_type,
+        column_position: 6
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 2
+      )
+    end
     cnt
   end
   let!(:country_of_destination1_context_node) do
-    cnt = FactoryBot.create(
-      :api_v3_context_node_type,
-      context: api_v3_context,
-      node_type: api_v3_country_node_type,
-      column_position: 7
-    )
-    FactoryBot.create(
-      :api_v3_context_node_type_property,
-      context_node_type: cnt,
-      column_group: 3
-    )
+    cnt = Api::V3::ContextNodeType.where(
+      context_id: api_v3_context.id, node_type_id: api_v3_country_node_type.id
+    ).first
+    unless cnt
+      cnt = FactoryBot.create(
+        :api_v3_context_node_type,
+        context: api_v3_context,
+        node_type: api_v3_country_node_type,
+        column_position: 7
+      )
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        column_group: 3
+      )
+    end
     cnt
   end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_contexts.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_contexts.rb
@@ -1,38 +1,47 @@
 shared_context 'api v3 brazil contexts' do
   include_context 'api v3 brazil country'
+  include_context 'api v3 commodities'
 
   let!(:api_v3_context) do
-    FactoryBot.create(
-      :api_v3_context,
-      country: api_v3_brazil,
-      commodity: FactoryBot.create(:api_v3_commodity, name: 'SOY'),
-      years: [2014, 2015],
-      default_year: 2015
-    )
+    Api::V3::Context.where(
+      country_id: api_v3_brazil.id, commodity_id: api_v3_soy.id
+    ).first ||
+      FactoryBot.create(
+        :api_v3_context,
+        country: api_v3_brazil,
+        commodity: api_v3_soy,
+        years: [2014, 2015],
+        default_year: 2015
+      )
   end
-  let!(:api_v3_context_properties) do
-    FactoryBot.create(
-      :api_v3_context_property,
-      context: api_v3_context,
-      is_disabled: false,
-      is_default: false
-    )
+  let!(:api_v3_context_property) do
+    Api::V3::ContextProperty.find_by_context_id(api_v3_context.id) ||
+      FactoryBot.create(
+        :api_v3_context_property,
+        context: api_v3_context,
+        is_disabled: false,
+        is_default: false
+      )
   end
   let!(:api_v3_another_context) do
-    FactoryBot.create(
-      :api_v3_context,
-      country: api_v3_brazil,
-      commodity: FactoryBot.create(:api_v3_commodity, name: 'BEEF'),
-      years: [2014, 2015],
-      default_year: 2015
-    )
+    Api::V3::Context.where(
+      country_id: api_v3_brazil.id, commodity_id: api_v3_beef.id
+    ).first ||
+      FactoryBot.create(
+        :api_v3_context,
+        country: api_v3_brazil,
+        commodity: api_v3_beef,
+        years: [2014, 2015],
+        default_year: 2015
+      )
   end
-  let!(:api_v3_another_context_properties) do
-    FactoryBot.create(
-      :api_v3_context_property,
-      context: api_v3_another_context,
-      is_disabled: false,
-      is_default: false
-    )
+  let!(:api_v3_another_context_property) do
+    Api::V3::ContextProperty.find_by_context_id(api_v3_another_context.id) ||
+      FactoryBot.create(
+        :api_v3_context_property,
+        context: api_v3_another_context,
+        is_disabled: false,
+        is_default: false
+      )
   end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_download_attributes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_download_attributes.rb
@@ -1,4 +1,4 @@
-shared_context 'api v3 brazil soy indicators' do
+shared_context 'api v3 brazil download attributes' do
   include_context 'api v3 quals'
   include_context 'api v3 quants'
   include_context 'api v3 brazil contexts'

--- a/spec/support/contexts/api/v3/brazil/brazil_map_attributes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_map_attributes.rb
@@ -1,4 +1,4 @@
-shared_context 'api v3 brazil context layers' do
+shared_context 'api v3 brazil map attributes' do
   include_context 'api v3 brazil contexts'
   include_context 'api v3 inds'
   include_context 'api v3 quants'

--- a/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
@@ -4,211 +4,222 @@ shared_context 'api v3 brazil soy nodes' do
   include_context 'api v3 brazil context nodes'
 
   let!(:api_v3_state_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'MATO GROSSO', node_type_id: api_v3_state_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'MATO GROSSO',
         node_type: api_v3_state_node_type,
         geo_id: 'BR51'
       )
-  end
-  let!(:api_v3_state_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_state_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_state_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_biome_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'AMAZONIA', node_type_id: api_v3_biome_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'AMAZONIA',
         node_type: api_v3_biome_node_type,
         geo_id: 'BR1'
       )
-  end
-  let!(:api_v3_biome_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_biome_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_biome_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_logistics_hub_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'CUIABA', node_type_id: api_v3_logistics_hub_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'CUIABA',
         node_type: api_v3_logistics_hub_node_type
       )
-  end
-  let!(:api_v3_logistics_hub_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_logistics_hub_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_logistics_hub_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_municipality_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'NOVA UBIRATA', node_type_id: api_v3_municipality_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'NOVA UBIRATA',
         node_type: api_v3_municipality_node_type,
         geo_id: 'BR5106240'
       )
-  end
-  let!(:api_v3_municipality_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_municipality_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_municipality_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_other_municipality_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'OTHER', node_type_id: api_v3_municipality_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'OTHER',
         node_type: api_v3_municipality_node_type
       )
-  end
-  let!(:api_v3_other_municipality_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_other_municipality_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_other_municipality_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_exporter1_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'AFG BRASIL', node_type_id: api_v3_exporter_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'AFG BRASIL',
         node_type: api_v3_exporter_node_type
       )
-  end
-  let!(:api_v3_exporter1_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_exporter1_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_exporter1_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_other_exporter_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'OTHER', node_type_id: api_v3_exporter_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'OTHER',
         node_type: api_v3_exporter_node_type
       )
-  end
-  let!(:api_v3_other_exporter_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_other_exporter_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_other_exporter_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_port1_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'IMBITUBA', node_type_id: api_v3_port_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'IMBITUBA',
         node_type: api_v3_port_node_type
       )
-  end
-  let!(:api_v3_port1_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_port1_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_port1_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_importer1_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'UNKNOWN CUSTOMER', node_type_id: api_v3_importer_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'UNKNOWN CUSTOMER',
         node_type: api_v3_importer_node_type
       )
-  end
-  let!(:api_v3_importer1_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_importer1_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_importer1_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_other_importer_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'OTHER', node_type_id: api_v3_importer_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'OTHER',
         node_type: api_v3_importer_node_type
       )
-  end
-  let!(:api_v3_other_importer_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_other_importer_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_other_importer_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_country_of_destination1_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'RUSSIAN FEDERATION', node_type_id: api_v3_country_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'RUSSIAN FEDERATION',
         node_type: api_v3_country_node_type,
         geo_id: 'CN'
       )
-  end
-  let!(:api_v3_country_of_destination1_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_country_of_destination1_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_country_of_destination1_node
+        node: node
       )
+    end
+    node
   end
+
   let!(:api_v3_other_country_of_destination_node) do
-    Api::V3::Node.where(
+    node = Api::V3::Node.where(
       name: 'OTHER', node_type_id: api_v3_country_node_type.id
-    ).first ||
-      FactoryBot.create(
+    ).first
+    unless node
+      node = FactoryBot.create(
         :api_v3_node,
         name: 'OTHER',
         node_type: api_v3_country_node_type
       )
-  end
-  let!(:api_v3_other_country_of_destination_node_property) do
-    Api::V3::NodeProperty.find_by_node_id(api_v3_other_country_of_destination_node.id) ||
       FactoryBot.create(
         :api_v3_node_property,
-        node: api_v3_other_country_of_destination_node
+        node: node
       )
+    end
+    node
   end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
@@ -1,7 +1,7 @@
 shared_context 'api v3 brazil soy nodes' do
   include_context 'api v3 node types'
   include_context 'api v3 quals'
-  include_context 'api v3 brazil context nodes'
+  include_context 'api v3 brazil context node types'
 
   let!(:api_v3_state_node) do
     node = Api::V3::Node.where(

--- a/spec/support/contexts/api/v3/brazil/brazil_two_flows.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_two_flows.rb
@@ -1,6 +1,6 @@
 shared_context 'api v3 brazil two flows' do
   include_context 'api v3 brazil soy nodes'
-  include_context 'api v3 brazil soy indicators'
+  include_context 'api v3 brazil download attributes'
 
   let(:api_v3_exporter2_node) do
     node = Api::V3::Node.where(

--- a/spec/support/contexts/api/v3/brazil/brazil_two_flows.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_two_flows.rb
@@ -3,25 +3,69 @@ shared_context 'api v3 brazil two flows' do
   include_context 'api v3 brazil soy indicators'
 
   let(:api_v3_exporter2_node) do
-    FactoryBot.create(
-      :api_v3_node, name: 'AFG BRASIL 2', node_type: api_v3_exporter_node_type
-    )
+    node = Api::V3::Node.where(
+      name: 'AFG BRASIL 2', node_type_id: api_v3_exporter_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node, name: 'AFG BRASIL 2', node_type: api_v3_exporter_node_type
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
   end
+
   let(:api_v3_port2_node) do
-    FactoryBot.create(
-      :api_v3_node, name: 'PARANAGUA', node_type: api_v3_port_node_type
-    )
+    node = Api::V3::Node.where(
+      name: 'PARANAGUA', node_type_id: api_v3_port_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node, name: 'PARANAGUA', node_type: api_v3_port_node_type
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
   end
+
   let(:api_v3_importer2_node) do
-    FactoryBot.create(
-      :api_v3_node, name: 'CHINATEX GRAINS & OILS IMP EXP CO', node_type: api_v3_importer_node_type
-    )
+    node = Api::V3::Node.where(
+      name: 'CHINATEX GRAINS & OILS IMP EXP CO', node_type_id: api_v3_importer_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node, name: 'CHINATEX GRAINS & OILS IMP EXP CO', node_type: api_v3_importer_node_type
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
   end
+
   let(:api_v3_country_of_destination2_node) do
-    FactoryBot.create(
-      :api_v3_node, name: 'CHINA', node_type: api_v3_country_node_type
-    )
+    node = Api::V3::Node.where(
+      name: 'CHINA', node_type_id: api_v3_country_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node, name: 'CHINA', node_type: api_v3_country_node_type
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
   end
+
   let!(:api_v3_flow1) do
     FactoryBot.create(
       :api_v3_flow,

--- a/spec/support/contexts/api/v3/paraguay/paraguay_context.rb
+++ b/spec/support/contexts/api/v3/paraguay/paraguay_context.rb
@@ -15,7 +15,7 @@ shared_context 'api v3 paraguay context' do
       )
   end
 
-  let!(:api_v3_paraguay_context_properties) do
+  let!(:api_v3_paraguay_context_property) do
     Api::V3::ContextProperty.find_by_context_id(api_v3_paraguay_context.id) ||
       FactoryBot.create(
         :api_v3_context_property,

--- a/spec/support/schemas/map_base_data.json
+++ b/spec/support/schemas/map_base_data.json
@@ -36,7 +36,10 @@
         "properties": {
           "aggregateMethod": {
             "id": "/properties/dimensions/items/properties/aggregateMethod",
-            "type": "null"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "bucket3": {
             "id": "/properties/dimensions/items/properties/bucket3",


### PR DESCRIPTION
- migrates schema specs from V2 to V3 (where that wasn't done before)
- switches the last remaining forgotten endpoint to V3 in front-end (create subscription)
- renames V3 spec shared contexts to better match new table names