### PR TITLE
Re-added appsignal

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,7 @@ POSTGRES_PASSWORD=
 POSTGRES_PORT=
 MAILCHIMP_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 MAILCHIMP_LIST_ID=xxxxxxxxxx
+APPSIGNAL_PUSH_API_KEY=
 GOLD_MASTER_HOST_V1=http://localhost:8080
 GOLD_MASTER_HOST_V2=http://localhost:3000
 GOLD_MASTER_HOST_V3=http://localhost:3000

--- a/Capfile
+++ b/Capfile
@@ -40,3 +40,5 @@ require 'capistrano/npm'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
+
+require 'appsignal/capistrano'

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'paperclip', '~> 5.0.0'
 gem 'rack-cors', '~> 0.4'
 gem 'twitter', '~> 6.1'
 
+gem 'appsignal'
+
 group :development, :test do
   gem 'byebug', platform: :mri
   gem 'rspec-rails', '~> 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     annotate (2.7.2)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
+    appsignal (2.4.3)
+      rack
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (8.0.0)
@@ -385,6 +387,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   activeadmin (~> 1.2.1)
   annotate
+  appsignal
   byebug
   capistrano (= 3.7.1)
   capistrano-bundler

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The project's main configuration values can be set using [environment variables]
 * POSTGRES_PORT: Port used to connect to your PostgreSQL server instance
 * MAILCHIMP_API_KEY: API key for Mailchimp mailing service
 * MAILCHIMP_LIST_ID: List ID for Mailchimp mailing service
+* APPSIGNAL_PUSH_API_KEY: Appsignal API key for tracking exceptions
 * GOLD_MASTER_HOST_V1:
 * GOLD_MASTER_HOST_V2:
 * GOLD_MASTER_HOST_V3:

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,41 @@
+default: &defaults
+  # Your push api key, it is possible to set this dynamically using ERB:
+  push_api_key: "<%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
+
+  # Your app's name
+  name: "Trase"
+
+  # Actions that should not be monitored by AppSignal
+  # ignore_actions:
+  #   - ApplicationController#isup
+
+  # Errors that should not be recorded by AppSignal
+  # For more information see our docs:
+  # https://docs.appsignal.com/ruby/configuration/ignore-errors.html
+  # ignore_errors:
+  #   - Exception
+  #   - NoMemoryError
+  #   - ScriptError
+  #   - LoadError
+  #   - NotImplementedError
+  #   - SyntaxError
+  #   - SecurityError
+  #   - SignalException
+  #   - Interrupt
+  #   - SystemExit
+  #   - SystemStackError
+  ignore_errors:
+    - ActiveRecord::RecordNotFound
+    # - ActionController::RoutingError
+  # See http://docs.appsignal.com/ruby/configuration/options.html for
+  # all configuration options.
+
+# Configuration per environment, leave out an environment or set active
+# to false to not push metrics for that environment.
+production:
+  <<: *defaults
+  active: true
+
+staging:
+  <<: *defaults
+  active: true


### PR DESCRIPTION
We have previously removed appsignal as I was under the impression we won't continue using it, but alas we still do, which is great so let's put this back in. The push api key has not changed and is still in the env files for all servers so this should be picked up without any further configuration after deploy.