### PR TITLE
Feature/yellow tables admin interface

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,8 @@ engines:
     enabled: true
   duplication:
     enabled: true
+    exclude_paths:
+      - app/admin/api/v3/
     config:
       languages:
       - ruby:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,10 @@ Style/BlockComments:
   Exclude:
     - 'spec/spec_helper.rb'
 
+Style/ClassVars:
+  Exclude:
+    - 'app/models/api/v3/base_model.rb'
+
 Style/Documentation:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'rspec-rails', '~> 3.5'
   gem 'rails-controller-testing'
+  gem 'rspec-collection_matchers'
   gem 'factory_bot_rails'
   gem 'json-schema'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,6 +295,8 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rspec-collection_matchers (1.1.3)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.7.0)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
@@ -429,6 +431,7 @@ DEPENDENCIES
   rack-cors (~> 0.4)
   rails (~> 5.1.1)
   rails-controller-testing
+  rspec-collection_matchers
   rspec-rails (~> 3.5)
   rubocop
   rubyzip

--- a/app/admin/api/v3/carto_layer.rb
+++ b/app/admin/api/v3/carto_layer.rb
@@ -7,13 +7,13 @@ ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
     f.semantic_errors
     inputs do
       input :contextual_layer, as: :select, required: true,
-        collection: Api::V3::ContextualLayer.select_options
+            collection: Api::V3::ContextualLayer.select_options
       input :identifier, required: true, as: :string,
-        hint: object.class.column_comment('identifier')
+            hint: object.class.column_comment('identifier')
       input :years_str, label: 'Years',
-        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :raster_url,
-        hint: object.class.column_comment('raster_url')
+            hint: object.class.column_comment('raster_url')
     end
     f.actions
   end

--- a/app/admin/api/v3/carto_layer.rb
+++ b/app/admin/api/v3/carto_layer.rb
@@ -1,0 +1,29 @@
+ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :contextual_layer_id, :identifier, :years_str, :raster_url
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :contextual_layer, as: :select, required: true,
+        collection: Api::V3::ContextualLayer.select_options
+      input :identifier, required: true, as: :string
+      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
+      input :raster_url
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |layer| layer.contextual_layer&.context&.country&.name }
+    column('Commodity') { |layer| layer.contextual_layer&.context&.commodity&.name }
+    column('ContextualLayer') { |layer| layer.contextual_layer&.identifier }
+    column :identifier
+    column :years
+    column :raster_url
+    actions
+  end
+
+  filter :contextual_layer, collection: -> { Api::V3::ContextualLayer.select_options }
+end

--- a/app/admin/api/v3/carto_layer.rb
+++ b/app/admin/api/v3/carto_layer.rb
@@ -8,9 +8,12 @@ ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
     inputs do
       input :contextual_layer, as: :select, required: true,
         collection: Api::V3::ContextualLayer.select_options
-      input :identifier, required: true, as: :string
-      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
-      input :raster_url
+      input :identifier, required: true, as: :string,
+        hint: object.class.column_comment('identifier')
+      input :years_str, label: 'Years',
+        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+      input :raster_url,
+        hint: object.class.column_comment('raster_url')
     end
     f.actions
   end

--- a/app/admin/api/v3/carto_layer.rb
+++ b/app/admin/api/v3/carto_layer.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Map Settings'
 
   permit_params :contextual_layer_id, :identifier, :years_str, :raster_url
 
@@ -7,11 +7,11 @@ ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
     f.semantic_errors
     inputs do
       input :contextual_layer, as: :select, required: true,
-            collection: Api::V3::ContextualLayer.select_options
+                               collection: Api::V3::ContextualLayer.select_options
       input :identifier, required: true, as: :string,
-            hint: object.class.column_comment('identifier')
+                         hint: object.class.column_comment('identifier')
       input :years_str, label: 'Years',
-            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+                        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :raster_url,
             hint: object.class.column_comment('raster_url')
     end
@@ -21,12 +21,28 @@ ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
   index do
     column('Country') { |layer| layer.contextual_layer&.context&.country&.name }
     column('Commodity') { |layer| layer.contextual_layer&.context&.commodity&.name }
-    column('ContextualLayer') { |layer| layer.contextual_layer&.identifier }
+    column('Contextual Layer') { |layer| layer.contextual_layer&.title }
     column :identifier
     column :years
     column :raster_url
     actions
   end
 
+  show do
+    attributes_table do
+      row :contextual_layer
+      row('Country') { |layer| layer.contextual_layer&.context&.country&.name }
+      row('Commodity') { |layer| layer.contextual_layer&.context&.commodity&.name }
+
+      row :identifier
+      row 'Years', &:years_str
+      row :raster_url
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :contextual_layer, collection: -> { Api::V3::ContextualLayer.select_options }
+
+  filter :contextual_layer_context_id, label: 'Context', as: :select, collection: -> { Api::V3::Context.select_options }
 end

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -9,10 +9,15 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
     inputs do
       input :context_node_type, as: :select, required: true,
         collection: Api::V3::ContextNodeType.select_options
-      input :column_group, required: true
-      input :is_default, as: :boolean, required: true
-      input :is_geo_column, as: :boolean, required: true
-      input :is_choropleth_disabled, as: :boolean, required: true
+      input :column_group, as: :select, required: true,
+        collection: Api::V3::ContextNodeTypeProperty::COLUMN_GROUP,
+        hint: object.class.column_comment('column_group')
+      input :is_default, as: :boolean, required: true,
+        hint: object.class.column_comment('is_default')
+      input :is_geo_column, as: :boolean, required: true,
+        hint: object.class.column_comment('is_geo_column')
+      input :is_choropleth_disabled, as: :boolean, required: true,
+        hint: object.class.column_comment('is_choropleth_disabled')
     end
     f.actions
   end

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -8,16 +8,16 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
     f.semantic_errors
     inputs do
       input :context_node_type, as: :select, required: true,
-        collection: Api::V3::ContextNodeType.select_options
+            collection: Api::V3::ContextNodeType.select_options
       input :column_group, as: :select, required: true,
-        collection: Api::V3::ContextNodeTypeProperty::COLUMN_GROUP,
-        hint: object.class.column_comment('column_group')
+            collection: Api::V3::ContextNodeTypeProperty::COLUMN_GROUP,
+            hint: object.class.column_comment('column_group')
       input :is_default, as: :boolean, required: true,
-        hint: object.class.column_comment('is_default')
+            hint: object.class.column_comment('is_default')
       input :is_geo_column, as: :boolean, required: true,
-        hint: object.class.column_comment('is_geo_column')
+            hint: object.class.column_comment('is_geo_column')
       input :is_choropleth_disabled, as: :boolean, required: true,
-        hint: object.class.column_comment('is_choropleth_disabled')
+            hint: object.class.column_comment('is_choropleth_disabled')
     end
     f.actions
   end

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -1,0 +1,33 @@
+ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypeProperty' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_node_type_id, :column_group, :is_default,
+                :is_geo_column#, :is_choropleth_disabled
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context_node_type, as: :select, required: true,
+        collection: Api::V3::ContextNodeType.select_options
+      input :column_group, required: true
+      input :is_default, as: :boolean, required: true
+      input :is_geo_column, as: :boolean, required: true
+      # input :is_choropleth_disabled, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |property| property.context_node_type&.context&.country&.name }
+    column('Commodity') { |property| property.context_node_type&.context&.commodity&.name }
+    column('Node Type') { |property| property.context_node_type&.node_type&.name }
+    column :column_group
+    column :is_default
+    column :is_geo_column
+    # column :is_choropleth_disabled
+    actions
+  end
+
+  filter :context_node_type, collection: -> { Api::V3::ContextNodeType.
+    select_options }
+end

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypeProperty' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Map Settings'
 
   permit_params :context_node_type_id, :column_group, :is_default,
                 :is_geo_column, :is_choropleth_disabled
@@ -8,24 +8,24 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
     f.semantic_errors
     inputs do
       input :context_node_type, as: :select, required: true,
-            collection: Api::V3::ContextNodeType.select_options
+                                collection: Api::V3::ContextNodeType.select_options
       input :column_group, as: :select, required: true,
-            collection: Api::V3::ContextNodeTypeProperty::COLUMN_GROUP,
-            hint: object.class.column_comment('column_group')
+                           collection: Api::V3::ContextNodeTypeProperty::COLUMN_GROUP,
+                           hint: object.class.column_comment('column_group')
       input :is_default, as: :boolean, required: true,
-            hint: object.class.column_comment('is_default')
+                         hint: object.class.column_comment('is_default')
       input :is_geo_column, as: :boolean, required: true,
-            hint: object.class.column_comment('is_geo_column')
+                            hint: object.class.column_comment('is_geo_column')
       input :is_choropleth_disabled, as: :boolean, required: true,
-            hint: object.class.column_comment('is_choropleth_disabled')
+                                     hint: object.class.column_comment('is_choropleth_disabled')
     end
     f.actions
   end
 
   index do
-    column('Country') { |property| property.context_node_type&.context&.country&.name }
-    column('Commodity') { |property| property.context_node_type&.context&.commodity&.name }
-    column('Node Type') { |property| property.context_node_type&.node_type&.name }
+    column('Country', sortable: true) { |property| property.context_node_type&.context&.country&.name }
+    column('Commodity', sortable: true) { |property| property.context_node_type&.context&.commodity&.name }
+    column('Node Type', sortable: true) { |property| property.context_node_type&.node_type&.name }
     column :column_group
     column :is_default
     column :is_geo_column
@@ -33,6 +33,28 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
     actions
   end
 
-  filter :context_node_type, collection: -> { Api::V3::ContextNodeType.
-    select_options }
+  show do
+    attributes_table do
+      row('Country') { |property| property.context_node_type&.context&.country&.name }
+      row('Commodity') { |property| property.context_node_type&.context&.commodity&.name }
+      row('Node Type') { |property| property.context_node_type&.node_type&.name }
+
+      row :column_group
+      row :is_default
+      row :is_geo_column
+      row :is_choropleth_disabled
+      row :created_at
+      row :updated_at
+    end
+  end
+
+  filter :context_node_type, collection: -> {
+    Api::V3::ContextNodeType.
+      select_options
+  }
+
+  filter :context_node_type_context_id, label: 'Context', as: :select, collection: -> {
+    Api::V3::Context.
+      select_options
+  }
 end

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -2,7 +2,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
   menu parent: 'Yellow Tables'
 
   permit_params :context_node_type_id, :column_group, :is_default,
-                :is_geo_column#, :is_choropleth_disabled
+                :is_geo_column, :is_choropleth_disabled
 
   form do |f|
     f.semantic_errors
@@ -12,7 +12,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
       input :column_group, required: true
       input :is_default, as: :boolean, required: true
       input :is_geo_column, as: :boolean, required: true
-      # input :is_choropleth_disabled, as: :boolean, required: true
+      input :is_choropleth_disabled, as: :boolean, required: true
     end
     f.actions
   end
@@ -24,7 +24,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
     column :column_group
     column :is_default
     column :is_geo_column
-    # column :is_choropleth_disabled
+    column :is_choropleth_disabled
     actions
   end
 

--- a/app/admin/api/v3/context_property.rb
+++ b/app/admin/api/v3/context_property.rb
@@ -9,7 +9,8 @@ ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
     inputs do
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
-      input :default_basemap, as: :string
+      input :default_basemap, as: :select,
+        collection: Api::V3::ContextProperty::DEFAULT_BASEMAP
       input :is_disabled, as: :boolean, required: true
       input :is_default, as: :boolean, required: true
       input :is_subnational, as: :boolean, required: true

--- a/app/admin/api/v3/context_property.rb
+++ b/app/admin/api/v3/context_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'General Settings'
 
   permit_params :context_id, :default_basemap, :is_disabled, :is_default,
                 :is_subnational
@@ -8,16 +8,16 @@ ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
     f.semantic_errors
     inputs do
       input :context, as: :select, required: true,
-            collection: Api::V3::Context.select_options
+                      collection: Api::V3::Context.select_options
       input :default_basemap, as: :select,
-            collection: Api::V3::ContextProperty::DEFAULT_BASEMAP,
-            hint: object.class.column_comment('default_basemap')
+                              collection: Api::V3::ContextProperty::DEFAULT_BASEMAP,
+                              hint: object.class.column_comment('default_basemap')
       input :is_disabled, as: :boolean, required: true,
-            hint: object.class.column_comment('is_disabled')
+                          hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-            hint: object.class.column_comment('is_default')
+                         hint: object.class.column_comment('is_default')
       input :is_subnational, as: :boolean, required: true,
-            hint: object.class.column_comment('is_subnational')
+                             hint: object.class.column_comment('is_subnational')
     end
     f.actions
   end

--- a/app/admin/api/v3/context_property.rb
+++ b/app/admin/api/v3/context_property.rb
@@ -10,10 +10,14 @@ ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
       input :default_basemap, as: :select,
-        collection: Api::V3::ContextProperty::DEFAULT_BASEMAP
-      input :is_disabled, as: :boolean, required: true
-      input :is_default, as: :boolean, required: true
-      input :is_subnational, as: :boolean, required: true
+        collection: Api::V3::ContextProperty::DEFAULT_BASEMAP,
+        hint: object.class.column_comment('default_basemap')
+      input :is_disabled, as: :boolean, required: true,
+        hint: object.class.column_comment('is_disabled')
+      input :is_default, as: :boolean, required: true,
+        hint: object.class.column_comment('is_default')
+      input :is_subnational, as: :boolean, required: true,
+        hint: object.class.column_comment('is_subnational')
     end
     f.actions
   end

--- a/app/admin/api/v3/context_property.rb
+++ b/app/admin/api/v3/context_property.rb
@@ -8,16 +8,16 @@ ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
     f.semantic_errors
     inputs do
       input :context, as: :select, required: true,
-        collection: Api::V3::Context.select_options
+            collection: Api::V3::Context.select_options
       input :default_basemap, as: :select,
-        collection: Api::V3::ContextProperty::DEFAULT_BASEMAP,
-        hint: object.class.column_comment('default_basemap')
+            collection: Api::V3::ContextProperty::DEFAULT_BASEMAP,
+            hint: object.class.column_comment('default_basemap')
       input :is_disabled, as: :boolean, required: true,
-        hint: object.class.column_comment('is_disabled')
+            hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-        hint: object.class.column_comment('is_default')
+            hint: object.class.column_comment('is_default')
       input :is_subnational, as: :boolean, required: true,
-        hint: object.class.column_comment('is_subnational')
+            hint: object.class.column_comment('is_subnational')
     end
     f.actions
   end

--- a/app/admin/api/v3/context_property.rb
+++ b/app/admin/api/v3/context_property.rb
@@ -1,0 +1,30 @@
+ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_id, :default_basemap, :is_disabled, :is_default,
+                :is_subnational
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context, as: :select, required: true,
+        collection: Api::V3::Context.select_options
+      input :default_basemap, as: :string
+      input :is_disabled, as: :boolean, required: true
+      input :is_default, as: :boolean, required: true
+      input :is_subnational, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |property| property.context&.country&.name }
+    column('Commodity') { |property| property.context&.commodity&.name }
+    column :is_disabled
+    column :is_default
+    column :is_subnational
+    actions
+  end
+
+  filter :context, collection: -> { Api::V3::Context.select_options }
+end

--- a/app/admin/api/v3/contextual_layer.rb
+++ b/app/admin/api/v3/contextual_layer.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Map Settings'
 
   permit_params :context_id, :title, :identifier, :position,
                 :tooltip_text, :legend, :is_default
@@ -8,19 +8,19 @@ ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
     f.semantic_errors
     inputs do
       input :context, as: :select, required: true,
-            collection: Api::V3::Context.select_options
+                      collection: Api::V3::Context.select_options
       input :title, required: true, as: :string,
-            hint: object.class.column_comment('title')
+                    hint: object.class.column_comment('title')
       input :identifier, required: true, as: :string,
-            hint: object.class.column_comment('identifier')
+                         hint: object.class.column_comment('identifier')
       input :position, required: true,
-            hint: object.class.column_comment('position')
+                       hint: object.class.column_comment('position')
       input :tooltip_text, as: :string,
-            hint: object.class.column_comment('tooltip_text')
+                           hint: object.class.column_comment('tooltip_text')
       input :legend,
             hint: object.class.column_comment('legend')
       input :is_default, as: :boolean, required: true,
-            hint: object.class.column_comment('is_default')
+                         hint: object.class.column_comment('is_default')
     end
     f.actions
   end
@@ -35,6 +35,21 @@ ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
     column :legend
     column :is_default
     actions
+  end
+
+  show do
+    attributes_table do
+      row('Country') { |attr| attr.context&.country&.name }
+      row('Commodity') { |attr| attr.context&.commodity&.name }
+      row :title
+      row :identifier
+      row :position
+      row :tooltip_text
+      row :legend
+      row :is_default
+      row :created_at
+      row :updated_at
+    end
   end
 
   filter :context, collection: -> { Api::V3::Context.select_options }

--- a/app/admin/api/v3/contextual_layer.rb
+++ b/app/admin/api/v3/contextual_layer.rb
@@ -1,0 +1,35 @@
+ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_id, :title, :identifier, :position,
+                :tooltip_text, :legend, :is_default
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context, as: :select, required: true,
+        collection: Api::V3::Context.select_options
+      input :title, required: true, as: :string
+      input :identifier, required: true, as: :string
+      input :position, required: true
+      input :tooltip_text, as: :string
+      input :legend
+      input :is_default, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |property| property.context&.country&.name }
+    column('Commodity') { |property| property.context&.commodity&.name }
+    column :title
+    column :identifier
+    column :position
+    column :tooltip_text
+    column :legend
+    column :is_default
+    actions
+  end
+
+  filter :context, collection: -> { Api::V3::Context.select_options }
+end

--- a/app/admin/api/v3/contextual_layer.rb
+++ b/app/admin/api/v3/contextual_layer.rb
@@ -8,19 +8,19 @@ ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
     f.semantic_errors
     inputs do
       input :context, as: :select, required: true,
-        collection: Api::V3::Context.select_options
+            collection: Api::V3::Context.select_options
       input :title, required: true, as: :string,
-        hint: object.class.column_comment('title')
+            hint: object.class.column_comment('title')
       input :identifier, required: true, as: :string,
-        hint: object.class.column_comment('identifier')
+            hint: object.class.column_comment('identifier')
       input :position, required: true,
-        hint: object.class.column_comment('position')
+            hint: object.class.column_comment('position')
       input :tooltip_text, as: :string,
-        hint: object.class.column_comment('tooltip_text')
+            hint: object.class.column_comment('tooltip_text')
       input :legend,
-        hint: object.class.column_comment('legend')
+            hint: object.class.column_comment('legend')
       input :is_default, as: :boolean, required: true,
-        hint: object.class.column_comment('is_default')
+            hint: object.class.column_comment('is_default')
     end
     f.actions
   end

--- a/app/admin/api/v3/contextual_layer.rb
+++ b/app/admin/api/v3/contextual_layer.rb
@@ -9,12 +9,18 @@ ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
     inputs do
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
-      input :title, required: true, as: :string
-      input :identifier, required: true, as: :string
-      input :position, required: true
-      input :tooltip_text, as: :string
-      input :legend
-      input :is_default, as: :boolean, required: true
+      input :title, required: true, as: :string,
+        hint: object.class.column_comment('title')
+      input :identifier, required: true, as: :string,
+        hint: object.class.column_comment('identifier')
+      input :position, required: true,
+        hint: object.class.column_comment('position')
+      input :tooltip_text, as: :string,
+        hint: object.class.column_comment('tooltip_text')
+      input :legend,
+        hint: object.class.column_comment('legend')
+      input :is_default, as: :boolean, required: true,
+        hint: object.class.column_comment('is_default')
     end
     f.actions
   end

--- a/app/admin/api/v3/country_property.rb
+++ b/app/admin/api/v3/country_property.rb
@@ -1,0 +1,26 @@
+ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :country_id, :latitude, :longitude, :zoom
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :country, as: :select, required: true
+      input :latitude, required: true
+      input :longitude, required: true
+      input :zoom, required: true
+    end
+    f.actions
+  end
+
+  index download_links: false do
+    column('Country') { |property| property.country&.name }
+    column :latitude
+    column :longitude
+    column :zoom
+    actions
+  end
+
+  filter :country
+end

--- a/app/admin/api/v3/country_property.rb
+++ b/app/admin/api/v3/country_property.rb
@@ -8,11 +8,11 @@ ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
     inputs do
       input :country, as: :select, required: true
       input :latitude, required: true,
-        hint: object.class.column_comment('latitude')
+            hint: object.class.column_comment('latitude')
       input :longitude, required: true,
-        hint: object.class.column_comment('longitude')
+            hint: object.class.column_comment('longitude')
       input :zoom, required: true,
-        hint: object.class.column_comment('zoom')
+            hint: object.class.column_comment('zoom')
     end
     f.actions
   end

--- a/app/admin/api/v3/country_property.rb
+++ b/app/admin/api/v3/country_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Map Settings'
 
   permit_params :country_id, :latitude, :longitude, :zoom
 
@@ -8,11 +8,11 @@ ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
     inputs do
       input :country, as: :select, required: true
       input :latitude, required: true,
-            hint: object.class.column_comment('latitude')
+                       hint: object.class.column_comment('latitude')
       input :longitude, required: true,
-            hint: object.class.column_comment('longitude')
+                        hint: object.class.column_comment('longitude')
       input :zoom, required: true,
-            hint: object.class.column_comment('zoom')
+                   hint: object.class.column_comment('zoom')
     end
     f.actions
   end

--- a/app/admin/api/v3/country_property.rb
+++ b/app/admin/api/v3/country_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
-  menu parent: 'Map Settings'
+  menu parent: 'General Settings'
 
   permit_params :country_id, :latitude, :longitude, :zoom
 

--- a/app/admin/api/v3/country_property.rb
+++ b/app/admin/api/v3/country_property.rb
@@ -7,9 +7,12 @@ ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
     f.semantic_errors
     inputs do
       input :country, as: :select, required: true
-      input :latitude, required: true
-      input :longitude, required: true
-      input :zoom, required: true
+      input :latitude, required: true,
+        hint: object.class.column_comment('latitude')
+      input :longitude, required: true,
+        hint: object.class.column_comment('longitude')
+      input :zoom, required: true,
+        hint: object.class.column_comment('zoom')
     end
     f.actions
   end

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -11,9 +11,12 @@ ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
         select_options
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
-      input :position, required: true
-      input :display_name, required: true, as: :string
-      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
+      input :position, required: true,
+        hint: object.class.column_comment('position')
+      input :display_name, required: true, as: :string,
+        hint: object.class.column_comment('display_name')
+      input :years_str, label: 'Years',
+        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
     end
     f.actions
   end

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -33,6 +33,7 @@ ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
 
   show do
     attributes_table do
+      row :readonly_attribute_display_name
       row('Property', &:readonly_attribute_display_name)
       row('Country') { |property| property.context&.country&.name }
       row('Commodity') { |property| property.context&.commodity&.name }

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Data Download Settings'
 
   permit_params :context_id, :position, :display_name, :years_str,
                 :readonly_attribute_id
@@ -7,24 +7,24 @@ ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
   form do |f|
     f.semantic_errors
     inputs do
-      input :readonly_attribute_id, as: :select,
-            collection: Api::V3::Readonly::Attribute.select_options
+      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
+        select_options, label: 'Property'
       input :context, as: :select, required: true,
-            collection: Api::V3::Context.select_options
+                      collection: Api::V3::Context.select_options
       input :position, required: true,
-            hint: object.class.column_comment('position')
+                       hint: object.class.column_comment('position')
       input :display_name, required: true, as: :string,
-            hint: object.class.column_comment('display_name')
+                           hint: object.class.column_comment('display_name')
       input :years_str, label: 'Years',
-            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+                        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
     end
     f.actions
   end
 
   index do
-    column :readonly_attribute_name
-    column('Country') { |property| property.context&.country&.name }
-    column('Commodity') { |property| property.context&.commodity&.name }
+    column('Property', sortable: true, &:readonly_attribute_display_name)
+    column('Country', sortable: true) { |property| property.context&.country&.name }
+    column('Commodity', sortable: true) { |property| property.context&.commodity&.name }
     column :position
     column :display_name
     column :years
@@ -33,10 +33,15 @@ ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
 
   show do
     attributes_table do
-      row :readonly_attribute_name
-      default_attribute_table_rows.each do |field|
-        row field
-      end
+      row('Property', &:readonly_attribute_display_name)
+      row('Country') { |property| property.context&.country&.name }
+      row('Commodity') { |property| property.context&.commodity&.name }
+
+      row :position
+      row :display_name
+      row :years
+      row :created_at
+      row :updated_at
     end
   end
 

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -1,11 +1,14 @@
 ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
   menu parent: 'Yellow Tables'
 
-  permit_params :context_id, :position, :display_name, :years_str
+  permit_params :context_id, :position, :display_name, :years_str,
+                :readonly_attribute_id
 
   form do |f|
     f.semantic_errors
     inputs do
+      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
+        select_options
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
       input :position, required: true
@@ -16,12 +19,22 @@ ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
   end
 
   index do
+    column :readonly_attribute_name
     column('Country') { |property| property.context&.country&.name }
     column('Commodity') { |property| property.context&.commodity&.name }
     column :position
     column :display_name
     column :years
     actions
+  end
+
+  show do
+    attributes_table do
+      row :readonly_attribute_name
+      default_attribute_table_rows.each do |field|
+        row field
+      end
+    end
   end
 
   filter :context, collection: -> { Api::V3::Context.select_options }

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -7,16 +7,16 @@ ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
   form do |f|
     f.semantic_errors
     inputs do
-      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
-        select_options
+      input :readonly_attribute_id, as: :select,
+            collection: Api::V3::Readonly::Attribute.select_options
       input :context, as: :select, required: true,
-        collection: Api::V3::Context.select_options
+            collection: Api::V3::Context.select_options
       input :position, required: true,
-        hint: object.class.column_comment('position')
+            hint: object.class.column_comment('position')
       input :display_name, required: true, as: :string,
-        hint: object.class.column_comment('display_name')
+            hint: object.class.column_comment('display_name')
       input :years_str, label: 'Years',
-        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
     end
     f.actions
   end

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -1,0 +1,28 @@
+ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_id, :position, :display_name, :years_str
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context, as: :select, required: true,
+        collection: Api::V3::Context.select_options
+      input :position, required: true
+      input :display_name, required: true, as: :string
+      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |property| property.context&.country&.name }
+    column('Commodity') { |property| property.context&.commodity&.name }
+    column :position
+    column :display_name
+    column :years
+    actions
+  end
+
+  filter :context, collection: -> { Api::V3::Context.select_options }
+end

--- a/app/admin/api/v3/ind_property.rb
+++ b/app/admin/api/v3/ind_property.rb
@@ -11,7 +11,8 @@ ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
       input :ind, as: :select, required: true,
         collection: Api::V3::Ind.select_options
       input :display_name, required: true, as: :string
-      input :unit_type, as: :string
+      input :unit_type, as: :select,
+        collection: Api::V3::IndProperty::UNIT_TYPE
       input :tooltip_text, as: :string
       input :is_visible_on_place_profile, as: :boolean, required: true
       input :is_visible_on_actor_profile, as: :boolean, required: true

--- a/app/admin/api/v3/ind_property.rb
+++ b/app/admin/api/v3/ind_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Data Properties'
 
   permit_params :ind_id, :display_name, :unit_type, :tooltip_text,
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,
@@ -9,35 +9,30 @@ ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
     f.semantic_errors
     inputs do
       input :ind, as: :select, required: true,
-            collection: Api::V3::Ind.select_options
+                  collection: Api::V3::Ind.select_options
       input :display_name, required: true, as: :string,
-            hint: object.class.column_comment('display_name')
+                           hint: object.class.column_comment('display_name')
       input :unit_type, as: :select,
-            collection: Api::V3::IndProperty::UNIT_TYPE,
-            hint: object.class.column_comment('unit_type')
+                        collection: Api::V3::IndProperty::UNIT_TYPE,
+                        hint: object.class.column_comment('unit_type')
       input :tooltip_text, as: :string,
-            hint: object.class.column_comment('tooltip_text')
+                           hint: object.class.column_comment('tooltip_text')
       input :is_visible_on_place_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_visible_on_place_profile')
+                                          hint: object.class.column_comment('is_visible_on_place_profile')
       input :is_visible_on_actor_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_visible_on_actor_profile')
+                                          hint: object.class.column_comment('is_visible_on_actor_profile')
       input :is_temporal_on_place_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_temporal_on_place_profile')
+                                           hint: object.class.column_comment('is_temporal_on_place_profile')
       input :is_temporal_on_actor_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_temporal_on_actor_profile')
+                                           hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end
 
   index do
-    column('Ind') { |property| property.ind&.name }
     column :display_name
     column :unit_type
     column :tooltip_text
-    column :is_visible_on_place_profile
-    column :is_visible_on_actor_profile
-    column :is_temporal_on_place_profile
-    column :is_temporal_on_actor_profile
     actions
   end
 

--- a/app/admin/api/v3/ind_property.rb
+++ b/app/admin/api/v3/ind_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
-  menu parent: 'Data Properties'
+  menu parent: 'General Settings'
 
   permit_params :ind_id, :display_name, :unit_type, :tooltip_text,
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,

--- a/app/admin/api/v3/ind_property.rb
+++ b/app/admin/api/v3/ind_property.rb
@@ -10,14 +10,21 @@ ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
     inputs do
       input :ind, as: :select, required: true,
         collection: Api::V3::Ind.select_options
-      input :display_name, required: true, as: :string
+      input :display_name, required: true, as: :string,
+        hint: object.class.column_comment('display_name')
       input :unit_type, as: :select,
-        collection: Api::V3::IndProperty::UNIT_TYPE
-      input :tooltip_text, as: :string
-      input :is_visible_on_place_profile, as: :boolean, required: true
-      input :is_visible_on_actor_profile, as: :boolean, required: true
-      input :is_temporal_on_place_profile, as: :boolean, required: true
-      input :is_temporal_on_actor_profile, as: :boolean, required: true
+        collection: Api::V3::IndProperty::UNIT_TYPE,
+        hint: object.class.column_comment('unit_type')
+      input :tooltip_text, as: :string,
+        hint: object.class.column_comment('tooltip_text')
+      input :is_visible_on_place_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_visible_on_place_profile')
+      input :is_visible_on_actor_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_visible_on_actor_profile')
+      input :is_temporal_on_place_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_temporal_on_place_profile')
+      input :is_temporal_on_actor_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end

--- a/app/admin/api/v3/ind_property.rb
+++ b/app/admin/api/v3/ind_property.rb
@@ -9,22 +9,22 @@ ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
     f.semantic_errors
     inputs do
       input :ind, as: :select, required: true,
-        collection: Api::V3::Ind.select_options
+            collection: Api::V3::Ind.select_options
       input :display_name, required: true, as: :string,
-        hint: object.class.column_comment('display_name')
+            hint: object.class.column_comment('display_name')
       input :unit_type, as: :select,
-        collection: Api::V3::IndProperty::UNIT_TYPE,
-        hint: object.class.column_comment('unit_type')
+            collection: Api::V3::IndProperty::UNIT_TYPE,
+            hint: object.class.column_comment('unit_type')
       input :tooltip_text, as: :string,
-        hint: object.class.column_comment('tooltip_text')
+            hint: object.class.column_comment('tooltip_text')
       input :is_visible_on_place_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_visible_on_place_profile')
+            hint: object.class.column_comment('is_visible_on_place_profile')
       input :is_visible_on_actor_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_visible_on_actor_profile')
+            hint: object.class.column_comment('is_visible_on_actor_profile')
       input :is_temporal_on_place_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_temporal_on_place_profile')
+            hint: object.class.column_comment('is_temporal_on_place_profile')
       input :is_temporal_on_actor_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_temporal_on_actor_profile')
+            hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end

--- a/app/admin/api/v3/ind_property.rb
+++ b/app/admin/api/v3/ind_property.rb
@@ -1,0 +1,37 @@
+ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :ind_id, :display_name, :unit_type, :tooltip_text,
+                :is_visible_on_place_profile, :is_visible_on_actor_profile,
+                :is_temporal_on_place_profile, :is_temporal_on_actor_profile
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :ind, as: :select, required: true,
+        collection: Api::V3::Ind.select_options
+      input :display_name, required: true, as: :string
+      input :unit_type, as: :string
+      input :tooltip_text, as: :string
+      input :is_visible_on_place_profile, as: :boolean, required: true
+      input :is_visible_on_actor_profile, as: :boolean, required: true
+      input :is_temporal_on_place_profile, as: :boolean, required: true
+      input :is_temporal_on_actor_profile, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Ind') { |property| property.ind&.name }
+    column :display_name
+    column :unit_type
+    column :tooltip_text
+    column :is_visible_on_place_profile
+    column :is_visible_on_actor_profile
+    column :is_temporal_on_place_profile
+    column :is_temporal_on_actor_profile
+    actions
+  end
+
+  filter :ind, collection: -> { Api::V3::Ind.select_options }
+end

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -18,13 +18,20 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
         select_options
       input :map_attribute_group, as: :select, required: true,
         collection: Api::V3::MapAttributeGroup.select_options
-      input :position, required: true
-      input :bucket_3_str, hint: 'Comma-separated list of 2 values', label: 'Bucket 3', required: true
-      input :bucket_5_str, hint: 'Comma-separated list of 4 values', label: 'Bucket 5', required: true
-      input :color_scale, as: :select, collection: Api::V3::MapAttribute::COLOR_SCALE
-      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
-      input :is_disabled, as: :boolean, required: true
-      input :is_default, as: :boolean, required: true
+      input :position, required: true,
+        hint: object.class.column_comment('position')
+      input :bucket_3_str, label: 'Bucket 3', required: true,
+        hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 2 values)'
+      input :bucket_5_str, label: 'Bucket 5', required: true,
+        hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 4 values)'
+      input :color_scale, as: :select, collection: Api::V3::MapAttribute::COLOR_SCALE,
+        hint: object.class.column_comment('color_scale')
+      input :years_str, label: 'Years',
+        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+      input :is_disabled, as: :boolean, required: true,
+        hint: object.class.column_comment('is_disabled')
+      input :is_default, as: :boolean, required: true,
+        hint: object.class.column_comment('is_default')
     end
     f.actions
   end

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Map Settings'
 
   includes [
     {map_attribute_group: {context: [:country, :commodity]}},
@@ -15,36 +15,35 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
     f.semantic_errors
     inputs do
       input :readonly_attribute_id, as: :select,
-            collection: Api::V3::Readonly::Attribute.select_options
+                                    collection: Api::V3::Readonly::Attribute.select_options
       input :map_attribute_group, as: :select, required: true,
-            collection: Api::V3::MapAttributeGroup.select_options
+                                  collection: Api::V3::MapAttributeGroup.select_options
       input :position, required: true,
-            hint: object.class.column_comment('position')
-      input :bucket_3_str, label: 'Bucket 3', required: true,
-            hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 2 values)'
-      input :bucket_5_str, label: 'Bucket 5', required: true,
-            hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 4 values)'
+                       hint: object.class.column_comment('position')
+      input :bucket_3_str, required: true,
+                           hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list)',
+                           label: 'Single dimension buckets'
+      input :bucket_5_str, required: true,
+                           hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list)',
+                           label: 'Dual dimension buckets'
       input :color_scale, as: :select, collection: Api::V3::MapAttribute::COLOR_SCALE,
-            hint: object.class.column_comment('color_scale')
+                          hint: object.class.column_comment('color_scale')
       input :years_str, label: 'Years',
-            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+                        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :is_disabled, as: :boolean, required: true,
-            hint: object.class.column_comment('is_disabled')
+                          hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-            hint: object.class.column_comment('is_default')
+                         hint: object.class.column_comment('is_default')
     end
     f.actions
   end
 
   index do
-    column :readonly_attribute_name
+    column :readonly_attribute_display_name
     column('Country') { |attribute| attribute.map_attribute_group&.context&.country&.name }
     column('Commodity') { |attribute| attribute.map_attribute_group&.context&.commodity&.name }
-    column('MapAttributeGroup') { |attribute| attribute.map_attribute_group&.name }
+    column('Map Attribute Group') { |attribute| attribute.map_attribute_group&.name }
     column :position
-    column :bucket_3
-    column :bucket_5
-    column :color_scale
     column :years
     column :is_disabled
     column :is_default
@@ -53,14 +52,29 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
 
   show do
     attributes_table do
-      row :readonly_attribute_name
-      default_attribute_table_rows.each do |field|
-        row field
-      end
+      row :readonly_attribute_display_name
+      row :map_attribute_group
+      row('Country') { |attr| attr.map_attribute_group&.context&.country&.name }
+      row('Commodity') { |attr| attr.map_attribute_group&.context&.commodity&.name }
+      row :position
+      row('Single dimension buckets', &:bucket_3_str)
+      row('Dual dimension buckets', &:bucket_5_str)
+      row :color_scale
+      row('Years', &:years_str)
+      row :is_disabled
+      row :is_default
+      row :created_at
+      row :updated_at
     end
   end
 
+  filter :map_attribute_group_context_id, label: 'Context', as: :select, collection: -> {
+    Api::V3::Context.
+      select_options
+  }
+
   filter :map_attribute_group, collection: -> {
-    Api::V3::MapAttributeGroup.select_options
+    Api::V3::MapAttributeGroup.
+      select_options
   }
 end

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -14,24 +14,24 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
   form do |f|
     f.semantic_errors
     inputs do
-      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
-        select_options
+      input :readonly_attribute_id, as: :select,
+            collection: Api::V3::Readonly::Attribute.select_options
       input :map_attribute_group, as: :select, required: true,
-        collection: Api::V3::MapAttributeGroup.select_options
+            collection: Api::V3::MapAttributeGroup.select_options
       input :position, required: true,
-        hint: object.class.column_comment('position')
+            hint: object.class.column_comment('position')
       input :bucket_3_str, label: 'Bucket 3', required: true,
-        hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 2 values)'
+            hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 2 values)'
       input :bucket_5_str, label: 'Bucket 5', required: true,
-        hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 4 values)'
+            hint: (object.class.column_comment('bucket_3') || '') + ' (comma-separated list of 4 values)'
       input :color_scale, as: :select, collection: Api::V3::MapAttribute::COLOR_SCALE,
-        hint: object.class.column_comment('color_scale')
+            hint: object.class.column_comment('color_scale')
       input :years_str, label: 'Years',
-        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :is_disabled, as: :boolean, required: true,
-        hint: object.class.column_comment('is_disabled')
+            hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-        hint: object.class.column_comment('is_default')
+            hint: object.class.column_comment('is_default')
     end
     f.actions
   end
@@ -60,6 +60,7 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
     end
   end
 
-  filter :map_attribute_group, collection: -> { Api::V3::MapAttributeGroup.
-    select_options }
+  filter :map_attribute_group, collection: -> {
+    Api::V3::MapAttributeGroup.select_options
+  }
 end

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -1,13 +1,21 @@
 ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
   menu parent: 'Yellow Tables'
 
+  includes [
+    {map_attribute_group: {context: [:country, :commodity]}},
+    :map_ind,
+    :map_quant
+  ]
+
   permit_params :map_attribute_group_id, :position, :bucket_3_str,
                 :bucket_5_str, :color_scale, :years_str, :is_disabled,
-                :is_default
+                :is_default, :readonly_attribute_id
 
   form do |f|
     f.semantic_errors
     inputs do
+      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
+        select_options
       input :map_attribute_group, as: :select, required: true,
         collection: Api::V3::MapAttributeGroup.select_options
       input :position, required: true
@@ -22,6 +30,7 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
   end
 
   index do
+    column :readonly_attribute_name
     column('Country') { |attribute| attribute.map_attribute_group&.context&.country&.name }
     column('Commodity') { |attribute| attribute.map_attribute_group&.context&.commodity&.name }
     column('MapAttributeGroup') { |attribute| attribute.map_attribute_group&.name }
@@ -33,6 +42,15 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
     column :is_disabled
     column :is_default
     actions
+  end
+
+  show do
+    attributes_table do
+      row :readonly_attribute_name
+      default_attribute_table_rows.each do |field|
+        row field
+      end
+    end
   end
 
   filter :map_attribute_group, collection: -> { Api::V3::MapAttributeGroup.

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -1,0 +1,40 @@
+ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :map_attribute_group_id, :position, :bucket_3_str,
+                :bucket_5_str, :color_scale, :years_str, :is_disabled,
+                :is_default
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :map_attribute_group, as: :select, required: true,
+        collection: Api::V3::MapAttributeGroup.select_options
+      input :position, required: true
+      input :bucket_3_str, hint: 'Comma-separated list of 2 values', label: 'Bucket 3', required: true
+      input :bucket_5_str, hint: 'Comma-separated list of 4 values', label: 'Bucket 5', required: true
+      input :color_scale, as: :string
+      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
+      input :is_disabled, as: :boolean, required: true
+      input :is_default, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |attribute| attribute.map_attribute_group&.context&.country&.name }
+    column('Commodity') { |attribute| attribute.map_attribute_group&.context&.commodity&.name }
+    column('MapAttributeGroup') { |attribute| attribute.map_attribute_group&.name }
+    column :position
+    column :bucket_3
+    column :bucket_5
+    column :color_scale
+    column :years
+    column :is_disabled
+    column :is_default
+    actions
+  end
+
+  filter :map_attribute_group, collection: -> { Api::V3::MapAttributeGroup.
+    select_options }
+end

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -21,7 +21,7 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
       input :position, required: true
       input :bucket_3_str, hint: 'Comma-separated list of 2 values', label: 'Bucket 3', required: true
       input :bucket_5_str, hint: 'Comma-separated list of 4 values', label: 'Bucket 5', required: true
-      input :color_scale, as: :string
+      input :color_scale, as: :select, collection: Api::V3::MapAttribute::COLOR_SCALE
       input :years_str, hint: 'Comma-separated list of years', label: 'Years'
       input :is_disabled, as: :boolean, required: true
       input :is_default, as: :boolean, required: true

--- a/app/admin/api/v3/map_attribute_group.rb
+++ b/app/admin/api/v3/map_attribute_group.rb
@@ -1,0 +1,26 @@
+ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_id, :name, :position
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context, as: :select, required: true,
+        collection: Api::V3::Context.select_options
+      input :name, required: true, as: :string
+      input :position, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |group| group.context&.country&.name }
+    column('Commodity') { |group| group.context&.commodity&.name }
+    column :name
+    column :position
+    actions
+  end
+
+  filter :context, collection: -> { Api::V3::Context.select_options }
+end

--- a/app/admin/api/v3/map_attribute_group.rb
+++ b/app/admin/api/v3/map_attribute_group.rb
@@ -8,8 +8,10 @@ ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
     inputs do
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
-      input :name, required: true, as: :string
-      input :position, required: true
+      input :name, required: true, as: :string,
+        hint: object.class.column_comment('name')
+      input :position, required: true,
+        hint: object.class.column_comment('position')
     end
     f.actions
   end

--- a/app/admin/api/v3/map_attribute_group.rb
+++ b/app/admin/api/v3/map_attribute_group.rb
@@ -7,11 +7,11 @@ ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
     f.semantic_errors
     inputs do
       input :context, as: :select, required: true,
-        collection: Api::V3::Context.select_options
+            collection: Api::V3::Context.select_options
       input :name, required: true, as: :string,
-        hint: object.class.column_comment('name')
+            hint: object.class.column_comment('name')
       input :position, required: true,
-        hint: object.class.column_comment('position')
+            hint: object.class.column_comment('position')
     end
     f.actions
   end

--- a/app/admin/api/v3/map_attribute_group.rb
+++ b/app/admin/api/v3/map_attribute_group.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Map Settings'
 
   permit_params :context_id, :name, :position
 
@@ -7,11 +7,11 @@ ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
     f.semantic_errors
     inputs do
       input :context, as: :select, required: true,
-            collection: Api::V3::Context.select_options
+                      collection: Api::V3::Context.select_options
       input :name, required: true, as: :string,
-            hint: object.class.column_comment('name')
+                   hint: object.class.column_comment('name')
       input :position, required: true,
-            hint: object.class.column_comment('position')
+                       hint: object.class.column_comment('position')
     end
     f.actions
   end
@@ -22,6 +22,17 @@ ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
     column :name
     column :position
     actions
+  end
+
+  show do
+    attributes_table do
+      row('Country') { |group| group.context&.country&.name }
+      row('Commodity') { |group| group.context&.commodity&.name }
+      row :name
+      row :position
+      row :created_at
+      row :updated_at
+    end
   end
 
   filter :context, collection: -> { Api::V3::Context.select_options }

--- a/app/admin/api/v3/profile.rb
+++ b/app/admin/api/v3/profile.rb
@@ -8,7 +8,9 @@ ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
     inputs do
       input :context_node_type, as: :select, required: true,
         collection: Api::V3::ContextNodeType.select_options
-      input :name, as: :string
+      input :name, as: :select,
+        collection: Api::V3::Profile::NAME,
+        hint: object.class.column_comment('name')
     end
     f.actions
   end

--- a/app/admin/api/v3/profile.rb
+++ b/app/admin/api/v3/profile.rb
@@ -1,0 +1,26 @@
+ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_node_type_id, :name
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context_node_type, as: :select, required: true,
+        collection: Api::V3::ContextNodeType.select_options
+      input :name, as: :string
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |property| property.context_node_type&.context&.country&.name }
+    column('Commodity') { |property| property.context_node_type&.context&.commodity&.name }
+    column('Node Type') { |property| property.context_node_type&.node_type&.name }
+    column :name
+    actions
+  end
+
+  filter :context_node_type, collection: -> { Api::V3::ContextNodeType.
+    select_options }
+end

--- a/app/admin/api/v3/profile.rb
+++ b/app/admin/api/v3/profile.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Profile Settings'
 
   permit_params :context_node_type_id, :name
 
@@ -7,10 +7,10 @@ ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
     f.semantic_errors
     inputs do
       input :context_node_type, as: :select, required: true,
-            collection: Api::V3::ContextNodeType.select_options
+                                collection: Api::V3::ContextNodeType.select_options
       input :name, as: :select,
-            collection: Api::V3::Profile::NAME,
-            hint: object.class.column_comment('name')
+                   collection: Api::V3::Profile::NAME,
+                   hint: object.class.column_comment('name')
     end
     f.actions
   end
@@ -22,6 +22,22 @@ ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
     column :name
     actions
   end
+
+  show do
+    attributes_table do
+      row('Country') { |property| property.context_node_type&.context&.country&.name }
+      row('Commodity') { |property| property.context_node_type&.context&.commodity&.name }
+      row('Node Type') { |property| property.context_node_type&.node_type&.name }
+      row :name
+      row :created_at
+      row :updated_at
+    end
+  end
+
+  filter :context_node_type, collection: -> {
+    Api::V3::ContextNodeType.
+      select_options
+  }
 
   filter :context_node_type, collection: -> {
     Api::V3::ContextNodeType.select_options

--- a/app/admin/api/v3/profile.rb
+++ b/app/admin/api/v3/profile.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
-  menu parent: 'Profile Settings'
+  menu parent: 'General Settings'
 
   permit_params :context_node_type_id, :name
 

--- a/app/admin/api/v3/profile.rb
+++ b/app/admin/api/v3/profile.rb
@@ -7,10 +7,10 @@ ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
     f.semantic_errors
     inputs do
       input :context_node_type, as: :select, required: true,
-        collection: Api::V3::ContextNodeType.select_options
+            collection: Api::V3::ContextNodeType.select_options
       input :name, as: :select,
-        collection: Api::V3::Profile::NAME,
-        hint: object.class.column_comment('name')
+            collection: Api::V3::Profile::NAME,
+            hint: object.class.column_comment('name')
     end
     f.actions
   end
@@ -23,6 +23,7 @@ ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
     actions
   end
 
-  filter :context_node_type, collection: -> { Api::V3::ContextNodeType.
-    select_options }
+  filter :context_node_type, collection: -> {
+    Api::V3::ContextNodeType.select_options
+  }
 end

--- a/app/admin/api/v3/qual_property.rb
+++ b/app/admin/api/v3/qual_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::QualProperty, as: 'QualProperty' do
-  menu parent: 'Data Properties'
+  menu parent: 'General Settings'
 
   permit_params :qual_id, :display_name, :tooltip_text,
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,

--- a/app/admin/api/v3/qual_property.rb
+++ b/app/admin/api/v3/qual_property.rb
@@ -9,19 +9,19 @@ ActiveAdmin.register Api::V3::QualProperty, as: 'QualProperty' do
     f.semantic_errors
     inputs do
       input :qual, as: :select, required: true,
-        collection: Api::V3::Qual.select_options
+            collection: Api::V3::Qual.select_options
       input :display_name, required: true, as: :string,
-        hint: object.class.column_comment('display_name')
+            hint: object.class.column_comment('display_name')
       input :tooltip_text, as: :string,
-        hint: object.class.column_comment('tooltip_text')
+            hint: object.class.column_comment('tooltip_text')
       input :is_visible_on_place_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_visible_on_place_profile')
+            hint: object.class.column_comment('is_visible_on_place_profile')
       input :is_visible_on_actor_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_visible_on_actor_profile')
+            hint: object.class.column_comment('is_visible_on_actor_profile')
       input :is_temporal_on_place_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_temporal_on_place_profile')
+            hint: object.class.column_comment('is_temporal_on_place_profile')
       input :is_temporal_on_actor_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_temporal_on_actor_profile')
+            hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end

--- a/app/admin/api/v3/qual_property.rb
+++ b/app/admin/api/v3/qual_property.rb
@@ -1,0 +1,35 @@
+ActiveAdmin.register Api::V3::QualProperty, as: 'QualProperty' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :qual_id, :display_name, :tooltip_text,
+                :is_visible_on_place_profile, :is_visible_on_actor_profile,
+                :is_temporal_on_place_profile, :is_temporal_on_actor_profile
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :qual, as: :select, required: true,
+        collection: Api::V3::Qual.select_options
+      input :display_name, required: true, as: :string
+      input :tooltip_text, as: :string
+      input :is_visible_on_place_profile, as: :boolean, required: true
+      input :is_visible_on_actor_profile, as: :boolean, required: true
+      input :is_temporal_on_place_profile, as: :boolean, required: true
+      input :is_temporal_on_actor_profile, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Qual') { |property| property.qual&.name }
+    column :display_name
+    column :tooltip_text
+    column :is_visible_on_place_profile
+    column :is_visible_on_actor_profile
+    column :is_temporal_on_place_profile
+    column :is_temporal_on_actor_profile
+    actions
+  end
+
+  filter :qual, collection: -> { Api::V3::Qual.select_options }
+end

--- a/app/admin/api/v3/qual_property.rb
+++ b/app/admin/api/v3/qual_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::QualProperty, as: 'QualProperty' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Data Properties'
 
   permit_params :qual_id, :display_name, :tooltip_text,
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,
@@ -9,31 +9,26 @@ ActiveAdmin.register Api::V3::QualProperty, as: 'QualProperty' do
     f.semantic_errors
     inputs do
       input :qual, as: :select, required: true,
-            collection: Api::V3::Qual.select_options
+                   collection: Api::V3::Qual.select_options
       input :display_name, required: true, as: :string,
-            hint: object.class.column_comment('display_name')
+                           hint: object.class.column_comment('display_name')
       input :tooltip_text, as: :string,
-            hint: object.class.column_comment('tooltip_text')
+                           hint: object.class.column_comment('tooltip_text')
       input :is_visible_on_place_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_visible_on_place_profile')
+                                          hint: object.class.column_comment('is_visible_on_place_profile')
       input :is_visible_on_actor_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_visible_on_actor_profile')
+                                          hint: object.class.column_comment('is_visible_on_actor_profile')
       input :is_temporal_on_place_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_temporal_on_place_profile')
+                                           hint: object.class.column_comment('is_temporal_on_place_profile')
       input :is_temporal_on_actor_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_temporal_on_actor_profile')
+                                           hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end
 
   index do
-    column('Qual') { |property| property.qual&.name }
     column :display_name
     column :tooltip_text
-    column :is_visible_on_place_profile
-    column :is_visible_on_actor_profile
-    column :is_temporal_on_place_profile
-    column :is_temporal_on_actor_profile
     actions
   end
 

--- a/app/admin/api/v3/qual_property.rb
+++ b/app/admin/api/v3/qual_property.rb
@@ -10,12 +10,18 @@ ActiveAdmin.register Api::V3::QualProperty, as: 'QualProperty' do
     inputs do
       input :qual, as: :select, required: true,
         collection: Api::V3::Qual.select_options
-      input :display_name, required: true, as: :string
-      input :tooltip_text, as: :string
-      input :is_visible_on_place_profile, as: :boolean, required: true
-      input :is_visible_on_actor_profile, as: :boolean, required: true
-      input :is_temporal_on_place_profile, as: :boolean, required: true
-      input :is_temporal_on_actor_profile, as: :boolean, required: true
+      input :display_name, required: true, as: :string,
+        hint: object.class.column_comment('display_name')
+      input :tooltip_text, as: :string,
+        hint: object.class.column_comment('tooltip_text')
+      input :is_visible_on_place_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_visible_on_place_profile')
+      input :is_visible_on_actor_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_visible_on_actor_profile')
+      input :is_temporal_on_place_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_temporal_on_place_profile')
+      input :is_temporal_on_actor_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end

--- a/app/admin/api/v3/quant_property.rb
+++ b/app/admin/api/v3/quant_property.rb
@@ -10,14 +10,21 @@ ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
     inputs do
       input :quant, as: :select, required: true,
         collection: Api::V3::Quant.select_options
-      input :display_name, required: true, as: :string
+      input :display_name, required: true, as: :string,
+        hint: object.class.column_comment('display_name')
       input :unit_type, as: :select,
-        collection: Api::V3::QuantProperty::UNIT_TYPE
-      input :tooltip_text, as: :string
-      input :is_visible_on_place_profile, as: :boolean, required: true
-      input :is_visible_on_actor_profile, as: :boolean, required: true
-      input :is_temporal_on_place_profile, as: :boolean, required: true
-      input :is_temporal_on_actor_profile, as: :boolean, required: true
+        collection: Api::V3::QuantProperty::UNIT_TYPE,
+        hint: object.class.column_comment('unit_type')
+      input :tooltip_text, as: :string,
+        hint: object.class.column_comment('tooltip_text')
+      input :is_visible_on_place_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_visible_on_place_profile')
+      input :is_visible_on_actor_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_visible_on_actor_profile')
+      input :is_temporal_on_place_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_temporal_on_place_profile')
+      input :is_temporal_on_actor_profile, as: :boolean, required: true,
+        hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end

--- a/app/admin/api/v3/quant_property.rb
+++ b/app/admin/api/v3/quant_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Data Properties'
 
   permit_params :quant_id, :display_name, :unit_type, :tooltip_text,
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,
@@ -9,35 +9,30 @@ ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
     f.semantic_errors
     inputs do
       input :quant, as: :select, required: true,
-            collection: Api::V3::Quant.select_options
+                    collection: Api::V3::Quant.select_options
       input :display_name, required: true, as: :string,
-            hint: object.class.column_comment('display_name')
+                           hint: object.class.column_comment('display_name')
       input :unit_type, as: :select,
-            collection: Api::V3::QuantProperty::UNIT_TYPE,
-            hint: object.class.column_comment('unit_type')
+                        collection: Api::V3::QuantProperty::UNIT_TYPE,
+                        hint: object.class.column_comment('unit_type')
       input :tooltip_text, as: :string,
-            hint: object.class.column_comment('tooltip_text')
+                           hint: object.class.column_comment('tooltip_text')
       input :is_visible_on_place_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_visible_on_place_profile')
+                                          hint: object.class.column_comment('is_visible_on_place_profile')
       input :is_visible_on_actor_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_visible_on_actor_profile')
+                                          hint: object.class.column_comment('is_visible_on_actor_profile')
       input :is_temporal_on_place_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_temporal_on_place_profile')
+                                           hint: object.class.column_comment('is_temporal_on_place_profile')
       input :is_temporal_on_actor_profile, as: :boolean, required: true,
-            hint: object.class.column_comment('is_temporal_on_actor_profile')
+                                           hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end
 
   index do
-    column('Quant') { |property| property.quant&.name }
     column :display_name
     column :unit_type
     column :tooltip_text
-    column :is_visible_on_place_profile
-    column :is_visible_on_actor_profile
-    column :is_temporal_on_place_profile
-    column :is_temporal_on_actor_profile
     actions
   end
 

--- a/app/admin/api/v3/quant_property.rb
+++ b/app/admin/api/v3/quant_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
-  menu parent: 'Data Properties'
+  menu parent: 'General Settings'
 
   permit_params :quant_id, :display_name, :unit_type, :tooltip_text,
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,

--- a/app/admin/api/v3/quant_property.rb
+++ b/app/admin/api/v3/quant_property.rb
@@ -9,22 +9,22 @@ ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
     f.semantic_errors
     inputs do
       input :quant, as: :select, required: true,
-        collection: Api::V3::Quant.select_options
+            collection: Api::V3::Quant.select_options
       input :display_name, required: true, as: :string,
-        hint: object.class.column_comment('display_name')
+            hint: object.class.column_comment('display_name')
       input :unit_type, as: :select,
-        collection: Api::V3::QuantProperty::UNIT_TYPE,
-        hint: object.class.column_comment('unit_type')
+            collection: Api::V3::QuantProperty::UNIT_TYPE,
+            hint: object.class.column_comment('unit_type')
       input :tooltip_text, as: :string,
-        hint: object.class.column_comment('tooltip_text')
+            hint: object.class.column_comment('tooltip_text')
       input :is_visible_on_place_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_visible_on_place_profile')
+            hint: object.class.column_comment('is_visible_on_place_profile')
       input :is_visible_on_actor_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_visible_on_actor_profile')
+            hint: object.class.column_comment('is_visible_on_actor_profile')
       input :is_temporal_on_place_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_temporal_on_place_profile')
+            hint: object.class.column_comment('is_temporal_on_place_profile')
       input :is_temporal_on_actor_profile, as: :boolean, required: true,
-        hint: object.class.column_comment('is_temporal_on_actor_profile')
+            hint: object.class.column_comment('is_temporal_on_actor_profile')
     end
     f.actions
   end

--- a/app/admin/api/v3/quant_property.rb
+++ b/app/admin/api/v3/quant_property.rb
@@ -11,7 +11,8 @@ ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
       input :quant, as: :select, required: true,
         collection: Api::V3::Quant.select_options
       input :display_name, required: true, as: :string
-      input :unit_type, as: :string
+      input :unit_type, as: :select,
+        collection: Api::V3::QuantProperty::UNIT_TYPE
       input :tooltip_text, as: :string
       input :is_visible_on_place_profile, as: :boolean, required: true
       input :is_visible_on_actor_profile, as: :boolean, required: true

--- a/app/admin/api/v3/quant_property.rb
+++ b/app/admin/api/v3/quant_property.rb
@@ -1,0 +1,37 @@
+ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :quant_id, :display_name, :unit_type, :tooltip_text,
+                :is_visible_on_place_profile, :is_visible_on_actor_profile,
+                :is_temporal_on_place_profile, :is_temporal_on_actor_profile
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :quant, as: :select, required: true,
+        collection: Api::V3::Quant.select_options
+      input :display_name, required: true, as: :string
+      input :unit_type, as: :string
+      input :tooltip_text, as: :string
+      input :is_visible_on_place_profile, as: :boolean, required: true
+      input :is_visible_on_actor_profile, as: :boolean, required: true
+      input :is_temporal_on_place_profile, as: :boolean, required: true
+      input :is_temporal_on_actor_profile, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Quant') { |property| property.quant&.name }
+    column :display_name
+    column :unit_type
+    column :tooltip_text
+    column :is_visible_on_place_profile
+    column :is_visible_on_actor_profile
+    column :is_temporal_on_place_profile
+    column :is_temporal_on_actor_profile
+    actions
+  end
+
+  filter :quant, collection: -> { Api::V3::Quant.select_options }
+end

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -1,0 +1,48 @@
+ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_id, :group_number, :position, :legend_type,
+                :legend_color_theme, :interval_count, :min_value, :max_value,
+                :divisor, :tooltip_text, :years_str, :is_disabled, :is_default
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context, as: :select, required: true,
+        collection: Api::V3::Context.select_options
+      input :group_number, required: true
+      input :position, required: true
+      input :legend_type, required: true, as: :string
+      input :legend_color_theme, required: true, as: :string
+      input :interval_count
+      input :min_value, as: :string
+      input :max_value, as: :string
+      input :divisor
+      input :tooltip_text, as: :string
+      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
+      input :is_disabled, as: :boolean, required: true
+      input :is_default, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |property| property.context&.country&.name }
+    column('Commodity') { |property| property.context&.commodity&.name }
+    column :group_number
+    column :position
+    column :legend_type
+    column :legend_color_theme
+    column :interval_count
+    column :min_value
+    column :max_value
+    column :divisor
+    column :tooltip_text
+    column :years
+    column :is_disabled
+    column :is_default
+    actions
+  end
+
+  filter :context, collection: -> { Api::V3::Context.select_options }
+end

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -21,8 +21,10 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
         collection: Api::V3::Context.select_options
       input :group_number, required: true
       input :position, required: true
-      input :legend_type, required: true, as: :string
-      input :legend_color_theme, required: true, as: :string
+      input :legend_type, required: true, as: :select,
+        collection: Api::V3::RecolorByAttribute::LEGEND_TYPE
+      input :legend_color_theme, required: true, as: :select,
+        collection: Api::V3::RecolorByAttribute::LEGEND_COLOR_THEME
       input :interval_count
       input :min_value, as: :string
       input :max_value, as: :string

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -1,13 +1,22 @@
 ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
   menu parent: 'Yellow Tables'
 
+  includes [
+    {context: [:country, :commodity]},
+    :recolor_by_ind,
+    :recolor_by_qual
+  ]
+
   permit_params :context_id, :group_number, :position, :legend_type,
                 :legend_color_theme, :interval_count, :min_value, :max_value,
-                :divisor, :tooltip_text, :years_str, :is_disabled, :is_default
+                :divisor, :tooltip_text, :years_str, :is_disabled, :is_default,
+                :readonly_attribute_id
 
   form do |f|
     f.semantic_errors
     inputs do
+      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
+        select_options
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
       input :group_number, required: true
@@ -27,6 +36,7 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
   end
 
   index do
+    column :readonly_attribute_name
     column('Country') { |property| property.context&.country&.name }
     column('Commodity') { |property| property.context&.commodity&.name }
     column :group_number
@@ -42,6 +52,15 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
     column :is_disabled
     column :is_default
     actions
+  end
+
+  show do
+    attributes_table do
+      row :readonly_attribute_name
+      default_attribute_table_rows.each do |field|
+        row field
+      end
+    end
   end
 
   filter :context, collection: -> { Api::V3::Context.select_options }

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Sankey Settings'
 
   includes [
     {context: [:country, :commodity]},
@@ -16,51 +16,45 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
     f.semantic_errors
     inputs do
       input :readonly_attribute_id, as: :select,
-            collection: Api::V3::Readonly::Attribute.select_options
+                                    collection: Api::V3::Readonly::Attribute.select_options,
+                                    label: 'Recolor By Property'
       input :context, as: :select, required: true,
-            collection: Api::V3::Context.select_options
+                      collection: Api::V3::Context.select_options
       input :group_number, required: true,
-            hint: object.class.column_comment('group_number')
+                           hint: object.class.column_comment('group_number')
       input :position, required: true,
-            hint: object.class.column_comment('position')
+                       hint: object.class.column_comment('position')
       input :legend_type, required: true, as: :select,
-            collection: Api::V3::RecolorByAttribute::LEGEND_TYPE,
-            hint: object.class.column_comment('legend_type')
+                          collection: Api::V3::RecolorByAttribute::LEGEND_TYPE,
+                          hint: object.class.column_comment('legend_type')
       input :legend_color_theme, required: true, as: :select,
-            collection: Api::V3::RecolorByAttribute::LEGEND_COLOR_THEME,
-            hint: object.class.column_comment('legend_color_theme')
+                                 collection: Api::V3::RecolorByAttribute::LEGEND_COLOR_THEME,
+                                 hint: object.class.column_comment('legend_color_theme')
       input :interval_count,
             hint: object.class.column_comment('interval_count')
       input :min_value, as: :string,
-            hint: object.class.column_comment('min_value')
+                        hint: object.class.column_comment('min_value')
       input :max_value, as: :string,
-            hint: object.class.column_comment('max_value')
+                        hint: object.class.column_comment('max_value')
       input :divisor,
             hint: object.class.column_comment('divisor')
       input :tooltip_text, as: :string,
-            hint: object.class.column_comment('tooltip_text')
+                           hint: object.class.column_comment('tooltip_text')
       input :years_str, label: 'Years',
-            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+                        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :is_disabled, as: :boolean, required: true,
-            hint: object.class.column_comment('is_disabled')
+                          hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-            hint: object.class.column_comment('is_default')
+                         hint: object.class.column_comment('is_default')
     end
     f.actions
   end
 
   index do
-    column :readonly_attribute_name
+    column('Recolor By Property', sortable: true, &:readonly_attribute_display_name)
     column('Country') { |property| property.context&.country&.name }
     column('Commodity') { |property| property.context&.commodity&.name }
-    column :group_number
     column :position
-    column :legend_type
-    column :legend_color_theme
-    column :interval_count
-    column :min_value
-    column :max_value
-    column :divisor
     column :tooltip_text
     column :years
     column :is_disabled
@@ -70,12 +64,28 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
 
   show do
     attributes_table do
-      row :readonly_attribute_name
-      default_attribute_table_rows.each do |field|
-        row field
-      end
+      row('Country') { |property| property.context&.country&.name }
+      row('Commodity') { |property| property.context&.commodity&.name }
+      row('Recolor By Property', &:readonly_attribute_display_name)
+
+      row :group_number
+      row :position
+      row :legend_type
+      row :legend_color_theme
+      row :interval_count
+      row :min_value
+      row :max_value
+      row :divisor
+      row :tooltip_text
+      row('Years', &:years_str)
+      row :is_disabled
+      row :is_default
+      row :created_at
+      row :updated_at
     end
   end
 
   filter :context, collection: -> { Api::V3::Context.select_options }
+  filter :is_disabled
+  filter :is_default
 end

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -64,6 +64,7 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
 
   show do
     attributes_table do
+      row :readonly_attribute_display_name
       row('Country') { |property| property.context&.country&.name }
       row('Commodity') { |property| property.context&.commodity&.name }
       row('Recolor By Property', &:readonly_attribute_display_name)

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -16,35 +16,35 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
     f.semantic_errors
     inputs do
       input :readonly_attribute_id, as: :select,
-        collection: Api::V3::Readonly::Attribute.select_options
+            collection: Api::V3::Readonly::Attribute.select_options
       input :context, as: :select, required: true,
-        collection: Api::V3::Context.select_options
+            collection: Api::V3::Context.select_options
       input :group_number, required: true,
-        hint: object.class.column_comment('group_number')
+            hint: object.class.column_comment('group_number')
       input :position, required: true,
-        hint: object.class.column_comment('position')
+            hint: object.class.column_comment('position')
       input :legend_type, required: true, as: :select,
-        collection: Api::V3::RecolorByAttribute::LEGEND_TYPE,
-        hint: object.class.column_comment('legend_type')
+            collection: Api::V3::RecolorByAttribute::LEGEND_TYPE,
+            hint: object.class.column_comment('legend_type')
       input :legend_color_theme, required: true, as: :select,
-        collection: Api::V3::RecolorByAttribute::LEGEND_COLOR_THEME,
-        hint: object.class.column_comment('legend_color_theme')
+            collection: Api::V3::RecolorByAttribute::LEGEND_COLOR_THEME,
+            hint: object.class.column_comment('legend_color_theme')
       input :interval_count,
-        hint: object.class.column_comment('interval_count')
+            hint: object.class.column_comment('interval_count')
       input :min_value, as: :string,
-        hint: object.class.column_comment('min_value')
+            hint: object.class.column_comment('min_value')
       input :max_value, as: :string,
-        hint: object.class.column_comment('max_value')
+            hint: object.class.column_comment('max_value')
       input :divisor,
-        hint: object.class.column_comment('divisor')
+            hint: object.class.column_comment('divisor')
       input :tooltip_text, as: :string,
-        hint: object.class.column_comment('tooltip_text')
+            hint: object.class.column_comment('tooltip_text')
       input :years_str, label: 'Years',
-        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :is_disabled, as: :boolean, required: true,
-        hint: object.class.column_comment('is_disabled')
+            hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-        hint: object.class.column_comment('is_default')
+            hint: object.class.column_comment('is_default')
     end
     f.actions
   end

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -15,24 +15,36 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
   form do |f|
     f.semantic_errors
     inputs do
-      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
-        select_options
+      input :readonly_attribute_id, as: :select,
+        collection: Api::V3::Readonly::Attribute.select_options
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
-      input :group_number, required: true
-      input :position, required: true
+      input :group_number, required: true,
+        hint: object.class.column_comment('group_number')
+      input :position, required: true,
+        hint: object.class.column_comment('position')
       input :legend_type, required: true, as: :select,
-        collection: Api::V3::RecolorByAttribute::LEGEND_TYPE
+        collection: Api::V3::RecolorByAttribute::LEGEND_TYPE,
+        hint: object.class.column_comment('legend_type')
       input :legend_color_theme, required: true, as: :select,
-        collection: Api::V3::RecolorByAttribute::LEGEND_COLOR_THEME
-      input :interval_count
-      input :min_value, as: :string
-      input :max_value, as: :string
-      input :divisor
-      input :tooltip_text, as: :string
-      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
-      input :is_disabled, as: :boolean, required: true
-      input :is_default, as: :boolean, required: true
+        collection: Api::V3::RecolorByAttribute::LEGEND_COLOR_THEME,
+        hint: object.class.column_comment('legend_color_theme')
+      input :interval_count,
+        hint: object.class.column_comment('interval_count')
+      input :min_value, as: :string,
+        hint: object.class.column_comment('min_value')
+      input :max_value, as: :string,
+        hint: object.class.column_comment('max_value')
+      input :divisor,
+        hint: object.class.column_comment('divisor')
+      input :tooltip_text, as: :string,
+        hint: object.class.column_comment('tooltip_text')
+      input :years_str, label: 'Years',
+        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+      input :is_disabled, as: :boolean, required: true,
+        hint: object.class.column_comment('is_disabled')
+      input :is_default, as: :boolean, required: true,
+        hint: object.class.column_comment('is_default')
     end
     f.actions
   end

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -1,12 +1,19 @@
 ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
   menu parent: 'Yellow Tables'
 
+  includes [
+    {context: [:country, :commodity]},
+    :resize_by_quant
+  ]
+
   permit_params :context_id, :group_number, :position, :tooltip_text,
-                :years_str, :is_disabled, :is_default
+                :years_str, :is_disabled, :is_default, :readonly_attribute_id
 
   form do |f|
     f.semantic_errors
     inputs do
+      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
+        select_options
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
       input :group_number, required: true
@@ -20,6 +27,7 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
   end
 
   index do
+    column :readonly_attribute_name
     column('Country') { |property| property.context&.country&.name }
     column('Commodity') { |property| property.context&.commodity&.name }
     column :group_number
@@ -29,6 +37,15 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
     column :is_disabled
     column :is_default
     actions
+  end
+
+  show do
+    attributes_table do
+      row :readonly_attribute_name
+      default_attribute_table_rows.each do |field|
+        row field
+      end
+    end
   end
 
   filter :context, collection: -> { Api::V3::Context.select_options }

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
-  menu parent: 'Yellow Tables'
+  menu parent: 'Sankey Settings'
 
   includes [
     {context: [:country, :commodity]},
@@ -12,31 +12,31 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
   form do |f|
     f.semantic_errors
     inputs do
-      input :readonly_attribute_id, as: :select,
-            collection: Api::V3::Readonly::Attribute.select_options
+      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
+        select_options,
+                                    label: 'Resize By Property'
       input :context, as: :select, required: true,
-            collection: Api::V3::Context.select_options
+                      collection: Api::V3::Context.select_options
       input :group_number, required: true,
-            hint: object.class.column_comment('group_number')
+                           hint: object.class.column_comment('group_number')
       input :position, required: true,
-            hint: object.class.column_comment('position')
+                       hint: object.class.column_comment('position')
       input :tooltip_text, as: :string,
-            hint: object.class.column_comment('tooltip_text')
+                           hint: object.class.column_comment('tooltip_text')
       input :years_str, label: 'Years',
-            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+                        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :is_disabled, as: :boolean, required: true,
-            hint: object.class.column_comment('is_disabled')
+                          hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-            hint: object.class.column_comment('is_default')
+                         hint: object.class.column_comment('is_default')
     end
     f.actions
   end
 
   index do
-    column :readonly_attribute_name
+    column('Resize By Property', sortable: true, &:readonly_attribute_display_name)
     column('Country') { |property| property.context&.country&.name }
     column('Commodity') { |property| property.context&.commodity&.name }
-    column :group_number
     column :position
     column :tooltip_text
     column :years
@@ -47,12 +47,22 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
 
   show do
     attributes_table do
-      row :readonly_attribute_name
-      default_attribute_table_rows.each do |field|
-        row field
-      end
+      row('Country') { |property| property.context&.country&.name }
+      row('Commodity') { |property| property.context&.commodity&.name }
+      row('Resize By Property', &:readonly_attribute_display_name)
+
+      row :group_number
+      row :position
+      row :tooltip_text
+      row('Years', &:years_str)
+      row :is_disabled
+      row :is_default
+      row :created_at
+      row :updated_at
     end
   end
 
   filter :context, collection: -> { Api::V3::Context.select_options }
+  filter :is_disabled
+  filter :is_default
 end

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -16,12 +16,18 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
         select_options
       input :context, as: :select, required: true,
         collection: Api::V3::Context.select_options
-      input :group_number, required: true
-      input :position, required: true
-      input :tooltip_text, as: :string
-      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
-      input :is_disabled, as: :boolean, required: true
-      input :is_default, as: :boolean, required: true
+      input :group_number, required: true,
+        hint: object.class.column_comment('group_number')
+      input :position, required: true,
+        hint: object.class.column_comment('position')
+      input :tooltip_text, as: :string,
+        hint: object.class.column_comment('tooltip_text')
+      input :years_str, label: 'Years',
+        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+      input :is_disabled, as: :boolean, required: true,
+        hint: object.class.column_comment('is_disabled')
+      input :is_default, as: :boolean, required: true,
+        hint: object.class.column_comment('is_default')
     end
     f.actions
   end

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -1,0 +1,35 @@
+ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
+  menu parent: 'Yellow Tables'
+
+  permit_params :context_id, :group_number, :position, :tooltip_text,
+                :years_str, :is_disabled, :is_default
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :context, as: :select, required: true,
+        collection: Api::V3::Context.select_options
+      input :group_number, required: true
+      input :position, required: true
+      input :tooltip_text, as: :string
+      input :years_str, hint: 'Comma-separated list of years', label: 'Years'
+      input :is_disabled, as: :boolean, required: true
+      input :is_default, as: :boolean, required: true
+    end
+    f.actions
+  end
+
+  index do
+    column('Country') { |property| property.context&.country&.name }
+    column('Commodity') { |property| property.context&.commodity&.name }
+    column :group_number
+    column :position
+    column :tooltip_text
+    column :years
+    column :is_disabled
+    column :is_default
+    actions
+  end
+
+  filter :context, collection: -> { Api::V3::Context.select_options }
+end

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -47,6 +47,7 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
 
   show do
     attributes_table do
+      row :readonly_attribute_display_name
       row('Country') { |property| property.context&.country&.name }
       row('Commodity') { |property| property.context&.commodity&.name }
       row('Resize By Property', &:readonly_attribute_display_name)

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -12,22 +12,22 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
   form do |f|
     f.semantic_errors
     inputs do
-      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
-        select_options
+      input :readonly_attribute_id, as: :select,
+            collection: Api::V3::Readonly::Attribute.select_options
       input :context, as: :select, required: true,
-        collection: Api::V3::Context.select_options
+            collection: Api::V3::Context.select_options
       input :group_number, required: true,
-        hint: object.class.column_comment('group_number')
+            hint: object.class.column_comment('group_number')
       input :position, required: true,
-        hint: object.class.column_comment('position')
+            hint: object.class.column_comment('position')
       input :tooltip_text, as: :string,
-        hint: object.class.column_comment('tooltip_text')
+            hint: object.class.column_comment('tooltip_text')
       input :years_str, label: 'Years',
-        hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
+            hint: (object.class.column_comment('years') || '') + ' (comma-separated list)'
       input :is_disabled, as: :boolean, required: true,
-        hint: object.class.column_comment('is_disabled')
+            hint: object.class.column_comment('is_disabled')
       input :is_default, as: :boolean, required: true,
-        hint: object.class.column_comment('is_default')
+            hint: object.class.column_comment('is_default')
     end
     f.actions
   end

--- a/app/admin/database_update.rb
+++ b/app/admin/database_update.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register_page 'Database Update' do
+  menu priority: 4
+
   content do
     current_update = Api::V3::DatabaseUpdate.where(status: Api::V3::DatabaseUpdate::STARTED).first
     database_updates = Api::V3::DatabaseUpdate.order(:created_at).all

--- a/app/admin/post.rb
+++ b/app/admin/post.rb
@@ -1,6 +1,7 @@
 ActiveAdmin.register Content::Post, as: 'Post' do
   permit_params :title, :date, :image, :post_url, :category, :state, :highlighted
   config.sort_order = 'date_desc'
+  menu parent: 'Content'
 
   form do |f|
     f.semantic_errors

--- a/app/admin/site_dive.rb
+++ b/app/admin/site_dive.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register Content::SiteDive, as: 'Site Dive' do
+  menu parent: 'Content'
+
   permit_params :title, :page_url, :description
 
   form do |f|

--- a/app/admin/testimonial.rb
+++ b/app/admin/testimonial.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register Content::Testimonial, as: 'Testimonial' do
+  menu parent: 'Content'
+
   permit_params :quote, :author_name, :author_title, :image
 
   form do |f|

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register Content::User, as: 'User' do
+  menu priority: 3
+
   permit_params :email, :password, :password_confirmation
 
   index do

--- a/app/models/api/v3/base_model.rb
+++ b/app/models/api/v3/base_model.rb
@@ -5,6 +5,35 @@ module Api
       self.abstract_class = true
 
       establish_connection DB_REVAMP
+
+      private
+
+      def self.all_column_comments
+        unless defined?(@@all_comments)
+          data = YAML.safe_load(
+            File.open("#{Rails.root}/db/schema_comments.yml")
+          )
+          @@all_comments = data && data['tables']
+        end
+        @@all_comments
+      end
+
+      def self.column_comments
+        unless @comments
+          tmp = all_column_comments.find do |cc|
+            cc['name'] == table_name
+          end
+          @comments = tmp && tmp['columns']
+        end
+        @comments
+      end
+
+      def self.column_comment(column_name)
+        tmp = column_comments.find do |cc|
+          cc['name'] == column_name
+        end
+        tmp && tmp['comment']
+      end
     end
   end
 end

--- a/app/models/api/v3/base_model.rb
+++ b/app/models/api/v3/base_model.rb
@@ -6,33 +6,39 @@ module Api
 
       establish_connection DB_REVAMP
 
-      private
+      class << self
+        def column_comment(column_name)
+          tmp = column_comments.find do |cc|
+            cc['name'] == column_name
+          end
+          tmp && tmp['comment']
+        end
 
-      def self.all_column_comments
-        unless defined?(@@all_comments)
-          data = YAML.safe_load(
+        private
+
+        def all_column_comments
+          unless defined?(@@all_comments)
+            data = load_from_file
+            @@all_comments = data && data['tables']
+          end
+          @@all_comments
+        end
+
+        def column_comments
+          unless @comments
+            tmp = all_column_comments.find do |cc|
+              cc['name'] == table_name
+            end
+            @comments = tmp && tmp['columns']
+          end
+          @comments
+        end
+
+        def load_from_file
+          YAML.safe_load(
             File.open("#{Rails.root}/db/schema_comments.yml")
           )
-          @@all_comments = data && data['tables']
         end
-        @@all_comments
-      end
-
-      def self.column_comments
-        unless @comments
-          tmp = all_column_comments.find do |cc|
-            cc['name'] == table_name
-          end
-          @comments = tmp && tmp['columns']
-        end
-        @comments
-      end
-
-      def self.column_comment(column_name)
-        tmp = column_comments.find do |cc|
-          cc['name'] == column_name
-        end
-        tmp && tmp['comment']
       end
     end
   end

--- a/app/models/api/v3/carto_layer.rb
+++ b/app/models/api/v3/carto_layer.rb
@@ -1,7 +1,14 @@
 module Api
   module V3
     class CartoLayer < YellowTable
+      include Api::V3::StringyArray
+
       belongs_to :contextual_layer
+
+      validates :contextual_layer, presence: true
+      validates :identifier, presence: true, uniqueness: {scope: :contextual_layer}
+
+      stringy_array :years
 
       def self.yellow_foreign_keys
         [

--- a/app/models/api/v3/commodity.rb
+++ b/app/models/api/v3/commodity.rb
@@ -3,6 +3,8 @@ module Api
     class Commodity < BlueTable
       has_many :contexts
 
+      validates :name, presence: true, uniqueness: true
+
       def self.import_key
         [
           {name: :name, sql_type: 'TEXT'}

--- a/app/models/api/v3/context.rb
+++ b/app/models/api/v3/context.rb
@@ -20,7 +20,7 @@ module Api
       validates :commodity, presence: true, uniqueness: {scope: :country}
 
       def self.select_options
-        Api::V3::Context.all.map do |ctx|
+        Api::V3::Context.includes(:country, :commodity).all.map do |ctx|
           [[ctx.country&.name, ctx.commodity&.name].join(' / '), ctx.id]
         end
       end

--- a/app/models/api/v3/context.rb
+++ b/app/models/api/v3/context.rb
@@ -16,6 +16,15 @@ module Api
       delegate :is_subnational, to: :context_property
       delegate :default_basemap, to: :context_property
 
+      validates :country, presence: true
+      validates :commodity, presence: true, uniqueness: {scope: :country}
+
+      def self.select_options
+        Api::V3::Context.all.map do |ctx|
+          [[ctx.country&.name, ctx.commodity&.name].join(' / '), ctx.id]
+        end
+      end
+
       def self.import_key
         [
           {name: :country_id, sql_type: 'INT'},

--- a/app/models/api/v3/context_node_type.rb
+++ b/app/models/api/v3/context_node_type.rb
@@ -6,6 +6,23 @@ module Api
       has_one :context_node_type_property
       has_one :profile
 
+      validates :context, presence: true
+      validates :node_type, presence: true, uniqueness: {scope: :context}
+      validates :column_position, presence: true
+
+      def self.select_options
+        Api::V3::ContextNodeType.all.map do |ctx_nt|
+          [
+            [
+              ctx_nt.context&.country&.name,
+              ctx_nt.context&.commodity&.name,
+              ctx_nt.node_type&.name
+            ].join(' / '),
+            ctx_nt.id
+          ]
+        end
+      end
+
       def self.import_key
         [
           {name: :context_id, sql_type: 'INT'},

--- a/app/models/api/v3/context_node_type.rb
+++ b/app/models/api/v3/context_node_type.rb
@@ -11,7 +11,9 @@ module Api
       validates :column_position, presence: true
 
       def self.select_options
-        Api::V3::ContextNodeType.all.map do |ctx_nt|
+        Api::V3::ContextNodeType.includes(
+          context: [:country, :commodity]
+        ).all.map do |ctx_nt|
           [
             [
               ctx_nt.context&.country&.name,

--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -1,7 +1,17 @@
 module Api
   module V3
     class ContextNodeTypeProperty < YellowTable
+      COLUMN_GROUP = [
+        0, 1, 2, 3
+      ].freeze
+
       belongs_to :context_node_type
+
+      validates :context_node_type, presence: true, uniqueness: true
+      validates :column_group, presence: true, inclusion: COLUMN_GROUP
+      validates :is_default, inclusion: { in: [true, false] }
+      validates :is_geo_column, inclusion: { in: [true, false] }
+      # validates :is_choropleth_disabled, inclusion: { in: [true, false] }
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -11,7 +11,7 @@ module Api
       validates :column_group, presence: true, inclusion: COLUMN_GROUP
       validates :is_default, inclusion: { in: [true, false] }
       validates :is_geo_column, inclusion: { in: [true, false] }
-      # validates :is_choropleth_disabled, inclusion: { in: [true, false] }
+      validates :is_choropleth_disabled, inclusion: { in: [true, false] }
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -9,9 +9,9 @@ module Api
 
       validates :context_node_type, presence: true, uniqueness: true
       validates :column_group, presence: true, inclusion: COLUMN_GROUP
-      validates :is_default, inclusion: { in: [true, false] }
-      validates :is_geo_column, inclusion: { in: [true, false] }
-      validates :is_choropleth_disabled, inclusion: { in: [true, false] }
+      validates :is_default, inclusion: {in: [true, false]}
+      validates :is_geo_column, inclusion: {in: [true, false]}
+      validates :is_choropleth_disabled, inclusion: {in: [true, false]}
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/context_property.rb
+++ b/app/models/api/v3/context_property.rb
@@ -1,7 +1,20 @@
 module Api
   module V3
     class ContextProperty < YellowTable
+      DEFAULT_BASEMAP = [
+        'default',
+        'satellite',
+        'topo',
+        'streets'
+      ].freeze
+
       belongs_to :context
+
+      validates :context, presence: true, uniqueness: true
+      validates :is_disabled, inclusion: { in: [true, false] }
+      validates :is_default, inclusion: { in: [true, false] }
+      validates :is_subnational, inclusion: { in: [true, false] }
+      validates :default_basemap, inclusion: { in: DEFAULT_BASEMAP, allow_blank: true }
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/context_property.rb
+++ b/app/models/api/v3/context_property.rb
@@ -11,10 +11,10 @@ module Api
       belongs_to :context
 
       validates :context, presence: true, uniqueness: true
-      validates :is_disabled, inclusion: { in: [true, false] }
-      validates :is_default, inclusion: { in: [true, false] }
-      validates :is_subnational, inclusion: { in: [true, false] }
-      validates :default_basemap, inclusion: { in: DEFAULT_BASEMAP, allow_blank: true }
+      validates :is_disabled, inclusion: {in: [true, false]}
+      validates :is_default, inclusion: {in: [true, false]}
+      validates :is_subnational, inclusion: {in: [true, false]}
+      validates :default_basemap, inclusion: {in: DEFAULT_BASEMAP, allow_blank: true}
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/context_property.rb
+++ b/app/models/api/v3/context_property.rb
@@ -1,12 +1,12 @@
 module Api
   module V3
     class ContextProperty < YellowTable
-      DEFAULT_BASEMAP = [
-        'default',
-        'satellite',
-        'topo',
-        'streets'
-      ].freeze
+      DEFAULT_BASEMAP = %w(
+        default
+        satellite
+        topo
+        streets
+      ).freeze
 
       belongs_to :context
 

--- a/app/models/api/v3/contextual_layer.rb
+++ b/app/models/api/v3/contextual_layer.rb
@@ -10,7 +10,7 @@ module Api
       validates :title, presence: true
       validates :identifier, presence: true, uniqueness: {scope: :context}
       validates :position, presence: true, uniqueness: {scope: :context}
-      validates :is_default, inclusion: { in: [true, false] }
+      validates :is_default, inclusion: {in: [true, false]}
 
       def self.select_options
         Api::V3::ContextualLayer.includes(

--- a/app/models/api/v3/contextual_layer.rb
+++ b/app/models/api/v3/contextual_layer.rb
@@ -6,6 +6,12 @@ module Api
 
       scope :default, -> { where(is_default: true) }
 
+      validates :context, presence: true
+      validates :title, presence: true
+      validates :identifier, presence: true, uniqueness: {scope: :context}
+      validates :position, presence: true, uniqueness: {scope: :context}
+      validates :is_default, inclusion: { in: [true, false] }
+
       def self.blue_foreign_keys
         [
           {name: :context_id, table_class: Api::V3::Context}

--- a/app/models/api/v3/contextual_layer.rb
+++ b/app/models/api/v3/contextual_layer.rb
@@ -20,7 +20,7 @@ module Api
             [
               layer.context&.country&.name,
               layer.context&.commodity&.name,
-              layer.identifier
+              layer.title
             ].join(' / '),
             layer.id
           ]

--- a/app/models/api/v3/contextual_layer.rb
+++ b/app/models/api/v3/contextual_layer.rb
@@ -12,6 +12,19 @@ module Api
       validates :position, presence: true, uniqueness: {scope: :context}
       validates :is_default, inclusion: { in: [true, false] }
 
+      def self.select_options
+        Api::V3::ContextualLayer.all.map do |layer|
+          [
+            [
+              layer.context&.country&.name,
+              layer.context&.commodity&.name,
+              layer.identifier
+            ].join(' / '),
+            layer.id
+          ]
+        end
+      end
+
       def self.blue_foreign_keys
         [
           {name: :context_id, table_class: Api::V3::Context}

--- a/app/models/api/v3/contextual_layer.rb
+++ b/app/models/api/v3/contextual_layer.rb
@@ -13,7 +13,9 @@ module Api
       validates :is_default, inclusion: { in: [true, false] }
 
       def self.select_options
-        Api::V3::ContextualLayer.all.map do |layer|
+        Api::V3::ContextualLayer.includes(
+          context: [:country, :commodity]
+        ).all.map do |layer|
           [
             [
               layer.context&.country&.name,

--- a/app/models/api/v3/country.rb
+++ b/app/models/api/v3/country.rb
@@ -8,6 +8,9 @@ module Api
       delegate :longitude, to: :country_property
       delegate :zoom, to: :country_property
 
+      validates :name, presence: true
+      validates :iso2, presence: true, uniqueness: true
+
       def self.import_key
         [
           {name: :iso2, sql_type: 'TEXT'}

--- a/app/models/api/v3/country_property.rb
+++ b/app/models/api/v3/country_property.rb
@@ -3,6 +3,11 @@ module Api
     class CountryProperty < YellowTable
       belongs_to :country
 
+      validates :country, presence: true, uniqueness: true
+      validates :latitude, presence: true
+      validates :longitude, presence: true
+      validates :zoom, presence: true, inclusion: { in: 0..18 }
+
       def self.blue_foreign_keys
         [
           {name: :country_id, table_class: Api::V3::Country}

--- a/app/models/api/v3/country_property.rb
+++ b/app/models/api/v3/country_property.rb
@@ -6,7 +6,7 @@ module Api
       validates :country, presence: true, uniqueness: true
       validates :latitude, presence: true
       validates :longitude, presence: true
-      validates :zoom, presence: true, inclusion: { in: 0..18 }
+      validates :zoom, presence: true, inclusion: {in: 0..18}
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -11,13 +11,12 @@ module Api
       validates :context, presence: true
       validates :position, presence: true, uniqueness: {scope: :context}
       validates :display_name, presence: true
-      validates_with OneAssociatedAttributeValidator, {
-        attributes: [:download_qual, :download_quant]
-      }
+      validates_with OneAssociatedAttributeValidator,
+                     attributes: [:download_qual, :download_quant]
       validates_with AttributeAssociatedOnceValidator,
-        attribute: :download_qual, if: :new_download_qual_given?
+                     attribute: :download_qual, if: :new_download_qual_given?
       validates_with AttributeAssociatedOnceValidator,
-        attribute: :download_quant, if: :new_download_quant_given?
+                     attribute: :download_quant, if: :new_download_quant_given?
 
       after_commit :refresh_dependencies
 

--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -2,14 +2,25 @@ module Api
   module V3
     class DownloadAttribute < YellowTable
       include Api::V3::StringyArray
+      include Api::V3::AssociatedAttributes
 
       belongs_to :context
+      has_one :download_qual, autosave: true
+      has_one :download_quant, autosave: true
 
       validates :context, presence: true
       validates :position, presence: true, uniqueness: {scope: :context}
       validates :display_name, presence: true
+      validates_with OneAssociatedAttributeValidator, {
+        attributes: [:download_qual, :download_quant]
+      }
+      validates_with AttributeAssociatedOnceValidator,
+        attribute: :download_qual, if: :new_download_qual_given?
+      validates_with AttributeAssociatedOnceValidator,
+        attribute: :download_quant, if: :new_download_quant_given?
 
       stringy_array :years
+      manage_associated_attributes [:download_qual, :download_quant]
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -1,7 +1,15 @@
 module Api
   module V3
     class DownloadAttribute < YellowTable
+      include Api::V3::StringyArray
+
       belongs_to :context
+
+      validates :context, presence: true
+      validates :position, presence: true, uniqueness: {scope: :context}
+      validates :display_name, presence: true
+
+      stringy_array :years
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -19,6 +19,8 @@ module Api
       validates_with AttributeAssociatedOnceValidator,
         attribute: :download_quant, if: :new_download_quant_given?
 
+      after_commit :refresh_dependencies
+
       stringy_array :years
       manage_associated_attributes [:download_qual, :download_quant]
 
@@ -26,6 +28,10 @@ module Api
         [
           {name: :context_id, table_class: Api::V3::Context}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::DownloadAttribute.refresh
       end
     end
   end

--- a/app/models/api/v3/ind.rb
+++ b/app/models/api/v3/ind.rb
@@ -2,7 +2,12 @@ module Api
   module V3
     class Ind < BlueTable
       has_one :ind_property
+
       delegate :display_name, to: :ind_property
+
+      def self.select_options
+        all.map { |ind| [ind.name, ind.id] }
+      end
 
       def self.import_key
         [

--- a/app/models/api/v3/ind.rb
+++ b/app/models/api/v3/ind.rb
@@ -6,7 +6,7 @@ module Api
       delegate :display_name, to: :ind_property
 
       def self.select_options
-        all.map { |ind| [ind.name, ind.id] }
+        order(:name).map { |ind| [ind.name, ind.id] }
       end
 
       def self.import_key

--- a/app/models/api/v3/ind_property.rb
+++ b/app/models/api/v3/ind_property.rb
@@ -20,10 +20,16 @@ module Api
       validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
       validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
+      after_commit :refresh_dependencies
+
       def self.blue_foreign_keys
         [
           {name: :ind_id, table_class: Api::V3::Ind}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::Attribute.refresh
       end
     end
   end

--- a/app/models/api/v3/ind_property.rb
+++ b/app/models/api/v3/ind_property.rb
@@ -3,7 +3,22 @@ module Api
     class IndProperty < YellowTable
       include AttributePropertiesProfileScopes
 
+      UNIT_TYPE = [
+        'currency',
+        'ratio',
+        'score',
+        'unitless'
+      ].freeze
+
       belongs_to :ind
+
+      validates :ind, presence: true, uniqueness: true
+      validates :display_name, presence: true
+      validates :unit_type, inclusion: {in: UNIT_TYPE, allow_blank: true}
+      validates :is_visible_on_place_profile, inclusion: {in: [true, false]}
+      validates :is_visible_on_actor_profile, inclusion: {in: [true, false]}
+      validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
+      validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/ind_property.rb
+++ b/app/models/api/v3/ind_property.rb
@@ -3,12 +3,12 @@ module Api
     class IndProperty < YellowTable
       include AttributePropertiesProfileScopes
 
-      UNIT_TYPE = [
-        'currency',
-        'ratio',
-        'score',
-        'unitless'
-      ].freeze
+      UNIT_TYPE = %w(
+        currency
+        ratio
+        score
+        unitless
+      ).freeze
 
       belongs_to :ind
 

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -21,14 +21,14 @@ module Api
       include Api::V3::StringyArray
       include Api::V3::AssociatedAttributes
 
-      COLOR_SCALE = [
-        'bluered',
-        'green',
-        'blue',
-        'red',
-        'redblue',
-        'greenblue'
-        ].freeze
+      COLOR_SCALE = %w(
+        bluered
+        green
+        blue
+        red
+        redblue
+        greenblue
+      ).freeze
 
       belongs_to :map_attribute_group
       has_one :map_ind, autosave: true

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -35,17 +35,22 @@ module Api
       has_one :map_quant, autosave: true
 
       validates :map_attribute_group, presence: true
-      validates :position, presence: true, uniqueness: {scope: :map_attribute_group}
+      validates :position,
+                presence: true,
+                uniqueness: {scope: :map_attribute_group}
       validates :bucket_3, presence: true, array_size: {exactly: 2}
       validates :bucket_5, presence: true, array_size: {exactly: 4}
       validates :is_disabled, inclusion: {in: [true, false]}
       validates :is_default, inclusion: {in: [true, false]}
       validates :color_scale, inclusion: {in: COLOR_SCALE, allow_blank: true}
-      validates_with OneAssociatedAttributeValidator, {attributes: [:map_ind, :map_quant]}
+      validates_with OneAssociatedAttributeValidator,
+                     attributes: [:map_ind, :map_quant]
       validates_with AttributeAssociatedOnceValidator,
-        attribute: :map_ind, scope: :map_attribute_group, if: :new_map_ind_given?
+                     attribute: :map_ind, scope: :map_attribute_group,
+                     if: :new_map_ind_given?
       validates_with AttributeAssociatedOnceValidator,
-        attribute: :map_quant, scope: :map_attribute_group, if: :new_map_quant_given?
+                     attribute: :map_quant, scope: :map_attribute_group,
+                     if: :new_map_quant_given?
 
       after_commit :refresh_dependencies
 

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -47,6 +47,8 @@ module Api
       validates_with AttributeAssociatedOnceValidator,
         attribute: :map_quant, scope: :map_attribute_group, if: :new_map_quant_given?
 
+      after_commit :refresh_dependencies
+
       stringy_array :bucket_3
       stringy_array :bucket_5
       stringy_array :years
@@ -56,6 +58,10 @@ module Api
         [
           {name: :map_attribute_group_id, table_class: Api::V3::MapAttributeGroup}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::MapAttribute.refresh
       end
     end
   end

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -19,6 +19,7 @@ module Api
   module V3
     class MapAttribute < YellowTable
       include Api::V3::StringyArray
+      include Api::V3::AssociatedAttributes
 
       COLOR_SCALE = [
         'bluered',
@@ -30,6 +31,8 @@ module Api
         ].freeze
 
       belongs_to :map_attribute_group
+      has_one :map_ind, autosave: true
+      has_one :map_quant, autosave: true
 
       validates :map_attribute_group, presence: true
       validates :position, presence: true, uniqueness: {scope: :map_attribute_group}
@@ -38,10 +41,16 @@ module Api
       validates :is_disabled, inclusion: { in: [true, false] }
       validates :is_default, inclusion: { in: [true, false] }
       validates :color_scale, inclusion: { in: COLOR_SCALE, allow_blank: true }
+      validates_with OneAssociatedAttributeValidator, {attributes: [:map_ind, :map_quant]}
+      validates_with AttributeAssociatedOnceValidator,
+        attribute: :map_ind, scope: :map_attribute_group, if: :new_map_ind_given?
+      validates_with AttributeAssociatedOnceValidator,
+        attribute: :map_quant, scope: :map_attribute_group, if: :new_map_quant_given?
 
       stringy_array :bucket_3
       stringy_array :bucket_5
       stringy_array :years
+      manage_associated_attributes [:map_ind, :map_quant]
 
       def self.yellow_foreign_keys
         [

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -38,9 +38,9 @@ module Api
       validates :position, presence: true, uniqueness: {scope: :map_attribute_group}
       validates :bucket_3, presence: true, array_size: {exactly: 2}
       validates :bucket_5, presence: true, array_size: {exactly: 4}
-      validates :is_disabled, inclusion: { in: [true, false] }
-      validates :is_default, inclusion: { in: [true, false] }
-      validates :color_scale, inclusion: { in: COLOR_SCALE, allow_blank: true }
+      validates :is_disabled, inclusion: {in: [true, false]}
+      validates :is_default, inclusion: {in: [true, false]}
+      validates :color_scale, inclusion: {in: COLOR_SCALE, allow_blank: true}
       validates_with OneAssociatedAttributeValidator, {attributes: [:map_ind, :map_quant]}
       validates_with AttributeAssociatedOnceValidator,
         attribute: :map_ind, scope: :map_attribute_group, if: :new_map_ind_given?

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -18,7 +18,30 @@
 module Api
   module V3
     class MapAttribute < YellowTable
+      include Api::V3::StringyArray
+
+      COLOR_SCALE = [
+        'bluered',
+        'green',
+        'blue',
+        'red',
+        'redblue',
+        'greenblue'
+        ].freeze
+
       belongs_to :map_attribute_group
+
+      validates :map_attribute_group, presence: true
+      validates :position, presence: true, uniqueness: {scope: :map_attribute_group}
+      validates :bucket_3, presence: true, array_size: {exactly: 2}
+      validates :bucket_5, presence: true, array_size: {exactly: 4}
+      validates :is_disabled, inclusion: { in: [true, false] }
+      validates :is_default, inclusion: { in: [true, false] }
+      validates :color_scale, inclusion: { in: COLOR_SCALE, allow_blank: true }
+
+      stringy_array :bucket_3
+      stringy_array :bucket_5
+      stringy_array :years
 
       def self.yellow_foreign_keys
         [

--- a/app/models/api/v3/map_attribute_group.rb
+++ b/app/models/api/v3/map_attribute_group.rb
@@ -19,6 +19,19 @@ module Api
       validates :name, presence: true
       validates :position, presence: true, uniqueness: {scope: :context}
 
+      def self.select_options
+        Api::V3::MapAttributeGroup.all.map do |group|
+          [
+            [
+              group.context&.country&.name,
+              group.context&.commodity&.name,
+              group.name
+            ].join(' / '),
+            group.id
+          ]
+        end
+      end
+
       def self.blue_foreign_keys
         [
           {name: :context_id, table_class: Api::V3::Context}

--- a/app/models/api/v3/map_attribute_group.rb
+++ b/app/models/api/v3/map_attribute_group.rb
@@ -20,7 +20,9 @@ module Api
       validates :position, presence: true, uniqueness: {scope: :context}
 
       def self.select_options
-        Api::V3::MapAttributeGroup.all.map do |group|
+        Api::V3::MapAttributeGroup.includes(
+          context: [:country, :commodity]
+        ).all.map do |group|
           [
             [
               group.context&.country&.name,

--- a/app/models/api/v3/map_attribute_group.rb
+++ b/app/models/api/v3/map_attribute_group.rb
@@ -12,7 +12,12 @@
 module Api
   module V3
     class MapAttributeGroup < YellowTable
+      belongs_to :context
       has_many :map_attributes
+
+      validates :context, presence: true
+      validates :name, presence: true
+      validates :position, presence: true, uniqueness: {scope: :context}
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/map_attribute_group.rb
+++ b/app/models/api/v3/map_attribute_group.rb
@@ -19,6 +19,8 @@ module Api
       validates :name, presence: true
       validates :position, presence: true, uniqueness: {scope: :context}
 
+      after_commit :refresh_dependencies
+
       def self.select_options
         Api::V3::MapAttributeGroup.includes(
           context: [:country, :commodity]
@@ -38,6 +40,10 @@ module Api
         [
           {name: :context_id, table_class: Api::V3::Context}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::MapAttribute.refresh
       end
     end
   end

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -9,8 +9,9 @@ module Api
       belongs_to :context_node_type
 
       validates :context_node_type, presence: true
-      validates :name, uniqueness: {scope: :context_node_type},
-        inclusion: NAME
+      validates :name,
+                uniqueness: {scope: :context_node_type},
+                inclusion: NAME
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -1,7 +1,16 @@
 module Api
   module V3
     class Profile < YellowTable
+      NAME = [
+        'actor',
+        'place'
+      ].freeze
+
       belongs_to :context_node_type
+
+      validates :context_node_type, presence: true
+      validates :name, uniqueness: {scope: :context_node_type},
+        inclusion: NAME
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -1,10 +1,10 @@
 module Api
   module V3
     class Profile < YellowTable
-      NAME = [
-        'actor',
-        'place'
-      ].freeze
+      NAME = %w(
+        actor
+        place
+      ).freeze
 
       belongs_to :context_node_type
 

--- a/app/models/api/v3/qual.rb
+++ b/app/models/api/v3/qual.rb
@@ -2,7 +2,12 @@ module Api
   module V3
     class Qual < BlueTable
       has_one :qual_property
+
       delegate :display_name, to: :qual_property
+
+      def self.select_options
+        all.map { |qual| [qual.name, qual.id] }
+      end
 
       def self.import_key
         [

--- a/app/models/api/v3/qual.rb
+++ b/app/models/api/v3/qual.rb
@@ -6,7 +6,7 @@ module Api
       delegate :display_name, to: :qual_property
 
       def self.select_options
-        all.map { |qual| [qual.name, qual.id] }
+        order(:name).map { |qual| [qual.name, qual.id] }
       end
 
       def self.import_key

--- a/app/models/api/v3/qual_property.rb
+++ b/app/models/api/v3/qual_property.rb
@@ -5,6 +5,13 @@ module Api
 
       belongs_to :qual
 
+      validates :qual, presence: true, uniqueness: true
+      validates :display_name, presence: true
+      validates :is_visible_on_place_profile, inclusion: {in: [true, false]}
+      validates :is_visible_on_actor_profile, inclusion: {in: [true, false]}
+      validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
+      validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
+
       def self.blue_foreign_keys
         [
           {name: :qual_id, table_class: Api::V3::Qual}

--- a/app/models/api/v3/qual_property.rb
+++ b/app/models/api/v3/qual_property.rb
@@ -12,10 +12,16 @@ module Api
       validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
       validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
+      after_commit :refresh_dependencies
+
       def self.blue_foreign_keys
         [
           {name: :qual_id, table_class: Api::V3::Qual}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::Attribute.refresh
       end
     end
   end

--- a/app/models/api/v3/quant.rb
+++ b/app/models/api/v3/quant.rb
@@ -6,7 +6,7 @@ module Api
       delegate :display_name, to: :quant_property
 
       def self.select_options
-        all.map { |quant| [quant.name, quant.id] }
+        order(:name).map { |quant| [quant.name, quant.id] }
       end
 
       def self.import_key

--- a/app/models/api/v3/quant.rb
+++ b/app/models/api/v3/quant.rb
@@ -2,7 +2,12 @@ module Api
   module V3
     class Quant < BlueTable
       has_one :quant_property
+
       delegate :display_name, to: :quant_property
+
+      def self.select_options
+        all.map { |quant| [quant.name, quant.id] }
+      end
 
       def self.import_key
         [

--- a/app/models/api/v3/quant_property.rb
+++ b/app/models/api/v3/quant_property.rb
@@ -3,7 +3,23 @@ module Api
     class QuantProperty < YellowTable
       include AttributePropertiesProfileScopes
 
+      UNIT_TYPE = [
+        'currency',
+        'area',
+        'count',
+        'volume',
+        'unitless'
+      ].freeze
+
       belongs_to :quant
+
+      validates :quant, presence: true, uniqueness: true
+      validates :display_name, presence: true
+      validates :unit_type, inclusion: {in: UNIT_TYPE, allow_blank: true}
+      validates :is_visible_on_place_profile, inclusion: {in: [true, false]}
+      validates :is_visible_on_actor_profile, inclusion: {in: [true, false]}
+      validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
+      validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/quant_property.rb
+++ b/app/models/api/v3/quant_property.rb
@@ -3,13 +3,13 @@ module Api
     class QuantProperty < YellowTable
       include AttributePropertiesProfileScopes
 
-      UNIT_TYPE = [
-        'currency',
-        'area',
-        'count',
-        'volume',
-        'unitless'
-      ].freeze
+      UNIT_TYPE = %w(
+        currency
+        area
+        count
+        volume
+        unitless
+      ).freeze
 
       belongs_to :quant
 

--- a/app/models/api/v3/quant_property.rb
+++ b/app/models/api/v3/quant_property.rb
@@ -21,10 +21,16 @@ module Api
       validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
       validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
+      after_commit :refresh_dependencies
+
       def self.blue_foreign_keys
         [
           {name: :quant_id, table_class: Api::V3::Quant}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::Attribute.refresh
       end
     end
   end

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -6,7 +6,7 @@ module Api
         self.primary_key = 'id'
 
         def self.select_options
-          all.map { |a| [a.display_name, a.id] }
+          order(:display_name).map { |a| [a.display_name, a.id] }
         end
 
         def self.refresh

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -4,6 +4,10 @@ module Api
       class Attribute < BaseModel
         self.table_name = 'revamp.attributes_mv'
         self.primary_key = 'id'
+
+        def self.select_options
+          all.map { |a| [a.name, a.id ] }
+        end
       end
     end
   end

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -1,12 +1,26 @@
 module Api
   module V3
     module Readonly
-      class Attribute < BaseModel
+      class Attribute < Api::V3::Readonly::BaseModel
         self.table_name = 'revamp.attributes_mv'
         self.primary_key = 'id'
 
         def self.select_options
           all.map { |a| [a.name, a.id ] }
+        end
+
+        def self.refresh
+          super
+          dependents.each { |mv| mv.refresh }
+        end
+
+        def self.dependents
+          [
+            Api::V3::Readonly::DownloadAttribute,
+            Api::V3::Readonly::MapAttribute,
+            Api::V3::Readonly::RecolorByAttribute,
+            Api::V3::Readonly::ResizeByAttribute
+          ]
         end
       end
     end

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -6,12 +6,12 @@ module Api
         self.primary_key = 'id'
 
         def self.select_options
-          all.map { |a| [a.name, a.id ] }
+          all.map { |a| [a.display_name, a.id] }
         end
 
         def self.refresh
           super
-          dependents.each { |mv| mv.refresh }
+          dependents.each(&:refresh)
         end
 
         def self.dependents

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -5,6 +5,10 @@ module Api
         def readonly?
           true
         end
+
+        def self.refresh
+          Scenic.database.refresh_materialized_view(table_name, concurrently: false)
+        end
       end
     end
   end

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -1,7 +1,7 @@
 module Api
   module V3
     module Readonly
-      class DownloadAttribute < BaseModel
+      class DownloadAttribute < Api::V3::Readonly::BaseModel
         self.table_name = 'revamp.download_attributes_mv'
         self.primary_key = 'id'
 
@@ -9,7 +9,7 @@ module Api
         belongs_to :readonly_attribute, foreign_key: :attribute_id, class_name: 'Attribute'
 
         def self.refresh
-          ActiveRecord::Base.connection.execute('REFRESH MATERIALIZED VIEW download_attributes_mv')
+          Scenic.database.refresh_materialized_view(table_name, concurrently: false)
         end
       end
     end

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -10,6 +10,7 @@ module Api
 
         def self.refresh
           Scenic.database.refresh_materialized_view(table_name, concurrently: false)
+          # Api::V3::Readonly::DownloadFlow.refresh_later(skip_flow_paths: true)
         end
       end
     end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -7,7 +7,6 @@ module Api
 
         def self.refresh
           Scenic.database.refresh_materialized_view('revamp.flow_paths_mv', concurrently: false)
-          Scenic.database.refresh_materialized_view('revamp.download_attributes_values_mv', concurrently: false)
           Scenic.database.refresh_materialized_view(table_name, concurrently: false)
         end
       end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -1,13 +1,22 @@
 module Api
   module V3
     module Readonly
-      class DownloadFlow < BaseModel
+      class DownloadFlow < Api::V3::Readonly::BaseModel
         self.table_name = 'revamp.download_flows_mv'
         self.primary_key = 'id'
 
-        def self.refresh
-          Scenic.database.refresh_materialized_view('revamp.flow_paths_mv', concurrently: false)
+        def self.refresh(options = {})
+          unless options[:skip_flow_paths]
+            Scenic.database.refresh_materialized_view(
+              'revamp.flow_paths_mv', concurrently: false
+            )
+          end
           Scenic.database.refresh_materialized_view(table_name, concurrently: false)
+        end
+
+        # this materialized view takes a long time to refresh
+        def self.refresh_later(options = {})
+          DownloadFlowsRefreshWorker.perform_async(options)
         end
       end
     end

--- a/app/models/api/v3/readonly/map_attribute.rb
+++ b/app/models/api/v3/readonly/map_attribute.rb
@@ -1,14 +1,10 @@
 module Api
   module V3
     module Readonly
-      class MapAttribute < BaseModel
+      class MapAttribute < Api::V3::Readonly::BaseModel
         self.table_name = 'revamp.map_attributes_mv'
 
         belongs_to :map_attribute_group
-
-        def self.refresh
-          ActiveRecord::Base.connection.execute('REFRESH MATERIALIZED VIEW map_attributes_mv')
-        end
       end
     end
   end

--- a/app/models/api/v3/readonly/recolor_by_attribute.rb
+++ b/app/models/api/v3/readonly/recolor_by_attribute.rb
@@ -1,7 +1,7 @@
 module Api
   module V3
     module Readonly
-      class RecolorByAttribute < BaseModel
+      class RecolorByAttribute < Api::V3::Readonly::BaseModel
         self.table_name = 'revamp.recolor_by_attributes_mv'
         belongs_to :context
         belongs_to :readonly_attribute, foreign_key: :attribute_id, class_name: 'Attribute'

--- a/app/models/api/v3/readonly/resize_by_attribute.rb
+++ b/app/models/api/v3/readonly/resize_by_attribute.rb
@@ -1,7 +1,7 @@
 module Api
   module V3
     module Readonly
-      class ResizeByAttribute < BaseModel
+      class ResizeByAttribute < Api::V3::Readonly::BaseModel
         self.table_name = 'revamp.resize_by_attributes_mv'
         belongs_to :context
         belongs_to :readonly_attribute, foreign_key: :attribute_id, class_name: 'Attribute'

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -25,18 +25,23 @@ module Api
 
       validates :context, presence: true
       validates :group_number, presence: true
-      validates :position, presence: true, uniqueness: {scope: [:context, :group_number]}
+      validates :position,
+                presence: true,
+                uniqueness: {scope: [:context, :group_number]}
       validates :legend_type, presence: true, inclusion: {in: LEGEND_TYPE}
-      validates :legend_color_theme, presence: true, inclusion: {in: LEGEND_COLOR_THEME}
+      validates :legend_color_theme,
+                presence: true,
+                inclusion: {in: LEGEND_COLOR_THEME}
       validates :is_disabled, inclusion: {in: [true, false]}
       validates :is_default, inclusion: {in: [true, false]}
-      validates_with OneAssociatedAttributeValidator, {
-        attributes: [:recolor_by_ind, :recolor_by_qual]
-      }
+      validates_with OneAssociatedAttributeValidator,
+                     attributes: [:recolor_by_ind, :recolor_by_qual]
       validates_with AttributeAssociatedOnceValidator,
-        attribute: :recolor_by_ind, if: :new_recolor_by_ind_given?
+                     attribute: :recolor_by_ind,
+                     if: :new_recolor_by_ind_given?
       validates_with AttributeAssociatedOnceValidator,
-        attribute: :recolor_by_qual, if: :new_recolor_by_qual_given?
+                     attribute: :recolor_by_qual,
+                     if: :new_recolor_by_qual_given?
 
       after_commit :refresh_dependencies
 

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -2,6 +2,7 @@ module Api
   module V3
     class RecolorByAttribute < YellowTable
       include Api::V3::StringyArray
+      include Api::V3::AssociatedAttributes
 
       LEGEND_TYPE = [
         'qual',
@@ -19,8 +20,8 @@ module Api
         ].freeze
 
       belongs_to :context
-      has_many :recolor_by_inds
-      has_many :recolor_by_quals
+      has_one :recolor_by_ind, autosave: true
+      has_one :recolor_by_qual, autosave: true
 
       validates :context, presence: true
       validates :group_number, presence: true
@@ -29,8 +30,16 @@ module Api
       validates :legend_color_theme, presence: true, inclusion: { in: LEGEND_COLOR_THEME }
       validates :is_disabled, inclusion: { in: [true, false] }
       validates :is_default, inclusion: { in: [true, false] }
+      validates_with OneAssociatedAttributeValidator, {
+        attributes: [:recolor_by_ind, :recolor_by_qual]
+      }
+      validates_with AttributeAssociatedOnceValidator,
+        attribute: :recolor_by_ind, if: :new_recolor_by_ind_given?
+      validates_with AttributeAssociatedOnceValidator,
+        attribute: :recolor_by_qual, if: :new_recolor_by_qual_given?
 
       stringy_array :years
+      manage_associated_attributes [:recolor_by_ind, :recolor_by_qual]
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -26,10 +26,10 @@ module Api
       validates :context, presence: true
       validates :group_number, presence: true
       validates :position, presence: true, uniqueness: {scope: [:context, :group_number]}
-      validates :legend_type, presence: true, inclusion: { in: LEGEND_TYPE }
-      validates :legend_color_theme, presence: true, inclusion: { in: LEGEND_COLOR_THEME }
-      validates :is_disabled, inclusion: { in: [true, false] }
-      validates :is_default, inclusion: { in: [true, false] }
+      validates :legend_type, presence: true, inclusion: {in: LEGEND_TYPE}
+      validates :legend_color_theme, presence: true, inclusion: {in: LEGEND_COLOR_THEME}
+      validates :is_disabled, inclusion: {in: [true, false]}
+      validates :is_default, inclusion: {in: [true, false]}
       validates_with OneAssociatedAttributeValidator, {
         attributes: [:recolor_by_ind, :recolor_by_qual]
       }

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -1,9 +1,36 @@
 module Api
   module V3
     class RecolorByAttribute < YellowTable
+      include Api::V3::StringyArray
+
+      LEGEND_TYPE = [
+        'qual',
+        'linear',
+        'stars',
+        'percentual'
+      ].freeze
+
+      LEGEND_COLOR_THEME = [
+        'thematic',
+        'blue-green',
+        'yellow-green',
+        'red-blue',
+        'yes-no'
+        ].freeze
+
       belongs_to :context
       has_many :recolor_by_inds
       has_many :recolor_by_quals
+
+      validates :context, presence: true
+      validates :group_number, presence: true
+      validates :position, presence: true, uniqueness: {scope: [:context, :group_number]}
+      validates :legend_type, presence: true, inclusion: { in: LEGEND_TYPE }
+      validates :legend_color_theme, presence: true, inclusion: { in: LEGEND_COLOR_THEME }
+      validates :is_disabled, inclusion: { in: [true, false] }
+      validates :is_default, inclusion: { in: [true, false] }
+
+      stringy_array :years
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -38,6 +38,8 @@ module Api
       validates_with AttributeAssociatedOnceValidator,
         attribute: :recolor_by_qual, if: :new_recolor_by_qual_given?
 
+      after_commit :refresh_dependencies
+
       stringy_array :years
       manage_associated_attributes [:recolor_by_ind, :recolor_by_qual]
 
@@ -45,6 +47,10 @@ module Api
         [
           {name: :context_id, table_class: Api::V3::Context}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::RecolorByAttribute.refresh
       end
     end
   end

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -4,20 +4,20 @@ module Api
       include Api::V3::StringyArray
       include Api::V3::AssociatedAttributes
 
-      LEGEND_TYPE = [
-        'qual',
-        'linear',
-        'stars',
-        'percentual'
-      ].freeze
+      LEGEND_TYPE = %w(
+        qual
+        linear
+        stars
+        percentual
+      ).freeze
 
-      LEGEND_COLOR_THEME = [
-        'thematic',
-        'blue-green',
-        'yellow-green',
-        'red-blue',
-        'yes-no'
-        ].freeze
+      LEGEND_COLOR_THEME = %w(
+        thematic
+        blue-green
+        yellow-green
+        red-blue
+        yes-no
+      ).freeze
 
       belongs_to :context
       has_one :recolor_by_ind, autosave: true

--- a/app/models/api/v3/resize_by_attribute.rb
+++ b/app/models/api/v3/resize_by_attribute.rb
@@ -9,14 +9,16 @@ module Api
 
       validates :context, presence: true
       validates :group_number, presence: true
-      validates :position, presence: true, uniqueness: {scope: [:context, :group_number]}
+      validates :position,
+                presence: true,
+                uniqueness: {scope: [:context, :group_number]}
       validates :is_disabled, inclusion: {in: [true, false]}
       validates :is_default, inclusion: {in: [true, false]}
-      validates_with OneAssociatedAttributeValidator, {
-        attributes: [:resize_by_quant]
-      }
+      validates_with OneAssociatedAttributeValidator,
+                     attributes: [:resize_by_quant]
       validates_with AttributeAssociatedOnceValidator,
-        attribute: :resize_by_quant, if: :new_resize_by_quant_given?
+                     attribute: :resize_by_quant,
+                     if: :new_resize_by_quant_given?
 
       after_commit :refresh_dependencies
 

--- a/app/models/api/v3/resize_by_attribute.rb
+++ b/app/models/api/v3/resize_by_attribute.rb
@@ -1,8 +1,18 @@
 module Api
   module V3
     class ResizeByAttribute < YellowTable
+      include Api::V3::StringyArray
+
       belongs_to :context
       has_many :resize_by_quants
+
+      validates :context, presence: true
+      validates :group_number, presence: true
+      validates :position, presence: true, uniqueness: {scope: [:context, :group_number]}
+      validates :is_disabled, inclusion: { in: [true, false] }
+      validates :is_default, inclusion: { in: [true, false] }
+
+      stringy_array :years
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/resize_by_attribute.rb
+++ b/app/models/api/v3/resize_by_attribute.rb
@@ -10,8 +10,8 @@ module Api
       validates :context, presence: true
       validates :group_number, presence: true
       validates :position, presence: true, uniqueness: {scope: [:context, :group_number]}
-      validates :is_disabled, inclusion: { in: [true, false] }
-      validates :is_default, inclusion: { in: [true, false] }
+      validates :is_disabled, inclusion: {in: [true, false]}
+      validates :is_default, inclusion: {in: [true, false]}
       validates_with OneAssociatedAttributeValidator, {
         attributes: [:resize_by_quant]
       }

--- a/app/models/api/v3/resize_by_attribute.rb
+++ b/app/models/api/v3/resize_by_attribute.rb
@@ -2,17 +2,24 @@ module Api
   module V3
     class ResizeByAttribute < YellowTable
       include Api::V3::StringyArray
+      include Api::V3::AssociatedAttributes
 
       belongs_to :context
-      has_many :resize_by_quants
+      has_one :resize_by_quant, autosave: true
 
       validates :context, presence: true
       validates :group_number, presence: true
       validates :position, presence: true, uniqueness: {scope: [:context, :group_number]}
       validates :is_disabled, inclusion: { in: [true, false] }
       validates :is_default, inclusion: { in: [true, false] }
+      validates_with OneAssociatedAttributeValidator, {
+        attributes: [:resize_by_quant]
+      }
+      validates_with AttributeAssociatedOnceValidator,
+        attribute: :resize_by_quant, if: :new_resize_by_quant_given?
 
       stringy_array :years
+      manage_associated_attributes [:resize_by_quant]
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/resize_by_attribute.rb
+++ b/app/models/api/v3/resize_by_attribute.rb
@@ -18,6 +18,8 @@ module Api
       validates_with AttributeAssociatedOnceValidator,
         attribute: :resize_by_quant, if: :new_resize_by_quant_given?
 
+      after_commit :refresh_dependencies
+
       stringy_array :years
       manage_associated_attributes [:resize_by_quant]
 
@@ -25,6 +27,10 @@ module Api
         [
           {name: :context_id, table_class: Api::V3::Context}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::ResizeByAttribute.refresh
       end
     end
   end

--- a/app/models/concerns/api/v3/associated_attributes.rb
+++ b/app/models/concerns/api/v3/associated_attributes.rb
@@ -24,6 +24,10 @@ module Api
         readonly_attribute&.id
       end
 
+      def readonly_attribute_display_name
+        readonly_attribute&.display_name
+      end
+
       def readonly_attribute_name
         readonly_attribute&.name
       end
@@ -68,14 +72,12 @@ module Api
           if readonly_attribute.original_type != attr_type.capitalize
             # delete when saving parent
             send(attr_name)&.mark_for_destruction
+          elsif assoc_obj
+            # update existing associated object with new attribute id
+            assoc_obj.send(:"#{attr_type}_id=", readonly_attribute.original_id)
           else
-            if assoc_obj
-              # update existing associated object with new attribute id
-              assoc_obj.send(:"#{attr_type}_id=", readonly_attribute.original_id)
-            else
-              # build a new associated object (saved with parent)
-              self.send(:"build_#{attr_name}", :"#{attr_type}_id" => readonly_attribute.original_id)
-            end
+            # build a new associated object (saved with parent)
+            send(:"build_#{attr_name}", :"#{attr_type}_id" => readonly_attribute.original_id)
           end
         end
       end

--- a/app/models/concerns/api/v3/associated_attributes.rb
+++ b/app/models/concerns/api/v3/associated_attributes.rb
@@ -64,17 +64,21 @@ module Api
         return unless readonly_attribute
 
         assoc_attr_names_with_types.each do |attr_name, attr_type|
-          assoc_obj = send(attr_name)
-          if readonly_attribute.original_type != attr_type.capitalize
-            # delete when saving parent
-            send(attr_name)&.mark_for_destruction
-          elsif assoc_obj
-            # update existing associated object with new attribute id
-            assoc_obj.send(:"#{attr_type}_id=", readonly_attribute.original_id)
-          else
-            # build a new associated object (saved with parent)
-            send(:"build_#{attr_name}", :"#{attr_type}_id" => readonly_attribute.original_id)
-          end
+          assign_associated_object(readonly_attribute, attr_name, attr_type)
+        end
+      end
+
+      def assign_associated_object(readonly_attribute, attr_name, attr_type)
+        assoc_obj = send(attr_name)
+        if readonly_attribute.original_type != attr_type.capitalize
+          # delete when saving parent
+          send(attr_name)&.mark_for_destruction
+        elsif assoc_obj
+          # update existing associated object with new attribute id
+          assoc_obj.send(:"#{attr_type}_id=", readonly_attribute.original_id)
+        else
+          # build a new associated object (saved with parent)
+          send(:"build_#{attr_name}", :"#{attr_type}_id" => readonly_attribute.original_id)
         end
       end
 

--- a/app/models/concerns/api/v3/associated_attributes.rb
+++ b/app/models/concerns/api/v3/associated_attributes.rb
@@ -1,0 +1,84 @@
+require 'active_support/concern'
+module Api
+  module V3
+    module AssociatedAttributes
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def manage_associated_attributes(ary)
+          @associated_attributes = ary
+
+          @associated_attributes.each do |attr_name|
+            define_method(:"new_#{attr_name}_given?") do
+              send(attr_name).present? && !send(attr_name).marked_for_destruction?
+            end
+          end
+        end
+
+        def associated_attributes
+          @associated_attributes
+        end
+      end
+
+      def readonly_attribute_id
+        readonly_attribute&.id
+      end
+
+      def readonly_attribute_name
+        readonly_attribute&.name
+      end
+
+      def readonly_attribute_id=(id)
+        self.readonly_attribute = Api::V3::Readonly::Attribute.find_by_id(id)
+      end
+
+      private
+
+      def associated_attributes
+        self.class.instance_variable_get(:@associated_attributes)
+      end
+
+      def readonly_attribute
+        @readonly_attribute || (@readonly_attribute = find_readonly_attribute)
+      end
+
+      # iterates over declared associated attributes
+      # returns the first actual associated attribute found
+      def find_readonly_attribute
+        associated_attributes.detect do |attr_name|
+          attr_type = attr_name.to_s.split('_').last
+          next unless attr_type
+          # no good way to preload this
+          readonly_attribute = Api::V3::Readonly::Attribute.where(
+            original_id: send(attr_name)&.send(:"#{attr_type}_id"),
+            original_type: attr_type.capitalize
+          ).first
+          break readonly_attribute if readonly_attribute.present?
+          false
+        end
+      end
+
+      def readonly_attribute=(readonly_attribute)
+        return unless readonly_attribute
+
+        associated_attributes.each do |attr_name|
+          attr_type = attr_name.to_s.split('_').last
+          assoc_obj = send(attr_name)
+          next unless attr_type
+          if readonly_attribute.original_type != attr_type.capitalize
+            # delete when saving parent
+            send(attr_name)&.mark_for_destruction
+          else
+            if assoc_obj
+              # update existing associated object with new attribute id
+              assoc_obj.send(:"#{attr_type}_id=", readonly_attribute.original_id)
+            else
+              # build a new associated object (saved with parent)
+              self.send(:"build_#{attr_name}", :"#{attr_type}_id" => readonly_attribute.original_id)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/api/v3/stringy_array.rb
+++ b/app/models/concerns/api/v3/stringy_array.rb
@@ -1,0 +1,20 @@
+require 'active_support/concern'
+module Api
+  module V3
+    module StringyArray
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def stringy_array(attr_name)
+          define_method(:"#{attr_name}_str=") do |str|
+            str_to_ary = str&.split(',')&.map(&:strip) || []
+            write_attribute(attr_name, str_to_ary)
+          end
+          define_method(:"#{attr_name}_str") do
+            read_attribute(attr_name)&.join(', ')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/validators/array_size_validator.rb
+++ b/app/validators/array_size_validator.rb
@@ -1,0 +1,9 @@
+class ArraySizeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless options.key?(:exactly)
+    array_size = (value.try(:size) || 0)
+    expected_size = options[:exactly]
+    return if array_size == expected_size
+    record.errors.add(attribute, :invalid_size, size: expected_size)
+  end
+end

--- a/app/validators/attribute_associated_once_validator.rb
+++ b/app/validators/attribute_associated_once_validator.rb
@@ -1,0 +1,28 @@
+# Used in download_attributes, map_attributes, recolor_by_attributes
+# and resize_by attributes
+# to ensure that any attribute (ind / qual / quant) is only assigned once
+# in a given scope (the scope will typically be a context)
+class AttributeAssociatedOnceValidator < ActiveModel::Validator
+  def validate(record)
+    return unless options.key?(:attribute)
+    # e.g. map_ind
+    attribute_association_name = options[:attribute]
+    # e.g. ind
+    attribute_name = options[:attribute].to_s.split('_').last
+    # e.g. ind_id
+    attribute_id_name = "#{attribute_name}_id"
+    attribute_id = record.send(attribute_association_name)&.send(attribute_id_name)
+    scope_attribute_name = "#{options[:scope] || :context}_id"
+    existing_assignments = record.class.joins(attribute_association_name).where(
+      "#{attribute_association_name}s.#{attribute_name}_id" => attribute_id,
+      scope_attribute_name => record.send(scope_attribute_name)
+    )
+    if record.persisted?
+      existing_assignments = existing_assignments.where(
+        "#{record.class.table_name}.id <> ?", record.id
+      )
+    end
+    return if existing_assignments.reject { |aa| aa.marked_for_destruction? }.empty?
+    record.errors.add(:base, 'attribute can only be listed once per context')
+  end
+end

--- a/app/validators/attribute_associated_once_validator.rb
+++ b/app/validators/attribute_associated_once_validator.rb
@@ -22,7 +22,7 @@ class AttributeAssociatedOnceValidator < ActiveModel::Validator
         "#{record.class.table_name}.id <> ?", record.id
       )
     end
-    return if existing_assignments.reject { |aa| aa.marked_for_destruction? }.empty?
+    return if existing_assignments.reject(&:marked_for_destruction?).empty?
     record.errors.add(:base, 'attribute can only be listed once per context')
   end
 end

--- a/app/validators/one_associated_attribute_validator.rb
+++ b/app/validators/one_associated_attribute_validator.rb
@@ -1,0 +1,17 @@
+# Used in download_attributes, map_attributes, recolor_by_attributes
+# and resize_by attributes
+# which all have has_one associations, sometimes multiple
+# e.g. map_ind, map_quant
+# to ensure only one of those exists at a given time
+class OneAssociatedAttributeValidator < ActiveModel::Validator
+  def validate(record)
+    return unless options.key?(:attributes)
+    count = 0
+    options[:attributes].each do |attr_sym|
+      attribute = record.send(attr_sym)
+      count += 1 if attribute.present? && !attribute.marked_for_destruction?
+    end
+    return if count <= 1
+    record.errors.add(:base, 'can only be associated with one type of attribute')
+  end
+end

--- a/app/workers/download_flows_refresh_worker.rb
+++ b/app/workers/download_flows_refresh_worker.rb
@@ -1,0 +1,10 @@
+class DownloadFlowsRefreshWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: false
+
+  def perform(options)
+    # first check if there any jobs of this type already queued
+    # TODO
+    Api::V3::Readonly::DownloadFlow.refresh(options)
+  end
+end

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -39,3 +39,9 @@ production:
 staging:
   <<: *defaults
   active: true
+
+development:
+  active: false
+
+test:
+  active: false

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -222,6 +222,17 @@ ActiveAdmin.setup do |config|
   #     end
   #   end
 
+config.namespace :admin do |admin|
+  admin.build_menu do |menu|
+    menu.add label: 'Dashboard', priority: 1
+    menu.add label: 'Content', priority: 2
+    menu.add label: 'General Settings', priority: 5
+    menu.add label: 'Sankey Settings', priority: 6
+    menu.add label: 'Map Settings', priority: 7
+    menu.add label: 'Data Download Settings', priority: 8
+  end
+end
+
   # == Download Links
   #
   # You can disable download links on resource listing pages,

--- a/config/initializers/postgre_sql_database_tasks.rb
+++ b/config/initializers/postgre_sql_database_tasks.rb
@@ -49,7 +49,7 @@ module ActiveRecord
         # manually suppressing CREATE SERVER and CREATE USER MAPPING
         # which don't seem to be possible to keep outside the dump otherwise ;(
 
-        puts "Suppressing CREATE SERVER and CREATE USER MAPPING in dump. Please run rake db:revamp:init after restoring."
+        puts "Suppressing CREATE SERVER and CREATE USER MAPPING in dump. Please run rake db:remote:init after restoring."
 
         dump = File.read(filename)
         new_dump = dump.sub(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,11 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    errors:
+      models:
+        map_attribute:
+          attributes:
+            array:
+              invalid_size:
+                other: has wrong size, should be %{size}

--- a/db/migrate/20180202093906_simplify_download_flows_mview_dependencies.rb
+++ b/db/migrate/20180202093906_simplify_download_flows_mview_dependencies.rb
@@ -1,0 +1,20 @@
+class SimplifyDownloadFlowsMviewDependencies < ActiveRecord::Migration[5.1]
+  def change
+    with_search_path('revamp') do
+      drop_view :download_flows_mv, materialized: true
+      # we'll be merging download_attributes_valus_mv into download_flows_mv
+      drop_view :download_attributes_values_mv, materialized: true
+      drop_view :flow_paths_mv, materialized: true
+
+      # flow_paths_mv now without dependency on context_node_type_properties
+      create_view :flow_paths_mv, version: 2, materialized: true
+      add_index :flow_paths_mv, [:flow_id, :column_position]
+
+      create_view :download_flows_mv, version: 2, materialized: true
+      add_index :download_flows_mv, :exporter_node_id
+      add_index :download_flows_mv, :importer_node_id
+      add_index :download_flows_mv, :country_node_id
+      add_index :download_flows_mv, [:attribute_type, :attribute_id]
+    end
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -188,17 +188,17 @@ tables:
       - name: position
         comment: Display order in scope of group
       - name: bucket_3
-        comment: Choropleth buckets
+        comment: Choropleth buckets for single dimension choropleth
       - name: bucket_5
-        comment: Choropleth buckets
+        comment: Choropleth buckets for dual dimension choropleth
       - name: color_scale
         comment: Choropleth colour scale, e.g. blue
       - name: years
         comment: Years for which attribute is present; empty (NULL) for all years
       - name: is_disabled
-        comment: When set, do not show this attribute
+        comment: When set, this attribute is not displayed
       - name: is_default
-        comment: When set, show this attribute by default
+        comment: When set, show this attribute by default. A maximum of 2 attributes per context may be set as default.
   - name: map_inds
     comment: Inds to display on map (see map_attributes.)
   - name: map_quants
@@ -291,7 +291,7 @@ tables:
     comment: Attributes (inds/quals) available for recoloring.
     columns:
       - name: group_number
-        comment: Group number
+        comment: Attributes are displayed grouped by their group number, with a separator between groups
       - name: position
         comment: Display order in scope of context and group number
       - name: legend_type
@@ -305,13 +305,13 @@ tables:
       - name: max_value
         comment: Max value for the legend
       - name: divisor
-        comment: For percentual legends the step between intervals
+        comment: Step between intervals for percentual legends
       - name: tooltip_text
         comment: Tooltip text
       - name: years
         comment: Array of years for which to show this attribute in scope of chart; empty (NULL) for all years
       - name: is_disabled
-        comment: When set, do not show this attribute
+        comment: When set, this attribute is not displayed
       - name: is_default
         comment: When set, show this attribute by default
   - name: recolor_by_inds
@@ -330,7 +330,7 @@ tables:
       - name: years
         comment: Array of years for which to show this attribute in scope of chart; empty (NULL) for all years
       - name: is_disabled
-        comment: When set, do not show this attribute
+        comment: When set, this attribute is not displayed
       - name: is_default
         comment: When set, show this attribute by default
   - name: resize_by_quants

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -388,8 +388,6 @@ materialized_views:
     columns:
       - name: attribute_id
         comment: References the unique id in attributes_mv.
-  - name: download_attributes_values_mv
-    comment: Downloadable values from flow_inds/quals/quants
   - name: flow_paths_mv
     comment: Normalised flows
   - name: download_flows_mv

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -5,7 +5,9 @@ tables:
       - name: identifier
         comment: Identifier of the CartoDB named map, e.g. brazil_biomes; unique in scope of contextual layer
       - name: years
-        comment: Array of years for which to show this carto layer in scope of contextual layer; NULL for all years
+        comment: Array of years for which to show this carto layer in scope of contextual layer; empty (NULL) for all years
+      - name: raster_url
+        comment: Url of raster layer
   - name: chart_attributes
     comment: Attributes (inds/quals/quants) to display in a chart.
     columns:
@@ -14,7 +16,7 @@ tables:
       - name: position
         comment: Display order in scope of chart
       - name: years
-        comment: Array of years for which to show this attribute in scope of chart; NULL for all years
+        comment: Array of years for which to show this attribute in scope of chart; empty (NULL) for all years
   - name: chart_inds
     comment: Inds to display in a chart (see chart_attributes.)
   - name: chart_quals
@@ -45,7 +47,7 @@ tables:
   - name: context_node_type_properties
     columns:
       - name: column_group
-        comment: Number of sankey column in which to display nodes of this type
+        comment: Zero-based number of sankey column in which to display nodes of this type
       - name: is_default
         comment: When set, show this node type as default (only use for one)
       - name: is_geo_column
@@ -56,7 +58,7 @@ tables:
     comment: Country-commodity combinations.
     columns:
       - name: years
-        comment: Years for which country-commodity data is present; NULL for all years
+        comment: Years for which country-commodity data is present; empty (NULL) for all years
       - name: default_year
         comment: Default year for this context
   - name: context_properties
@@ -79,6 +81,8 @@ tables:
         comment: Identifier of layer, e.g. brazil_biomes
       - name: position
         comment: Display order in scope of context
+      - name: legend
+        comment: Legend as HTML snippet
       - name: tooltip_text
         comment: Tooltip text
       - name: is_default
@@ -93,20 +97,20 @@ tables:
   - name: country_properties
     columns:
       - name: latitude
-        comment: TODO
+        comment: Country latitide
       - name: longitude
-        comment: TODO
+        comment: Country longitude
       - name: zoom
-        comment: TODO
+        comment: Zoom level (0-18)
   - name: download_attributes
     comment: Attributes (quals/quants) available for download.
     columns:
       - name: position
         comment: Display order in scope of context
       - name: display_name
-        comment: Name of attribute for display
+        comment: Name of attribute for display in downloads
       - name: years
-        comment: Years for which attribute is present; NULL for all years
+        comment: Years for which attribute is present; empty (NULL) for all years
   - name: download_quals
     comment: Quals to include in downloads (see download_attributes.)
     columns:
@@ -168,7 +172,9 @@ tables:
       - name: is_visible_on_actor_profile
         comment: Whether to display this attribute on actor profile
       - name: is_temporal_on_place_profile
+        comment: Whether attribute has temporal data on place profile
       - name: is_temporal_on_actor_profile
+        comment: Whether attribute has temporal data on actor profile
   - name: map_attribute_groups
     comment: Groups attributes (inds/quals/quants) to display on map
     columns:
@@ -182,13 +188,13 @@ tables:
       - name: position
         comment: Display order in scope of group
       - name: bucket_3
-        comment: TODO
+        comment: Choropleth buckets
       - name: bucket_5
-        comment: TODO
+        comment: Choropleth buckets
       - name: color_scale
-        comment: TODO
+        comment: Choropleth colour scale, e.g. blue
       - name: years
-        comment: Years for which attribute is present; NULL for all years
+        comment: Years for which attribute is present; empty (NULL) for all years
       - name: is_disabled
         comment: When set, do not show this attribute
       - name: is_default
@@ -201,21 +207,21 @@ tables:
     comment: Values of inds for node
     columns:
       - name: year
-        comment: Year; NULL for all years
+        comment: Year; empty (NULL) for all years
       - name: value
         comment: Numeric value
   - name: node_quals
     comment: Values of quals for node
     columns:
       - name: year
-        comment: Year; NULL for all years
+        comment: Year; empty (NULL) for all years
       - name: value
         comment: Textual value
   - name: node_quants
     comment: Values of quants for node
     columns:
       - name: year
-        comment: Year; NULL for all years
+        comment: Year; empty (NULL) for all years
       - name: value
         comment: Numeric value
   - name: node_types
@@ -285,25 +291,25 @@ tables:
     comment: Attributes (inds/quals) available for recoloring.
     columns:
       - name: group_number
-        comment: TODO
+        comment: Group number
       - name: position
-        comment: Display order in scope of context
+        comment: Display order in scope of context and group number
       - name: legend_type
-        comment: TODO
+        comment: Type of legend, e.g. linear
       - name: legend_color_theme
-        comment: TODO
+        comment: Color theme of legend, e.g. red-blue
       - name: interval_count
-        comment: TODO
+        comment: For legends with min / max value, number of intervals of the legend
       - name: min_value
-        comment: TODO
+        comment: Min value for the legend
       - name: max_value
-        comment: TODO
+        comment: Max value for the legend
       - name: divisor
-        comment: TODO
+        comment: For percentual legends the step between intervals
       - name: tooltip_text
         comment: Tooltip text
       - name: years
-        comment: Array of years for which to show this attribute in scope of chart; NULL for all years
+        comment: Array of years for which to show this attribute in scope of chart; empty (NULL) for all years
       - name: is_disabled
         comment: When set, do not show this attribute
       - name: is_default
@@ -316,13 +322,13 @@ tables:
     comment: Attributes (quants) available for resizing.
     columns:
       - name: group_number
-        comment: TODO
+        comment: Group number
       - name: position
-        comment: Display order in scope of context
+        comment: Display order in scope of context and group number
       - name: tooltip_text
         comment: Tooltip text
       - name: years
-        comment: Array of years for which to show this attribute in scope of chart; NULL for all years
+        comment: Array of years for which to show this attribute in scope of chart; empty (NULL) for all years
       - name: is_disabled
         comment: When set, do not show this attribute
       - name: is_default

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1110,6 +1110,20 @@ COMMENT ON COLUMN ind_properties.is_visible_on_actor_profile IS 'Whether to disp
 
 
 --
+-- Name: COLUMN ind_properties.is_temporal_on_place_profile; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN ind_properties.is_temporal_on_place_profile IS 'Whether attribute has temporal data on place profile';
+
+
+--
+-- Name: COLUMN ind_properties.is_temporal_on_actor_profile; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN ind_properties.is_temporal_on_actor_profile IS 'Whether attribute has temporal data on actor profile';
+
+
+--
 -- Name: inds; Type: TABLE; Schema: revamp; Owner: -
 --
 
@@ -1427,7 +1441,14 @@ COMMENT ON COLUMN carto_layers.identifier IS 'Identifier of the CartoDB named ma
 -- Name: COLUMN carto_layers.years; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN carto_layers.years IS 'Array of years for which to show this carto layer in scope of contextual layer; NULL for all years';
+COMMENT ON COLUMN carto_layers.years IS 'Array of years for which to show this carto layer in scope of contextual layer; empty (NULL) for all years';
+
+
+--
+-- Name: COLUMN carto_layers.raster_url; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN carto_layers.raster_url IS 'Url of raster layer';
 
 
 --
@@ -1488,7 +1509,7 @@ COMMENT ON COLUMN chart_attributes."position" IS 'Display order in scope of char
 -- Name: COLUMN chart_attributes.years; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN chart_attributes.years IS 'Array of years for which to show this attribute in scope of chart; NULL for all years';
+COMMENT ON COLUMN chart_attributes.years IS 'Array of years for which to show this attribute in scope of chart; empty (NULL) for all years';
 
 
 --
@@ -1761,7 +1782,7 @@ CREATE TABLE context_node_type_properties (
 -- Name: COLUMN context_node_type_properties.column_group; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN context_node_type_properties.column_group IS 'Number of sankey column in which to display nodes of this type';
+COMMENT ON COLUMN context_node_type_properties.column_group IS 'Zero-based number of sankey column in which to display nodes of this type';
 
 
 --
@@ -1776,6 +1797,13 @@ COMMENT ON COLUMN context_node_type_properties.is_default IS 'When set, show thi
 --
 
 COMMENT ON COLUMN context_node_type_properties.is_geo_column IS 'When set, show nodes on map';
+
+
+--
+-- Name: COLUMN context_node_type_properties.is_choropleth_disabled; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN context_node_type_properties.is_choropleth_disabled IS 'When set, do not display the map choropleth';
 
 
 --
@@ -1938,7 +1966,7 @@ COMMENT ON TABLE contexts IS 'Country-commodity combinations.';
 -- Name: COLUMN contexts.years; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN contexts.years IS 'Years for which country-commodity data is present; NULL for all years';
+COMMENT ON COLUMN contexts.years IS 'Years for which country-commodity data is present; empty (NULL) for all years';
 
 
 --
@@ -2025,6 +2053,13 @@ COMMENT ON COLUMN contextual_layers.tooltip_text IS 'Tooltip text';
 --
 
 COMMENT ON COLUMN contextual_layers.is_default IS 'When set, show this layer by default';
+
+
+--
+-- Name: COLUMN contextual_layers.legend; Type: COMMENT; Schema: revamp; Owner: -
+--
+
+COMMENT ON COLUMN contextual_layers.legend IS 'Legend as HTML snippet';
 
 
 --
@@ -2117,21 +2152,21 @@ CREATE TABLE country_properties (
 -- Name: COLUMN country_properties.latitude; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN country_properties.latitude IS 'TODO';
+COMMENT ON COLUMN country_properties.latitude IS 'Country latitide';
 
 
 --
 -- Name: COLUMN country_properties.longitude; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN country_properties.longitude IS 'TODO';
+COMMENT ON COLUMN country_properties.longitude IS 'Country longitude';
 
 
 --
 -- Name: COLUMN country_properties.zoom; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN country_properties.zoom IS 'TODO';
+COMMENT ON COLUMN country_properties.zoom IS 'Zoom level (0-18)';
 
 
 --
@@ -2248,14 +2283,14 @@ COMMENT ON COLUMN download_attributes."position" IS 'Display order in scope of c
 -- Name: COLUMN download_attributes.display_name; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN download_attributes.display_name IS 'Name of attribute for display';
+COMMENT ON COLUMN download_attributes.display_name IS 'Name of attribute for display in downloads';
 
 
 --
 -- Name: COLUMN download_attributes.years; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN download_attributes.years IS 'Years for which attribute is present; NULL for all years';
+COMMENT ON COLUMN download_attributes.years IS 'Years for which attribute is present; empty (NULL) for all years';
 
 
 --
@@ -3046,28 +3081,28 @@ COMMENT ON COLUMN map_attributes."position" IS 'Display order in scope of group'
 -- Name: COLUMN map_attributes.bucket_3; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN map_attributes.bucket_3 IS 'TODO';
+COMMENT ON COLUMN map_attributes.bucket_3 IS 'Choropleth buckets';
 
 
 --
 -- Name: COLUMN map_attributes.bucket_5; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN map_attributes.bucket_5 IS 'TODO';
+COMMENT ON COLUMN map_attributes.bucket_5 IS 'Choropleth buckets';
 
 
 --
 -- Name: COLUMN map_attributes.color_scale; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN map_attributes.color_scale IS 'TODO';
+COMMENT ON COLUMN map_attributes.color_scale IS 'Choropleth colour scale, e.g. blue';
 
 
 --
 -- Name: COLUMN map_attributes.years; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN map_attributes.years IS 'Years for which attribute is present; NULL for all years';
+COMMENT ON COLUMN map_attributes.years IS 'Years for which attribute is present; empty (NULL) for all years';
 
 
 --
@@ -3324,7 +3359,7 @@ COMMENT ON TABLE node_inds IS 'Values of inds for node';
 -- Name: COLUMN node_inds.year; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN node_inds.year IS 'Year; NULL for all years';
+COMMENT ON COLUMN node_inds.year IS 'Year; empty (NULL) for all years';
 
 
 --
@@ -3417,7 +3452,7 @@ COMMENT ON TABLE node_quals IS 'Values of quals for node';
 -- Name: COLUMN node_quals.year; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN node_quals.year IS 'Year; NULL for all years';
+COMMENT ON COLUMN node_quals.year IS 'Year; empty (NULL) for all years';
 
 
 --
@@ -3471,7 +3506,7 @@ COMMENT ON TABLE node_quants IS 'Values of quants for node';
 -- Name: COLUMN node_quants.year; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN node_quants.year IS 'Year; NULL for all years';
+COMMENT ON COLUMN node_quants.year IS 'Year; empty (NULL) for all years';
 
 
 --
@@ -3696,56 +3731,56 @@ COMMENT ON TABLE recolor_by_attributes IS 'Attributes (inds/quals) available for
 -- Name: COLUMN recolor_by_attributes.group_number; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.group_number IS 'TODO';
+COMMENT ON COLUMN recolor_by_attributes.group_number IS 'Group number';
 
 
 --
 -- Name: COLUMN recolor_by_attributes."position"; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes."position" IS 'Display order in scope of context';
+COMMENT ON COLUMN recolor_by_attributes."position" IS 'Display order in scope of context and group number';
 
 
 --
 -- Name: COLUMN recolor_by_attributes.legend_type; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.legend_type IS 'TODO';
+COMMENT ON COLUMN recolor_by_attributes.legend_type IS 'Type of legend, e.g. linear';
 
 
 --
 -- Name: COLUMN recolor_by_attributes.legend_color_theme; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.legend_color_theme IS 'TODO';
+COMMENT ON COLUMN recolor_by_attributes.legend_color_theme IS 'Color theme of legend, e.g. red-blue';
 
 
 --
 -- Name: COLUMN recolor_by_attributes.interval_count; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.interval_count IS 'TODO';
+COMMENT ON COLUMN recolor_by_attributes.interval_count IS 'For legends with min / max value, number of intervals of the legend';
 
 
 --
 -- Name: COLUMN recolor_by_attributes.min_value; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.min_value IS 'TODO';
+COMMENT ON COLUMN recolor_by_attributes.min_value IS 'Min value for the legend';
 
 
 --
 -- Name: COLUMN recolor_by_attributes.max_value; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.max_value IS 'TODO';
+COMMENT ON COLUMN recolor_by_attributes.max_value IS 'Max value for the legend';
 
 
 --
 -- Name: COLUMN recolor_by_attributes.divisor; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.divisor IS 'TODO';
+COMMENT ON COLUMN recolor_by_attributes.divisor IS 'For percentual legends the step between intervals';
 
 
 --
@@ -3759,7 +3794,7 @@ COMMENT ON COLUMN recolor_by_attributes.tooltip_text IS 'Tooltip text';
 -- Name: COLUMN recolor_by_attributes.years; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN recolor_by_attributes.years IS 'Array of years for which to show this attribute in scope of chart; NULL for all years';
+COMMENT ON COLUMN recolor_by_attributes.years IS 'Array of years for which to show this attribute in scope of chart; empty (NULL) for all years';
 
 
 --
@@ -3965,14 +4000,14 @@ COMMENT ON TABLE resize_by_attributes IS 'Attributes (quants) available for resi
 -- Name: COLUMN resize_by_attributes.group_number; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN resize_by_attributes.group_number IS 'TODO';
+COMMENT ON COLUMN resize_by_attributes.group_number IS 'Group number';
 
 
 --
 -- Name: COLUMN resize_by_attributes."position"; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN resize_by_attributes."position" IS 'Display order in scope of context';
+COMMENT ON COLUMN resize_by_attributes."position" IS 'Display order in scope of context and group number';
 
 
 --
@@ -3986,7 +4021,7 @@ COMMENT ON COLUMN resize_by_attributes.tooltip_text IS 'Tooltip text';
 -- Name: COLUMN resize_by_attributes.years; Type: COMMENT; Schema: revamp; Owner: -
 --
 
-COMMENT ON COLUMN resize_by_attributes.years IS 'Array of years for which to show this attribute in scope of chart; NULL for all years';
+COMMENT ON COLUMN resize_by_attributes.years IS 'Array of years for which to show this attribute in scope of chart; empty (NULL) for all years';
 
 
 --

--- a/db/views/download_flows_mv_v02.sql
+++ b/db/views/download_flows_mv_v02.sql
@@ -1,0 +1,130 @@
+SELECT
+  f_0.flow_id AS id,
+  f_0.context_id,
+  f_0.year,
+  f_0.name AS name_0,
+  f_1.name AS name_1,
+  f_2.name AS name_2,
+  f_3.name AS name_3,
+  f_4.name AS name_4,
+  f_5.name AS name_5,
+  f_6.name AS name_6,
+  f_7.name AS name_7,
+  f_0.node_id AS node_id_0,
+  f_1.node_id AS node_id_1,
+  f_2.node_id AS node_id_2,
+  f_3.node_id AS node_id_3,
+  f_4.node_id AS node_id_4,
+  f_5.node_id AS node_id_5,
+  f_6.node_id AS node_id_6,
+  f_7.node_id AS node_id_7,
+  CASE
+    WHEN f_5.node_type_name = 'EXPORTER' THEN f_5.node_id -- BRAZIL-SOY
+    WHEN f_2.node_type_name = 'EXPORTER' THEN f_2.node_id -- PARAGUAY-SOY, BRAZIL-BEEF
+    WHEN f_2.node_type_name = 'TRADER' THEN f_2.node_id -- ARGENTINE-SOY, ARGENTINA-BEEF, PARAGUAY-BEEF
+    WHEN f_1.node_type_name = 'EXPORTER' THEN f_1.node_id -- INDONESIA-PALM OIL
+  END AS exporter_node_id,
+  CASE
+    WHEN f_6.node_type_name = 'IMPORTER' THEN f_6.node_id -- BRAZIL-SOY
+    WHEN f_3.node_type_name = 'IMPORTER' THEN f_3.node_id -- BRAZIL-BEEF
+    WHEN f_2.node_type_name = 'IMPORTER' THEN f_2.node_id -- INDONESIA-PALM OIL
+    ELSE NULL -- OTHERS
+  END AS importer_node_id,
+  CASE
+    WHEN f_7.node_type_name = 'COUNTRY' THEN f_7.node_id -- BRAZIL-SOY
+    WHEN f_4.node_type_name = 'COUNTRY' THEN f_4.node_id -- BRAZIL-BEEF
+    WHEN f_3.node_type_name = 'COUNTRY' THEN f_3.node_id -- OTHERS
+  END AS country_node_id,
+  fi.attribute_type,
+  fi.attribute_id,
+  fi.name AS attribute_name,
+  fi.name_with_unit AS attribute_name_with_unit,
+  fi.display_name,
+  BOOL_AND(fi.boolean_value) AS bool_and,
+  SUM(fi.numeric_value) AS sum,
+  CASE
+    WHEN fi.attribute_type = 'Qual' AND BOOL_AND(fi.boolean_value) THEN 'yes'
+    WHEN fi.attribute_type = 'Qual' AND NOT BOOL_AND(fi.boolean_value) THEN 'no'
+    ELSE SUM(fi.numeric_value)::TEXT
+  END AS total
+FROM flow_paths_mv f_0
+JOIN flow_paths_mv f_1 ON f_1.flow_id = f_0.flow_id AND f_1.column_position = 1
+JOIN flow_paths_mv f_2 ON f_2.flow_id = f_0.flow_id AND f_2.column_position = 2
+JOIN flow_paths_mv f_3 ON f_3.flow_id = f_0.flow_id AND f_3.column_position = 3
+LEFT JOIN flow_paths_mv f_4 ON f_4.flow_id = f_0.flow_id AND f_4.column_position = 4
+LEFT JOIN flow_paths_mv f_5 ON f_5.flow_id = f_0.flow_id AND f_5.column_position = 5
+LEFT JOIN flow_paths_mv f_6 ON f_6.flow_id = f_0.flow_id AND f_6.column_position = 6
+LEFT JOIN flow_paths_mv f_7 ON f_7.flow_id = f_0.flow_id AND f_7.column_position = 7
+JOIN (
+  SELECT
+    f.flow_id, f.qual_id AS attribute_id, 'Qual' AS attribute_type,
+    null AS numeric_value,
+    CASE
+      WHEN LOWER(value) = 'yes' THEN true
+      WHEN LOWER(value) = 'no' THEN false
+      ELSE null
+    END AS boolean_value,
+    q.name,
+    null AS unit,
+    q.name AS name_with_unit,
+    da.display_name,
+    da.context_id
+  FROM flow_quals f
+  JOIN quals q ON f.qual_id = q.id
+  JOIN download_quals dq ON dq.qual_id = q.id
+  JOIN download_attributes da ON dq.download_attribute_id = da.id
+  GROUP BY f.flow_id, f.qual_id, f.value, q.name, da.display_name, da.context_id
+
+  UNION ALL
+
+  SELECT
+    f.flow_id, f.quant_id, 'Quant',
+    f.value,
+    null,
+    q.name,
+    q.unit,
+    CASE
+      WHEN unit IS null THEN q.name
+      ELSE q.name || ' (' || q.unit || ')'
+    END,
+    da.display_name,
+    da.context_id
+  FROM flow_quants f
+  JOIN quants q ON f.quant_id = q.id
+  JOIN download_quants dq ON dq.quant_id = q.id
+  JOIN download_attributes da ON dq.download_attribute_id = da.id
+  GROUP BY f.flow_id, f.quant_id, f.value, q.name, q.unit, da.display_name, da.context_id
+) fi ON f_0.flow_id = fi.flow_id AND f_0.context_id = fi.context_id
+WHERE f_0.column_position = 0
+GROUP BY
+  f_0.flow_id,
+  f_0.context_id,
+  f_0.year,
+  f_0.name,
+  f_0.node_id,
+  f_1.name,
+  f_1.node_id,
+  f_1.node_type_name,
+  f_2.name,
+  f_2.node_id,
+  f_2.node_type_name,
+  f_3.name,
+  f_3.node_id,
+  f_3.node_type_name,
+  f_4.name,
+  f_4.node_id,
+  f_4.node_type_name,
+  f_5.name,
+  f_5.node_id,
+  f_5.node_type_name,
+  f_6.name,
+  f_6.node_id,
+  f_6.node_type_name,
+  f_7.name,
+  f_7.node_id,
+  f_7.node_type_name,
+  fi.attribute_type,
+  fi.attribute_id,
+  fi.name,
+  fi.name_with_unit,
+  fi.display_name;

--- a/db/views/flow_paths_mv_v02.sql
+++ b/db/views/flow_paths_mv_v02.sql
@@ -1,0 +1,32 @@
+SELECT
+  f.node_id,
+  n.geo_id,
+  CASE
+    WHEN cn.node_type_name = ANY (ARRAY['COUNTRY OF PRODUCTION'::text, 'BIOME'::text, 'LOGISTICS HUB'::text, 'STATE'::text])
+    THEN UPPER(n.name)
+    ELSE INITCAP(n.name)
+  END AS name,
+  cn.node_type_name,
+  cn.column_position,
+  f.id AS flow_id,
+  f.year,
+  f.context_id
+FROM (
+  SELECT
+    flows.id,
+    flows.year,
+    a.node_id,
+    a."position",
+    flows.context_id
+  FROM flows, LATERAL unnest(flows.path) WITH ORDINALITY a(node_id, "position")
+) f
+JOIN (
+  SELECT
+    cnt.context_id,
+    cnt.column_position,
+    cnt.node_type_id,
+    node_types.name AS node_type_name
+  FROM context_node_types cnt
+  JOIN node_types ON node_types.id = cnt.node_type_id
+) cn ON f."position" = (cn.column_position + 1) AND f.context_id = cn.context_id
+JOIN nodes n ON n.id = f.node_id;

--- a/lib/schema_revamp.rb
+++ b/lib/schema_revamp.rb
@@ -701,7 +701,6 @@ class SchemaRevamp
     refresh_materialized_view('recolor_by_attributes_mv')
     refresh_materialized_view('resize_by_attributes_mv')
     refresh_materialized_view('download_attributes_mv')
-    refresh_materialized_view('download_attributes_values_mv')
     refresh_materialized_view('flow_paths_mv')
     refresh_materialized_view('download_flows_mv')
     ActiveRecord::Base.connection.execute('COMMIT')

--- a/spec/factories/api/v3/api_v3_carto_layers.rb
+++ b/spec/factories/api/v3/api_v3_carto_layers.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :api_v3_carto_layer, class: 'Api::V3::CartoLayer' do
+    association :contextual_layer, factory: :api_v3_contextual_layer
+    sequence(:identifier) { |n| "carto layer #{n}" }
   end
 end

--- a/spec/factories/api/v3/api_v3_commodities.rb
+++ b/spec/factories/api/v3/api_v3_commodities.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :api_v3_commodity, class: 'Api::V3::Commodity' do
+    sequence(:name) { |n| "COMMODITY #{n}" }
   end
 end

--- a/spec/factories/api/v3/api_v3_context_node_type_properties.rb
+++ b/spec/factories/api/v3/api_v3_context_node_type_properties.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     column_group 0
     is_default false
     is_geo_column true
-    # is_choropleth_disabled false
+    is_choropleth_disabled false
   end
 end

--- a/spec/factories/api/v3/api_v3_context_node_type_properties.rb
+++ b/spec/factories/api/v3/api_v3_context_node_type_properties.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :api_v3_context_node_type_property, class: 'Api::V3::ContextNodeTypeProperty' do
+    association :context_node_type, factory: :api_v3_context_node_type
+    column_group 0
+    is_default false
+    is_geo_column true
+    # is_choropleth_disabled false
+  end
+end

--- a/spec/factories/api/v3/api_v3_context_node_types.rb
+++ b/spec/factories/api/v3/api_v3_context_node_types.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :api_v3_context_node_type, class: 'Api::V3::ContextNodeType' do
-  end
-
-  factory :api_v3_context_node_type_property, class: 'Api::V3::ContextNodeTypeProperty' do
+    association :context, factory: :api_v3_context
+    association :node_type, factory: :api_v3_node_type
+    column_position { rand(4) }
   end
 end

--- a/spec/factories/api/v3/api_v3_context_properties.rb
+++ b/spec/factories/api/v3/api_v3_context_properties.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :api_v3_context_property, class: 'Api::V3::ContextProperty' do
+    association :context, factory: :api_v3_context
+    default_basemap 'satellite'
+    is_disabled false
+    is_default false
+    is_subnational false
   end
 end

--- a/spec/factories/api/v3/api_v3_contexts.rb
+++ b/spec/factories/api/v3/api_v3_contexts.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :api_v3_context, class: 'Api::V3::Context' do
+    association :country, factory: :api_v3_country
+    association :commodity, factory: :api_v3_commodity
   end
 end

--- a/spec/factories/api/v3/api_v3_contextual_layers.rb
+++ b/spec/factories/api/v3/api_v3_contextual_layers.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :api_v3_contextual_layer, class: 'Api::V3::ContextualLayer' do
+    association :context, factory: :api_v3_context
+    title 'Title'
+    sequence(:identifier) { |n| "layer #{n}" }
+    sequence(:position) { |n| n }
+    is_default false
   end
 end

--- a/spec/factories/api/v3/api_v3_countries.rb
+++ b/spec/factories/api/v3/api_v3_countries.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :api_v3_country, class: 'Api::V3::Country' do
+    sequence(:iso2) { |n| ('AA'..'ZZ').to_a[n] }
+    name { iso2 + ' COUNTRY' }
   end
 end

--- a/spec/factories/api/v3/api_v3_country_properties.rb
+++ b/spec/factories/api/v3/api_v3_country_properties.rb
@@ -1,4 +1,8 @@
 FactoryBot.define do
   factory :api_v3_country_property, class: 'Api::V3::CountryProperty' do
+    association :country, factory: :api_v3_country
+    latitude -16.0
+    longitude -50.0
+    zoom 4
   end
 end

--- a/spec/factories/api/v3/api_v3_download_attributes.rb
+++ b/spec/factories/api/v3/api_v3_download_attributes.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :api_v3_download_attribute, class: 'Api::V3::DownloadAttribute' do
+    association :context, factory: :api_v3_context
+    sequence(:position) { |n| n }
+    sequence(:display_name) { |n| "attribute #{n}" }
   end
 end

--- a/spec/factories/api/v3/api_v3_ind_properties.rb
+++ b/spec/factories/api/v3/api_v3_ind_properties.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :api_v3_ind_property, class: 'Api::V3::IndProperty' do
+    association :ind, factory: :api_v3_ind
+    sequence(:display_name) { |n| "attribute #{n}" }
+    unit_type 'currency'
+    is_visible_on_place_profile false
+    is_visible_on_actor_profile false
+    is_temporal_on_place_profile false
+    is_temporal_on_actor_profile false
+  end
+end

--- a/spec/factories/api/v3/api_v3_inds.rb
+++ b/spec/factories/api/v3/api_v3_inds.rb
@@ -1,7 +1,4 @@
 FactoryBot.define do
   factory :api_v3_ind, class: 'Api::V3::Ind' do
   end
-
-  factory :api_v3_ind_property, class: 'Api::V3::IndProperty' do
-  end
 end

--- a/spec/factories/api/v3/api_v3_map_attribute_groups.rb
+++ b/spec/factories/api/v3/api_v3_map_attribute_groups.rb
@@ -1,4 +1,7 @@
 FactoryBot.define do
   factory :api_v3_map_attribute_group, class: 'Api::V3::MapAttributeGroup' do
+    association :context, factory: :api_v3_context
+    name 'Group'
+    sequence(:position) { |n| n }
   end
 end

--- a/spec/factories/api/v3/api_v3_map_attributes.rb
+++ b/spec/factories/api/v3/api_v3_map_attributes.rb
@@ -1,4 +1,10 @@
 FactoryBot.define do
   factory :api_v3_map_attribute, class: 'Api::V3::MapAttribute' do
+    association :map_attribute_group, factory: :api_v3_map_attribute_group
+    sequence(:position) { |n| n }
+    bucket_3 [33,66]
+    bucket_5 [20,40,60,80]
+    is_disabled false
+    is_default false
   end
 end

--- a/spec/factories/api/v3/api_v3_profiles.rb
+++ b/spec/factories/api/v3/api_v3_profiles.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :api_v3_profile, class: 'Api::V3::Profile' do
+    association :context_node_type, factory: :api_v3_context_node_type
+    name 'place'
   end
 end

--- a/spec/factories/api/v3/api_v3_qual_properties.rb
+++ b/spec/factories/api/v3/api_v3_qual_properties.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :api_v3_qual_property, class: 'Api::V3::QualProperty' do
+    association :qual, factory: :api_v3_qual
+    sequence(:display_name) { |n| "attribute #{n}" }
+    is_visible_on_place_profile false
+    is_visible_on_actor_profile false
+    is_temporal_on_place_profile false
+    is_temporal_on_actor_profile false
+  end
+end

--- a/spec/factories/api/v3/api_v3_quals.rb
+++ b/spec/factories/api/v3/api_v3_quals.rb
@@ -1,7 +1,4 @@
 FactoryBot.define do
   factory :api_v3_qual, class: 'Api::V3::Qual' do
   end
-
-  factory :api_v3_qual_property, class: 'Api::V3::QualProperty' do
-  end
 end

--- a/spec/factories/api/v3/api_v3_quant_properties.rb
+++ b/spec/factories/api/v3/api_v3_quant_properties.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :api_v3_quant_property, class: 'Api::V3::QuantProperty' do
+    association :quant, factory: :api_v3_quant
+    sequence(:display_name) { |n| "attribute #{n}" }
+    unit_type 'currency'
+    is_visible_on_place_profile false
+    is_visible_on_actor_profile false
+    is_temporal_on_place_profile false
+    is_temporal_on_actor_profile false
+  end
+end

--- a/spec/factories/api/v3/api_v3_quants.rb
+++ b/spec/factories/api/v3/api_v3_quants.rb
@@ -1,7 +1,4 @@
 FactoryBot.define do
   factory :api_v3_quant, class: 'Api::V3::Quant' do
   end
-
-  factory :api_v3_quant_property, class: 'Api::V3::QuantProperty' do
-  end
 end

--- a/spec/factories/api/v3/api_v3_recolor_by_attributes.rb
+++ b/spec/factories/api/v3/api_v3_recolor_by_attributes.rb
@@ -1,4 +1,11 @@
 FactoryBot.define do
   factory :api_v3_recolor_by_attribute, class: 'Api::V3::RecolorByAttribute' do
+    association :context, factory: :api_v3_context
+    sequence(:group_number) { |n| n }
+    sequence(:position) { |n| n }
+    legend_type 'percentual'
+    legend_color_theme 'blue-green'
+    is_disabled false
+    is_default false
   end
 end

--- a/spec/factories/api/v3/api_v3_resize_by_attributes.rb
+++ b/spec/factories/api/v3/api_v3_resize_by_attributes.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :api_v3_resize_by_attribute, class: 'Api::V3::ResizeByAttribute' do
+    association :context, factory: :api_v3_context
+    sequence(:group_number) { |n| n }
+    sequence(:position) { |n| n }
+    is_disabled false
+    is_default false
   end
 end

--- a/spec/models/api/v3/carto_layer_spec.rb
+++ b/spec/models/api/v3/carto_layer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::CartoLayer, type: :model do
+  include_context 'api v3 brazil contextual layers'
+
+  describe :validate do
+    let(:layer_without_contextual_layer) {
+      FactoryBot.build(:api_v3_carto_layer, contextual_layer: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_carto_layer,
+        contextual_layer: api_v3_contextual_layer_landcover,
+        identifier: 'landcover'
+      )
+    }
+    it 'fails when contextual layer missing' do
+      expect(layer_without_contextual_layer).to have(1).errors_on(:contextual_layer)
+    end
+    it 'fails when contextual_layer + identifier taken' do
+      expect(duplicate).to have(1).errors_on(:identifier)
+    end
+  end
+end

--- a/spec/models/api/v3/context_node_type_property_spec.rb
+++ b/spec/models/api/v3/context_node_type_property_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::ContextNodeTypeProperty, type: :model do
+  include_context 'api v3 brazil context node types'
+
+  describe :validate do
+    let(:property_without_context_node_type) {
+      FactoryBot.build(
+        :api_v3_context_node_type_property, context_node_type: nil
+      )
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_context_node_type_property,
+        context_node_type: api_v3_biome_context_node
+      )
+    }
+    it 'fails when context node type missing' do
+      expect(property_without_context_node_type).to have(1).
+        errors_on(:context_node_type)
+    end
+    it 'fails when context node type taken' do
+      expect(duplicate).to have(1).errors_on(:context_node_type)
+    end
+  end
+end

--- a/spec/models/api/v3/context_property_spec.rb
+++ b/spec/models/api/v3/context_property_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::ContextProperty, type: :model do
+  include_context 'api v3 brazil contexts'
+
+  describe :validate do
+    let(:property_without_context) {
+      FactoryBot.build(:api_v3_context_property, context: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(:api_v3_context_property, context: api_v3_context)
+    }
+    it 'fails when context missing' do
+      expect(property_without_context).to have(1).errors_on(:context)
+    end
+    it 'fails when context taken' do
+      expect(duplicate).to have(1).errors_on(:context)
+    end
+  end
+end

--- a/spec/models/api/v3/contextual_layer_spec.rb
+++ b/spec/models/api/v3/contextual_layer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::ContextualLayer, type: :model do
+  include_context 'api v3 brazil contextual layers'
+
+  describe :validate do
+    let(:layer_without_context) {
+      FactoryBot.build(:api_v3_contextual_layer, context: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_contextual_layer,
+        context: api_v3_context,
+        identifier: 'landcover'
+      )
+    }
+    it 'fails when context missing' do
+      expect(layer_without_context).to have(1).errors_on(:context)
+    end
+    it 'fails when context + identifier taken' do
+      expect(duplicate).to have(1).errors_on(:identifier)
+    end
+  end
+end

--- a/spec/models/api/v3/country_property_spec.rb
+++ b/spec/models/api/v3/country_property_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::CountryProperty, type: :model do
+  include_context 'api v3 brazil country'
+  include_context 'api v3 paraguay country'
+
+  describe :validate do
+    let(:property_without_country) {
+      FactoryBot.build(:api_v3_country_property, country: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(:api_v3_country_property, country: api_v3_brazil)
+    }
+    it 'fails when country missing' do
+      expect(property_without_country).to have(1).errors_on(:country)
+    end
+    it 'fails when country taken' do
+      expect(duplicate).to have(1).errors_on(:country)
+    end
+  end
+end

--- a/spec/models/api/v3/download_attribute_spec.rb
+++ b/spec/models/api/v3/download_attribute_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::DownloadAttribute, type: :model do
+  include_context 'api v3 brazil download attributes'
+
+  describe :validate do
+    let(:attribute_without_context) {
+      FactoryBot.build(:api_v3_download_attribute, context: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_download_attribute,
+        context: api_v3_context,
+        position: api_v3_deforestation_v2_download_attribute.position
+      )
+    }
+    it 'fails when context missing' do
+      expect(attribute_without_context).to have(1).errors_on(:context)
+    end
+    it 'fails when context + position taken' do
+      expect(duplicate).to have(1).errors_on(:position)
+    end
+  end
+end

--- a/spec/models/api/v3/ind_property_spec.rb
+++ b/spec/models/api/v3/ind_property_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::IndProperty, type: :model do
+  include_context 'api v3 inds'
+
+  describe :validate do
+    let(:property_without_ind) {
+      FactoryBot.build(:api_v3_ind_property, ind: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(:api_v3_ind_property, ind: api_v3_forest_500)
+    }
+    it 'fails when ind missing' do
+      expect(property_without_ind).to have(1).errors_on(:ind)
+    end
+    it 'fails when ind taken' do
+      expect(duplicate).to have(1).errors_on(:ind)
+    end
+  end
+end

--- a/spec/models/api/v3/map_attribute_group_spec.rb
+++ b/spec/models/api/v3/map_attribute_group_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::MapAttributeGroup, type: :model do
+  include_context 'api v3 brazil map attribute groups'
+
+  describe :validate do
+    let(:group_without_context) {
+      FactoryBot.build(:api_v3_map_attribute_group, context: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_map_attribute_group,
+        context: api_v3_context,
+        position: 1
+      )
+    }
+    it 'fails when context missing' do
+      expect(group_without_context).to have(1).errors_on(:context)
+    end
+    it 'fails when context + position taken' do
+      expect(duplicate).to have(1).errors_on(:position)
+    end
+  end
+end

--- a/spec/models/api/v3/map_attribute_spec.rb
+++ b/spec/models/api/v3/map_attribute_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::MapAttribute, type: :model do
+  include_context 'api v3 brazil map attributes'
+
+  describe :validate do
+    let(:layer_without_map_attribute_group) {
+      FactoryBot.build(:api_v3_map_attribute, map_attribute_group: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_map_attribute,
+        map_attribute_group: api_v3_map_attribute_group1,
+        position: api_v3_water_scarcity_map_attribute.position
+      )
+    }
+    it 'fails when map_attribute_group missing' do
+      expect(layer_without_map_attribute_group).to have(1).errors_on(:map_attribute_group)
+    end
+    it 'fails when map_attribute_group + position taken' do
+      expect(duplicate).to have(1).errors_on(:position)
+    end
+  end
+end

--- a/spec/models/api/v3/profile_spec.rb
+++ b/spec/models/api/v3/profile_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Profile, type: :model do
+  include_context 'api v3 brazil context node types'
+
+  describe :validate do
+    let(:profile_without_context_node_type) {
+      FactoryBot.build(
+        :api_v3_profile, context_node_type: nil
+      )
+    }
+    let(:duplicate) {
+      FactoryBot.create(
+        :api_v3_profile,
+        context_node_type: api_v3_exporter1_context_node,
+        name: 'actor'
+      )
+
+      FactoryBot.build(
+        :api_v3_profile,
+        context_node_type: api_v3_exporter1_context_node,
+        name: 'actor'
+      )
+    }
+    it 'fails when context node type missing' do
+      expect(profile_without_context_node_type).to have(1).
+        errors_on(:context_node_type)
+    end
+    it 'fails when context node type taken' do
+      expect(duplicate).to have(1).errors_on(:name)
+    end
+  end
+end

--- a/spec/models/api/v3/qual_property_spec.rb
+++ b/spec/models/api/v3/qual_property_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::QualProperty, type: :model do
+  include_context 'api v3 quals'
+
+  describe :validate do
+    let(:property_without_qual) {
+      FactoryBot.build(:api_v3_qual_property, qual: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(:api_v3_qual_property, qual: api_v3_state)
+    }
+    it 'fails when qual missing' do
+      expect(property_without_qual).to have(1).errors_on(:qual)
+    end
+    it 'fails when qual taken' do
+      expect(duplicate).to have(1).errors_on(:qual)
+    end
+  end
+end

--- a/spec/models/api/v3/quant_property_spec.rb
+++ b/spec/models/api/v3/quant_property_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::QuantProperty, type: :model do
+  include_context 'api v3 quants'
+
+  describe :validate do
+    let(:property_without_quant) {
+      FactoryBot.build(:api_v3_quant_property, quant: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(:api_v3_quant_property, quant: api_v3_area)
+    }
+    it 'fails when quant missing' do
+      expect(property_without_quant).to have(1).errors_on(:quant)
+    end
+    it 'fails when quant taken' do
+      expect(duplicate).to have(1).errors_on(:quant)
+    end
+  end
+end

--- a/spec/models/api/v3/recolor_by_attribute_spec.rb
+++ b/spec/models/api/v3/recolor_by_attribute_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::RecolorByAttribute, type: :model do
+  include_context 'api v3 brazil recolor by attributes'
+
+  describe :validate do
+    let(:attribute_without_context) {
+      FactoryBot.build(:api_v3_recolor_by_attribute, context: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_recolor_by_attribute,
+        context: api_v3_context,
+        group_number: api_v3_forest_500_recolor_by_attribute.group_number,
+        position: api_v3_forest_500_recolor_by_attribute.position
+      )
+    }
+    it 'fails when context missing' do
+      expect(attribute_without_context).to have(1).errors_on(:context)
+    end
+    it 'fails when context + group_number + position taken' do
+      expect(duplicate).to have(1).errors_on(:position)
+    end
+  end
+end

--- a/spec/models/api/v3/resize_by_attribute_spec.rb
+++ b/spec/models/api/v3/resize_by_attribute_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::ResizeByAttribute, type: :model do
+  include_context 'api v3 brazil resize by attributes'
+
+  describe :validate do
+    let(:attribute_without_context) {
+      FactoryBot.build(:api_v3_resize_by_attribute, context: nil)
+    }
+    let(:duplicate) {
+      FactoryBot.build(
+        :api_v3_resize_by_attribute,
+        context: api_v3_context,
+        group_number: api_v3_area_resize_by_attribute.group_number,
+        position: api_v3_area_resize_by_attribute.position
+      )
+    }
+    it 'fails when context missing' do
+      expect(attribute_without_context).to have(1).errors_on(:context)
+    end
+    it 'fails when context + group_number + position taken' do
+      expect(duplicate).to have(1).errors_on(:position)
+    end
+  end
+end

--- a/spec/responses/api/v3/contexts_spec.rb
+++ b/spec/responses/api/v3/contexts_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Get contexts', type: :request do
   include_context 'api v3 brazil soy nodes'
   include_context 'api v3 brazil download attributes'
-  include_context 'api v3 brazil resize by'
+  include_context 'api v3 brazil resize by attributes'
   include_context 'api v3 brazil recolor by attributes'
 
   describe 'GET /api/v3/contexts' do

--- a/spec/responses/api/v3/contexts_spec.rb
+++ b/spec/responses/api/v3/contexts_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Get contexts', type: :request do
   include_context 'api v3 brazil soy nodes'
   include_context 'api v3 brazil download attributes'
   include_context 'api v3 brazil resize by'
-  include_context 'api v3 brazil recolor by'
+  include_context 'api v3 brazil recolor by attributes'
 
   describe 'GET /api/v3/contexts' do
     before(:each) do

--- a/spec/support/contexts/api/v3/brazil/brazil_contextual_layers.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_contextual_layers.rb
@@ -1,7 +1,7 @@
 shared_context 'api v3 brazil contextual layers' do
   include_context 'api v3 brazil contexts'
 
-  let!(:api_v3_contextual_layer_water_scarcity) do
+  let!(:api_v3_contextual_layer_landcover) do
     contextual_layer = Api::V3::ContextualLayer.find_by_identifier('landcover')
     unless contextual_layer
       contextual_layer = FactoryBot.create(

--- a/spec/support/contexts/api/v3/brazil/brazil_map_attribute_groups.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_map_attribute_groups.rb
@@ -1,7 +1,5 @@
 shared_context 'api v3 brazil map attribute groups' do
   include_context 'api v3 brazil contexts'
-  include_context 'api v3 inds'
-  include_context 'api v3 quants'
 
   let!(:api_v3_map_attribute_group1) do
     Api::V3::MapAttributeGroup.where(

--- a/spec/support/contexts/api/v3/brazil/brazil_recolor_by_attributes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_recolor_by_attributes.rb
@@ -1,4 +1,4 @@
-shared_context 'api v3 brazil recolor by' do
+shared_context 'api v3 brazil recolor by attributes' do
   include_context 'api v3 brazil contexts'
   include_context 'api v3 quals'
   include_context 'api v3 inds'

--- a/spec/support/contexts/api/v3/brazil/brazil_resize_by_attributes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_resize_by_attributes.rb
@@ -1,4 +1,4 @@
-shared_context 'api v3 brazil resize by' do
+shared_context 'api v3 brazil resize by attributes' do
   include_context 'api v3 brazil contexts'
   include_context 'api v3 quants'
 


### PR DESCRIPTION
Adds admin interface for all "yellow tables" except for the ones related to charts. We're not using those tables at all at the moment and with potential changes in the next phase I thought it best not avoid possibly unnecessary functionality.

A few of the AR models share common functionality related to validating and managing relationships with  respective _inds / _quals / _quants tables; this applies to DownloadAttribute, MapAttribute, ResizeByAttribute and RecolorByAttribute.

The admin interface takes advantage of column comments in db/schema_comments.yml to display hints.

Where changes to the yellow tables require recalculation of materialized views there's an after_commit hook. One situation which is not handled is refreshing the materialized view which serves downloads; this needs to happen in a background job, and while that logic is ready it is commented out, because it still needs changes in respect to managing sidekiq queues - currently it would have been possible to start multiple refreshes at the same time. Ideally only one should be processed at a time and this capability will be added in a separate PR.