### PR TITLE
Feature/lock nodes

### DIFF
--- a/app/controllers/api/v3/flows_controller.rb
+++ b/app/controllers/api/v3/flows_controller.rb
@@ -24,6 +24,7 @@ module Api
           recolor_qual_name: params[:flow_qual],
           resize_quant_name: params[:flow_quant],
           selected_nodes_ids: params[:selected_nodes],
+          locked_nodes_ids: params[:locked_nodes],
           biome_id: params[:biome_filter_id],
           year_start: params[:year_start],
           year_end: params[:year_end] || params[:year_start],

--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -50,6 +50,9 @@ module Api
           @selected_nodes_ids = initialize_int_array_param(
             params[:selected_nodes_ids]
           )
+          @locked_nodes_ids = initialize_int_array_param(
+            params[:locked_nodes_ids]
+          )
           @biome_id = params[:biome_id]
           @year_start = params[:year_start]
           @year_end = params[:year_end]
@@ -58,8 +61,8 @@ module Api
 
         def initialize_int_array_param(param)
           ary = param || []
-          ary = ary.split(',').map(&:to_i) if ary.is_a?(String)
-          ary
+          ary = ary.split(',') if ary.is_a?(String)
+          ary.map(&:to_i)
         end
 
         def initialize_errors
@@ -201,7 +204,7 @@ module Api
         def active_nodes_for_position(flows_through_position, other_node_id)
           result = {other_node_id => 0}
           flows_through_position.each.with_index do |flow, i|
-            if i < @limit
+            if i < @limit || @locked_nodes_ids.include?(flow['node_id'])
               result[flow['node_id']] = flow['total']
             else
               result[other_node_id] += flow['total']
@@ -213,7 +216,7 @@ module Api
         def active_nodes_for_expanded_position(flows_through_position, other_node_id)
           result = {other_node_id => 0}
           flows_through_position.each do |flow|
-            if @selected_nodes_ids.include?(flow['node_id'])
+            if @selected_nodes_ids.include?(flow['node_id']) || @locked_nodes_ids.include?(flow['node_id'])
               result[flow['node_id']] = flow['total']
             else
               result[other_node_id] += flow['total']

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -171,6 +171,13 @@ paths:
           description: Number of top nodes (defaults to 100)
           required: false
           type: integer
+        - name: locked_nodes
+          in: query
+          description: Ids of nodes to keep selected even if they are out of range of current selection
+          required: false
+          type: array
+          items:
+            type: integer
       responses:
         '200':
           description: successful operation

--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -272,7 +272,8 @@ export function loadLinks() {
       year_start: state.tool.selectedYears[0],
       year_end: state.tool.selectedYears[1],
       include_columns: state.tool.selectedColumnsIds.join(','),
-      flow_quant: state.tool.selectedResizeBy.name
+      flow_quant: state.tool.selectedResizeBy.name,
+      locked_nodes: state.tool.selectedNodesIds
     };
 
     if (state.tool.detailedView === true) {

--- a/spec/models/flow_download_query_builder_spec.rb
+++ b/spec/models/flow_download_query_builder_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe FlowDownloadQueryBuilder, type: :model do
+  before(:all) { Api::V3::Flow.delete_all } # db clearing doesn't seem to work }
   include_context 'two flows'
   describe :query do
     before(:each) do

--- a/spec/services/api/v3/flows/filter_spec.rb
+++ b/spec/services/api/v3/flows/filter_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Flows::Filter do
+  before(:all) { Api::V3::Flow.delete_all } # db clearing doesn't seem to work }
+  include_context 'api v3 brazil flows quants'
+
+  let!(:api_v3_diamantino_node) {
+    node = Api::V3::Node.where(
+      name: 'DIAMANTINO', node_type_id: api_v3_municipality_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node,
+        name: 'DIAMANTINO',
+        node_type: api_v3_municipality_node_type,
+        geo_id: 'BR5103502'
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
+  }
+
+  let!(:api_v3_diamantino_flow) {
+    FactoryBot.create(
+      :api_v3_flow,
+      context: api_v3_context,
+      path: [
+        api_v3_biome_node,
+        api_v3_state_node,
+        api_v3_diamantino_node,
+        api_v3_logistics_hub_node,
+        api_v3_port1_node,
+        api_v3_exporter1_node,
+        api_v3_importer1_node,
+        api_v3_country_of_destination1_node
+      ].map(&:id),
+      year: 2015
+    )
+  }
+
+  let!(:api_v3_diamantino_flow_volume) {
+    FactoryBot.create(
+      :api_v3_flow_quant,
+      flow: api_v3_diamantino_flow,
+      quant: api_v3_volume,
+      value: 0.1
+    )
+  }
+
+  describe :active_nodes do
+    let(:node_types) {
+      [
+        api_v3_municipality_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ]
+    }
+
+    let(:filter_params) {
+      {
+        year_start: 2015,
+        year_end: 2015,
+        node_types_ids: node_types.map(&:id),
+        resize_quant_name: api_v3_volume.name,
+        limit: 1
+      }
+    }
+
+    let(:locked_nodes) {
+      {locked_nodes_ids: [api_v3_diamantino_node.id]}
+    }
+
+    context 'when overview mode' do
+      context 'when no locked nodes present' do
+        it 'does not include low volume nodes in active nodes' do
+          filter = Api::V3::Flows::Filter.new(
+            api_v3_context,
+            filter_params
+          )
+          filter.call
+          expect(filter.active_nodes).not_to have_key(api_v3_diamantino_node.id)
+        end
+      end
+      context 'when locked nodes' do
+        it 'includes locked low volume nodes in active nodes' do
+          filter = Api::V3::Flows::Filter.new(
+            api_v3_context,
+            filter_params.merge(locked_nodes)
+          )
+          filter.call
+          expect(filter.active_nodes).to have_key(api_v3_diamantino_node.id)
+        end
+      end
+    end
+
+    context 'when expanded mode' do
+      let(:expanded_nodes){
+        {selected_nodes_ids: [api_v3_country_of_destination1_node.id]}
+      }
+      context 'when no locked nodes present' do
+        it 'does not include low volume nodes in active nodes' do
+          filter = Api::V3::Flows::Filter.new(
+            api_v3_context,
+            filter_params.merge(expanded_nodes)
+          )
+          filter.call
+          expect(filter.active_nodes).not_to have_key(api_v3_diamantino_node.id)
+        end
+      end
+      context 'when locked nodes' do
+        it 'includes locked low volume nodes in active nodes' do
+          filter = Api::V3::Flows::Filter.new(
+            api_v3_context,
+            filter_params.merge(expanded_nodes).merge(locked_nodes)
+          )
+          filter.call
+          expect(filter.active_nodes).to have_key(api_v3_diamantino_node.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/contexts/api/v3/brazil/brazil_flows_quants.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows_quants.rb
@@ -10,7 +10,7 @@ shared_context 'api v3 brazil flows quants' do
       value: 10
     )
   end
-  let!(:flow1_volume) do
+  let!(:flow2_volume) do
     FactoryBot.create(
       :api_v3_flow_quant,
       flow: api_v3_flow2,

--- a/spec/support/contexts/api/v3/brazil/brazil_recolor_by.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_recolor_by.rb
@@ -3,69 +3,90 @@ shared_context 'api v3 brazil recolor by' do
   include_context 'api v3 quals'
   include_context 'api v3 inds'
 
-  let!(:recolor_by_attributes_forest_500) do
-    FactoryBot.create(
-      :api_v3_recolor_by_attribute,
-      tooltip_text: 'forest 500 tooltip text',
-      context: api_v3_context,
-      position: 1,
-      years: [],
-      group_number: 1,
-      is_disabled: false,
-      is_default: false,
-      legend_type: 'legend_type',
-      legend_color_theme: 'legend_color_theme'
-    )
-  end
-  let!(:recolor_by_inds_forest_500) do
-    FactoryBot.create(
-      :api_v3_recolor_by_ind,
-      recolor_by_attribute: recolor_by_attributes_forest_500,
-      ind: api_v3_forest_500
-    )
-  end
-
-  let!(:recolor_by_attributes_water_scarcity) do
-    FactoryBot.create(
-      :api_v3_recolor_by_attribute,
-      tooltip_text: 'water scarcity tooltip text',
-      context: api_v3_context,
-      position: 2,
-      years: [],
-      group_number: 1,
-      is_disabled: false,
-      is_default: false,
-      legend_type: 'legend_type',
-      legend_color_theme: 'legend_color_theme'
-    )
-  end
-  let!(:recolor_by_inds_water_scarcity) do
-    FactoryBot.create(
-      :api_v3_recolor_by_ind,
-      recolor_by_attribute: recolor_by_attributes_water_scarcity,
-      ind: api_v3_water_scarcity
-    )
+  let!(:api_v3_forest_500_recolor_by_attribute) do
+    recolor_by_attribute = Api::V3::RecolorByInd.
+      includes(:recolor_by_attribute).
+      where(
+        'recolor_by_attributes.context_id' => api_v3_context.id,
+        ind_id: api_v3_forest_500.id
+      ).first&.recolor_by_attribute
+    unless recolor_by_attribute
+      recolor_by_attribute = FactoryBot.create(
+        :api_v3_recolor_by_attribute,
+        tooltip_text: 'forest 500 tooltip text',
+        context: api_v3_context,
+        position: 1,
+        years: [],
+        group_number: 1,
+        is_disabled: false,
+        is_default: false,
+        legend_type: 'stars',
+        legend_color_theme: 'red-blue'
+      )
+      FactoryBot.create(
+        :api_v3_recolor_by_ind,
+        recolor_by_attribute: recolor_by_attribute,
+        ind: api_v3_forest_500
+      )
+    end
+    recolor_by_attribute
   end
 
-  let!(:recolor_by_attributes_biome) do
-    FactoryBot.create(
-      :api_v3_recolor_by_attribute,
-      tooltip_text: 'biome tooltip text',
-      context: api_v3_context,
-      position: 3,
-      years: [],
-      group_number: 1,
-      is_disabled: false,
-      is_default: false,
-      legend_type: 'legend_type',
-      legend_color_theme: 'legend_color_theme'
-    )
+  let!(:api_v3_water_scarcity_recolor_by_attribute) do
+    recolor_by_attribute = Api::V3::RecolorByInd.
+      includes(:recolor_by_attribute).
+      where(
+        'recolor_by_attributes.context_id' => api_v3_context.id,
+        ind_id: api_v3_water_scarcity.id
+      ).first&.recolor_by_attribute
+    unless recolor_by_attribute
+      recolor_by_attribute = FactoryBot.create(
+        :api_v3_recolor_by_attribute,
+        tooltip_text: 'water scarcity tooltip text',
+        context: api_v3_context,
+        position: 2,
+        years: [],
+        group_number: 1,
+        is_disabled: false,
+        is_default: false,
+        legend_type: 'linear',
+        legend_color_theme: 'red-blue'
+      )
+      FactoryBot.create(
+        :api_v3_recolor_by_ind,
+        recolor_by_attribute: recolor_by_attribute,
+        ind: api_v3_water_scarcity
+      )
+    end
+    recolor_by_attribute
   end
-  let!(:recolor_by_quals_biome) do
-    FactoryBot.create(
-      :api_v3_recolor_by_qual,
-      recolor_by_attribute: recolor_by_attributes_biome,
-      qual: api_v3_biome
-    )
+
+  let!(:api_v3_biome_recolor_by_attribute) do
+    recolor_by_attribute = Api::V3::RecolorByQual.
+      includes(:recolor_by_attribute).
+      where(
+        'recolor_by_attributes.context_id' => api_v3_context.id,
+        qual_id: api_v3_biome.id
+      ).first&.recolor_by_attribute
+    unless recolor_by_attribute
+      recolor_by_attribute = FactoryBot.create(
+        :api_v3_recolor_by_attribute,
+        tooltip_text: 'biome tooltip text',
+        context: api_v3_context,
+        position: 3,
+        years: [],
+        group_number: 1,
+        is_disabled: false,
+        is_default: false,
+        legend_type: 'qual',
+        legend_color_theme: 'thematic'
+      )
+      FactoryBot.create(
+        :api_v3_recolor_by_qual,
+        recolor_by_attribute: recolor_by_attribute,
+        qual: api_v3_biome
+      )
+    end
+    recolor_by_attribute
   end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_resize_by.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_resize_by.rb
@@ -2,43 +2,57 @@ shared_context 'api v3 brazil resize by' do
   include_context 'api v3 brazil contexts'
   include_context 'api v3 quants'
 
-  let!(:resize_by_attributes_area) do
-    FactoryBot.create(
-      :api_v3_resize_by_attribute,
-      tooltip_text: 'area tooltip text',
-      context: api_v3_context,
-      position: 1,
-      years: [],
-      group_number: 1,
-      is_disabled: false,
-      is_default: false
-    )
-  end
-  let!(:resize_by_quants_area) do
-    FactoryBot.create(
-      :api_v3_resize_by_quant,
-      resize_by_attribute: resize_by_attributes_area,
-      quant: api_v3_area
-    )
+  let!(:api_v3_area_resize_by_attribute) do
+    resize_by_attribute = Api::V3::ResizeByQuant.
+      includes(:resize_by_attribute).
+      where(
+        'resize_by_attributes.context_id' => api_v3_context.id,
+        quant_id: api_v3_area.id
+      ).first&.resize_by_attribute
+    unless resize_by_attribute
+      resize_by_attribute = FactoryBot.create(
+        :api_v3_resize_by_attribute,
+        tooltip_text: 'area tooltip text',
+        context: api_v3_context,
+        position: 1,
+        years: [],
+        group_number: 1,
+        is_disabled: false,
+        is_default: false
+      )
+      FactoryBot.create(
+        :api_v3_resize_by_quant,
+        resize_by_attribute: resize_by_attribute,
+        quant: api_v3_area
+      )
+    end
+    resize_by_attribute
   end
 
-  let!(:resize_by_attributes_land_conflict) do
-    FactoryBot.create(
-      :api_v3_resize_by_attribute,
-      tooltip_text: 'land conflict tooltip text',
-      context: api_v3_context,
-      position: 2,
-      years: [],
-      group_number: 1,
-      is_disabled: false,
-      is_default: false
-    )
-  end
-  let!(:resize_by_quants_land_conflict) do
-    FactoryBot.create(
-      :api_v3_resize_by_quant,
-      resize_by_attribute: resize_by_attributes_land_conflict,
-      quant: api_v3_land_conflicts
-    )
+  let!(:api_v3_land_conflict_resize_by_attribute) do
+    resize_by_attribute = Api::V3::ResizeByQuant.
+      includes(:resize_by_attribute).
+      where(
+        'resize_by_attributes.context_id' => api_v3_context.id,
+        quant_id: api_v3_land_conflicts.id
+      ).first&.resize_by_attribute
+    unless resize_by_attribute
+      resize_by_attribute = FactoryBot.create(
+        :api_v3_resize_by_attribute,
+        tooltip_text: 'land conflict tooltip text',
+        context: api_v3_context,
+        position: 2,
+        years: [],
+        group_number: 1,
+        is_disabled: false,
+        is_default: false
+      )
+      FactoryBot.create(
+        :api_v3_resize_by_quant,
+        resize_by_attribute: resize_by_attribute,
+        quant: api_v3_land_conflicts
+      )
+    end
+    resize_by_attribute
   end
 end


### PR DESCRIPTION
Implements #182 

A new parameter was added `locked_nodes`- array of node identifiers

Easy way to test is to manipulate n_nodes and locked_nodes

e.g. `/api/v3/contexts/1/flows?&year_start=2015&year_end=2015&include_columns=6,3,4,2&flow_quant=Volume&n_nodes=1&locked_nodes[]=2024`