### PR TITLE
Fix issue preveting loading default context layer

### DIFF
--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -265,7 +265,7 @@ export function loadNodes() {
 
       // are all currently selected map dimensions available ?
       if (
-        selectedMapDimensions !== undefined &&
+        selectedMapDimensionsSet.length > 0 &&
         _.difference(selectedMapDimensionsSet, allAvailableMapDimensionsUids).length === 0
       ) {
         dispatch(setMapDimensions(selectedMapDimensions.concat([])));


### PR DESCRIPTION
This is another side effect of setting the default state for the tool reducer. in this case, we went from undefined to an array with two nulls. so we need to take that into account

Fixes the part of  https://github.com/Vizzuality/trase/issues/247 concerning the default choropleth layer changes, together with config changes on staging (already done)