### PR TITLE
Schema-qualified call to extension function

### DIFF
--- a/app/services/api/v3/download/flow_download_query_builder.rb
+++ b/app/services/api/v3/download/flow_download_query_builder.rb
@@ -57,7 +57,7 @@ module Api
           ] + categories_names_with_type
 
           crosstab_sql = <<~SQL
-            CROSSTAB(
+            public.CROSSTAB(
               '#{source_sql}',
               '#{categories_sql}'
             )


### PR DESCRIPTION
This fixes the root cause of #204 - the fact that lookup for the pivoting function failed when using the `revamp` connection. But another problem persists with that endpoint, namely for Brazil-Soy the machine runs out of memory when zipping the response. Smaller contexts work.