### PR TITLE
Added top nodes endpoint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -21,6 +21,8 @@ engines:
         enabled: false
       IrresponsibleModule:
         enabled: false
+      InstanceVariableAssumption:
+        enabled: false
 
 ratings:
   paths:

--- a/app/controllers/api/v3/contexts_controller.rb
+++ b/app/controllers/api/v3/contexts_controller.rb
@@ -8,9 +8,12 @@ module Api
           includes(
             :country, :commodity, :context_property,
             readonly_recolor_by_attributes: :readonly_attribute,
-            readonly_resize_by_attributes: :readonly_attribute
+            readonly_resize_by_attributes: :readonly_attribute,
+            context_node_types: :node_type
           ).
-          all
+          references(:context_property).
+          where('NOT context_properties.is_disabled').
+          select(&:is_visible?)
 
         render json: @contexts, root: 'data',
                each_serializer: Api::V3::Contexts::ContextSerializer

--- a/app/controllers/api/v3/top_nodes_controller.rb
+++ b/app/controllers/api/v3/top_nodes_controller.rb
@@ -1,15 +1,27 @@
 module Api
   module V3
     class TopNodesController < ApiController
-      before_action :set_year
+      before_action :set_filter_params, only: :index
 
       def index
         ensure_required_param_present(:column_id)
         @result = Api::V3::TopNodes::ResponseBuilder.new(
-          @context, @year, params[:column_id], params[:n_nodes]
+          @context, @filter_params
         ).call
 
         render json: {data: @result}
+      end
+
+      private
+
+      def set_filter_params
+        year_start = params[:year_start] || @context.default_year
+        @filter_params = {
+          node_type_id: params[:column_id],
+          year_start: year_start,
+          year_end: params[:year_end] || year_start,
+          limit: params[:n_nodes]
+        }
       end
     end
   end

--- a/app/controllers/api/v3/top_nodes_controller.rb
+++ b/app/controllers/api/v3/top_nodes_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V3
+    class TopNodesController < ApiController
+      before_action :set_year
+
+      def index
+        ensure_required_param_present(:column_id)
+        @result = Api::V3::TopNodes::ResponseBuilder.new(
+          @context, @year, params[:column_id], params[:n_nodes]
+        ).call
+
+        render json: {data: @result}
+      end
+    end
+  end
+end

--- a/app/models/api/v3/context.rb
+++ b/app/models/api/v3/context.rb
@@ -19,6 +19,25 @@ module Api
       validates :country, presence: true
       validates :commodity, presence: true, uniqueness: {scope: :country}
 
+      def is_visible?
+        country.present? &&
+        commodity.present? &&
+        country_context_node_type.present? &&
+        exporter_context_node_type.present?
+      end
+
+      def country_context_node_type
+        context_node_types.find do |cnt|
+          cnt.node_type.name == NodeTypeName::COUNTRY
+        end
+      end
+
+      def exporter_context_node_type
+        context_node_types.find do |cnt|
+          cnt.node_type.name == NodeTypeName::EXPORTER
+        end
+      end
+
       def self.select_options
         Api::V3::Context.includes(:country, :commodity).all.map do |ctx|
           [[ctx.country&.name, ctx.commodity&.name].join(' / '), ctx.id]

--- a/app/serializers/api/v3/contexts/context_serializer.rb
+++ b/app/serializers/api/v3/contexts/context_serializer.rb
@@ -52,6 +52,13 @@ module Api
             []
           end
         end
+
+        attribute :world_map do
+          {
+            map_column_id: object.country_context_node_type&.node_type_id,
+            list_column_id: object.exporter_context_node_type&.node_type_id
+          }
+        end
       end
     end
   end

--- a/app/services/api/v3/actor_node/basic_attributes.rb
+++ b/app/services/api/v3/actor_node/basic_attributes.rb
@@ -50,13 +50,18 @@ module Api
 
         def initialize_top_nodes
           destination_top_nodes = Api::V3::Profiles::TopNodesList.new(
-            @context, @year, @node,
+            @context,
+            @node,
+            year_start: @year,
+            year_end: @year,
             other_node_type_name: NodeTypeName::COUNTRY,
             place_inds: @place_inds,
             place_quants: @place_quants
           )
           @main_destination = destination_top_nodes.sorted_list(
-            @volume_attribute, false, 1
+            @volume_attribute,
+            include_domestic_consumption: false,
+            limit: 1
           ).first
         end
 

--- a/app/services/api/v3/actor_node/sustainability_table.rb
+++ b/app/services/api/v3/actor_node/sustainability_table.rb
@@ -34,9 +34,18 @@ module Api
         end
 
         def sustainability_for_group(name, node_type, include_totals)
-          top_nodes_list = Api::V3::Profiles::TopNodesList.
-            new(@context, @year, @node, other_node_type_name: node_type)
-          top_nodes = top_nodes_list.sorted_list(@volume_attribute, false, 10)
+          top_nodes_list = Api::V3::Profiles::TopNodesList.new(
+            @context,
+            @node,
+            year_start: @year,
+            year_end: @year,
+            other_node_type_name: node_type
+          )
+          top_nodes = top_nodes_list.sorted_list(
+            @volume_attribute,
+            include_domestic_consumption: false,
+            limit: 10
+          )
           group_totals_hash = {}
           rows = top_nodes.map do |node|
             data_row(group_totals_hash, node_type, node)

--- a/app/services/api/v3/actor_node/top_nodes_summary.rb
+++ b/app/services/api/v3/actor_node/top_nodes_summary.rb
@@ -51,11 +51,24 @@ module Api
         end
 
         def initialize_top_nodes(node_type, attribute)
-          top_nodes_list = Api::V3::Profiles::TopNodesList.
-            new(@context, @year, @node, other_node_type_name: node_type)
-          @top_nodes = top_nodes_list.sorted_list(attribute, false, nil)
+          top_nodes_list = Api::V3::Profiles::TopNodesList.new(
+            @context,
+            @node,
+            year_start: @year,
+            year_end: @year,
+            other_node_type_name: node_type
+          )
+          @top_nodes = top_nodes_list.sorted_list(
+            attribute,
+            include_domestic_consumption: false,
+            limit: nil
+          )
           @top_node_values_by_year = top_nodes_list.
-            unsorted_list_grouped_by_year(attribute, false, nil).all
+            unsorted_list_grouped_by_year(
+              attribute,
+              include_domestic_consumption: false,
+              limit: nil
+            ).all
         end
 
         def nodes_by_year_summary_for_indicator(node_type, years, buckets, attribute)

--- a/app/services/api/v3/place_node/basic_attributes.rb
+++ b/app/services/api/v3/place_node/basic_attributes.rb
@@ -118,19 +118,32 @@ of #{@soy_area_formatted} #{@soy_area_unit} of land."
 
         def initialize_top_nodes
           exporter_top_nodes = Api::V3::Profiles::TopNodesList.new(
-            @context, @year, @node,
+            @context,
+            @node,
+            year_start: @year,
+            year_end: @year,
             other_node_type_name: NodeTypeName::EXPORTER
           )
           consumer_top_nodes = Api::V3::Profiles::TopNodesList.new(
-            @context, @year, @node,
+            @context,
+            @node,
+            year_start: @year,
+            year_end: @year,
             other_node_type_name: NodeTypeName::COUNTRY
           )
           @top_exporters = exporter_top_nodes.sorted_list(
-            @volume_attribute, false, 10
+            @volume_attribute,
+            include_domestic_consumption: false,
+            limit: 10
           )
-          @total_exports = exporter_top_nodes.total(@volume_attribute, false)
+          @total_exports = exporter_top_nodes.total(
+            @volume_attribute,
+            include_domestic_consumption: false
+          )
           @top_consumers = consumer_top_nodes.sorted_list(
-            @volume_attribute, true, 10
+            @volume_attribute,
+            include_domestic_consumption: true,
+            limit: 10
           )
         end
 

--- a/app/services/api/v3/place_node/mini_sankey.rb
+++ b/app/services/api/v3/place_node/mini_sankey.rb
@@ -14,8 +14,16 @@ module Api
           initialize_top_nodes(node_type, include_domestic_consumption)
 
           all_nodes_for_place = Api::V3::Profiles::TopNodesList.new(
-            @context, @year, @node, other_node_type_name: node_type
-          ).unsorted_list(@volume_attribute, include_domestic_consumption, nil)
+            @context,
+            @node,
+            year_start: @year,
+            year_end: @year,
+            other_node_type_name: node_type
+          ).unsorted_list(
+            @volume_attribute,
+            include_domestic_consumption: include_domestic_consumption,
+            limit: nil
+          )
 
           {
             name: @node.name,
@@ -39,12 +47,21 @@ module Api
 
         def initialize_top_nodes(node_type, include_domestic_consumption)
           top_nodes_list = Api::V3::Profiles::TopNodesList.new(
-            @context, @year, @node, other_node_type_name: node_type
+            @context,
+            @node,
+            year_start: @year,
+            year_end: @year,
+            other_node_type_name: node_type
           )
           @top_nodes = top_nodes_list.sorted_list(
-            @volume_attribute, include_domestic_consumption, 10
+            @volume_attribute,
+            include_domestic_consumption: include_domestic_consumption,
+            limit: 10
           )
-          @all_nodes_total = top_nodes_list.total(@volume_attribute, include_domestic_consumption)
+          @all_nodes_total = top_nodes_list.total(
+            @volume_attribute,
+            include_domestic_consumption: include_domestic_consumption
+          )
         end
       end
     end

--- a/app/services/api/v3/top_nodes/response_builder.rb
+++ b/app/services/api/v3/top_nodes/response_builder.rb
@@ -1,0 +1,45 @@
+module Api
+  module V3
+    module TopNodes
+      class ResponseBuilder
+        attr_reader :top_nodes
+
+        def initialize(context, year, node_type_id, limit = nil)
+          @context = context
+          @year = year
+          @node_type_id = node_type_id
+          @limit = limit || 10
+          @volume_attribute = Dictionary::Quant.instance.get('Volume')
+          raise 'Quant Volume not found' unless @volume_attribute.present?
+        end
+
+        def call
+          top_nodes_list = Api::V3::Profiles::TopNodesForContextList.new(
+            @context,
+            @year,
+            other_node_type_id: @node_type_id
+          )
+          @top_nodes = top_nodes_list.
+            sorted_list(@volume_attribute, false, @limit)
+          @all_nodes_total = top_nodes_list.total(
+            @volume_attribute, false
+          )
+
+          {
+            context_id: @context.id,
+            indicator: @volume_attribute.display_name,
+            unit: @volume_attribute.unit,
+            targetNodes: @top_nodes.map do |top_node|
+              {
+                id: top_node['node_id'],
+                name: top_node['name'],
+                height: top_node['value'] / @all_nodes_total,
+                value: top_node['value']
+              }
+            end
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/top_nodes/response_builder.rb
+++ b/app/services/api/v3/top_nodes/response_builder.rb
@@ -33,6 +33,7 @@ module Api
               {
                 id: top_node['node_id'],
                 name: top_node['name'],
+                geo_id: top_node['geo_id'],
                 height: top_node['value'] / @all_nodes_total,
                 value: top_node['value']
               }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
         end
         resources :download, only: [:index], as: :download
         resources :linked_nodes, only: [:index], controller: :linked_nodes
+        resources :top_nodes, only: [:index]
       end
       resources :newsletter_subscriptions, only: [:create]
     end

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -439,6 +439,15 @@ definitions:
             type: number
           zoom:
             type: integer
+      worldMap:
+        type: object
+        properties:
+          mapColumnId:
+            type: integer
+            description: 'Id of column to use as parameter to top nodes for top destination countries (world map)'
+          listColumnId:
+            type: integer
+            description: 'Id of column to use as parameter to top nodes for top exporters (world map - list)'
       recolorBy:
         type: array
         items:

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -359,6 +359,46 @@ paths:
       responses:
         '200':
           description: successful operation
+  '/context/{context_id}/top_nodes':
+    get:
+      tags:
+        - flow
+      summary: 'Top nodes of given node type per context'
+      description: ''
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: context_id
+          in: path
+          description: ''
+          required: true
+          type: integer
+        - name: column_id
+          in: query
+          description: Node type id
+          required: true
+          type: integer
+        - name: year
+          in: query
+          description: Year
+          required: false
+          type: integer
+        - name: n_nodes
+          in: query
+          description: Number of top nodes (defaults to 10)
+          required: false
+          type: integer
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                $ref: '#/definitions/TopNodes'
 definitions:
   Context:
     type: object
@@ -1082,3 +1122,30 @@ definitions:
                       type: array
                       items:
                         type: number
+  TopNodes:
+    type: object
+    properties:
+      data:
+        type: object
+        properties:
+          context_id:
+            type: integer
+          indicator:
+            type: string
+            description: 'e.g. Trade volume'
+          unit:
+            type: string
+            description: 'e.g. Tn'
+          target_nods:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                height:
+                  type: number
+                value:
+                  type: number

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -380,9 +380,14 @@ paths:
           description: Node type id
           required: true
           type: integer
-        - name: year
+        - name: year_start
           in: query
-          description: Year
+          description: Start year (defaults to context default year)
+          required: false
+          type: integer
+        - name: year_end
+          in: query
+          description: End year (defaults to start year)
           required: false
           type: integer
         - name: n_nodes

--- a/lib/api/v3/profiles/top_nodes_for_context_list.rb
+++ b/lib/api/v3/profiles/top_nodes_for_context_list.rb
@@ -1,0 +1,129 @@
+module Api
+  module V3
+    module Profiles
+      class TopNodesForContextList
+        def initialize(context, year, data)
+          @context = context
+          @year = year
+          @other_node_index =
+            if data[:other_node_type_name]
+              Api::V3::NodeType.node_index_for_name(
+                @context, data[:other_node_type_name]
+              )
+            elsif data[:other_node_type_id]
+              Api::V3::NodeType.node_index_for_id(
+                @context, data[:other_node_type_id]
+              )
+            end
+        end
+
+        def sorted_list(
+          attribute, include_domestic_consumption = true, limit = 10
+        )
+          result = query(attribute, include_domestic_consumption).
+            order('value DESC')
+          result = result.limit(limit) if limit.present?
+          result
+        end
+
+        def unsorted_list(
+          attribute, include_domestic_consumption = true, limit = 10
+        )
+          result = query(attribute, include_domestic_consumption)
+          result = result.limit(limit) if limit.present?
+          result
+        end
+
+        def unsorted_list_grouped_by_year(
+          attribute, include_domestic_consumption = true, limit = 10
+        )
+          result = query_grouped_by_year(
+            attribute, include_domestic_consumption
+          )
+          result = result.limit(limit) if limit.present?
+          result
+        end
+
+        def total(attribute, include_domestic_consumption = true)
+          query(attribute, include_domestic_consumption).
+            except(:group).except(:select).sum(:value)
+        end
+
+        private
+
+        # attribute is either a Quant or an Ind
+        def query_all_years(attribute, include_domestic_consumption = true)
+          attribute_type = attribute.class.name.demodulize.downcase
+          value_table = 'flow_' + attribute_type + 's'
+          query = Api::V3::Flow.select(select_clause(value_table)).
+            joins("JOIN #{value_table} ON flows.id = #{value_table}.flow_id").
+            joins(nodes_join_clause).
+            joins('JOIN node_properties ON nodes.id = node_properties.node_id').
+            where(context_id: @context.id).
+            where('NOT nodes.is_unknown').
+            where("#{value_table}.#{attribute_type}_id" => attribute.id)
+
+          unless include_domestic_consumption
+            query = query.where('NOT node_properties.is_domestic_consumption')
+          end
+          query.group(group_clause)
+        end
+
+        def query_grouped_by_year(
+          attribute, include_domestic_consumption = true
+        )
+          query_all_years(attribute, include_domestic_consumption).
+            select(:year).
+            group(:year)
+        end
+
+        def query(attribute, include_domestic_consumption = true)
+          query_all_years(attribute, include_domestic_consumption).
+            where(year: @year)
+        end
+
+        def select_clause(value_table)
+          ActiveRecord::Base.send(
+            :sanitize_sql_array,
+            [
+              [
+                'flows.path[?] AS node_id',
+                "SUM(#{value_table}.value)::DOUBLE PRECISION AS value",
+                'nodes.name AS name',
+                "node_properties.is_domestic_consumption AS \
+is_domestic_consumption",
+                'nodes.geo_id'
+              ].join(', '),
+              @other_node_index
+            ]
+          )
+        end
+
+        def nodes_join_clause
+          ActiveRecord::Base.send(
+            :sanitize_sql_array,
+            [
+              'JOIN nodes ON nodes.id = flows.path[?]',
+              @other_node_index
+            ]
+          )
+        end
+
+        def group_clause
+          ActiveRecord::Base.send(
+            :sanitize_sql_array,
+            [
+              [
+                'flows.path[?]',
+                'nodes.name',
+                'nodes.geo_id',
+                'node_properties.is_domestic_consumption'
+              ].join(', '),
+              @other_node_index
+            ]
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/api/v3/profiles/top_nodes_for_context_list.rb
+++ b/lib/api/v3/profiles/top_nodes_for_context_list.rb
@@ -2,61 +2,70 @@ module Api
   module V3
     module Profiles
       class TopNodesForContextList
-        def initialize(context, year, data)
+        DEFAULT_LIMIT = 10
+
+        def initialize(context, data)
           @context = context
-          @year = year
+          @year_start = data[:year_start]
+          @year_end = data[:year_end] || @year_start
           @other_node_index =
-            if data[:other_node_type_name]
+            if (other_node_type_name = data[:other_node_type_name])
               Api::V3::NodeType.node_index_for_name(
-                @context, data[:other_node_type_name]
+                @context, other_node_type_name
               )
-            elsif data[:other_node_type_id]
+            elsif (other_node_type_id = data[:other_node_type_id])
               Api::V3::NodeType.node_index_for_id(
-                @context, data[:other_node_type_id]
+                @context, other_node_type_id
               )
             end
         end
 
-        def sorted_list(
-          attribute, include_domestic_consumption = true, limit = 10
-        )
-          result = query(attribute, include_domestic_consumption).
-            order('value DESC')
+        def sorted_list(attribute, options)
+          limit = limit_from_options(options)
+          result = query(attribute, options).order('value DESC')
           result = result.limit(limit) if limit.present?
           result
         end
 
-        def unsorted_list(
-          attribute, include_domestic_consumption = true, limit = 10
-        )
-          result = query(attribute, include_domestic_consumption)
+        def unsorted_list(attribute, options)
+          limit = limit_from_options(options)
+          result = query(attribute, options)
           result = result.limit(limit) if limit.present?
           result
         end
 
-        def unsorted_list_grouped_by_year(
-          attribute, include_domestic_consumption = true, limit = 10
-        )
+        def unsorted_list_grouped_by_year(attribute, options)
+          limit = limit_from_options(options)
           result = query_grouped_by_year(
-            attribute, include_domestic_consumption
+            attribute, options
           )
           result = result.limit(limit) if limit.present?
           result
         end
 
-        def total(attribute, include_domestic_consumption = true)
-          query(attribute, include_domestic_consumption).
+        def total(attribute, options)
+          query(attribute, options).
             except(:group).except(:select).sum(:value)
         end
 
         private
 
+        def limit_from_options(options)
+          if options.key?(:limit)
+            options.delete(:limit)
+          else
+            DEFAULT_LIMIT
+          end
+        end
+
         # attribute is either a Quant or an Ind
-        def query_all_years(attribute, include_domestic_consumption = true)
+        def query_all_years(attribute, options = {})
+          include_domestic_consumption = options.
+            delete(:include_domestic_consumption)
           attribute_type = attribute.class.name.demodulize.downcase
           value_table = 'flow_' + attribute_type + 's'
           query = Api::V3::Flow.select(select_clause(value_table)).
-            joins("JOIN #{value_table} ON flows.id = #{value_table}.flow_id").
+            joins(value_table_join_clause(value_table)).
             joins(nodes_join_clause).
             joins('JOIN node_properties ON nodes.id = node_properties.node_id').
             where(context_id: @context.id).
@@ -69,17 +78,15 @@ module Api
           query.group(group_clause)
         end
 
-        def query_grouped_by_year(
-          attribute, include_domestic_consumption = true
-        )
-          query_all_years(attribute, include_domestic_consumption).
+        def query_grouped_by_year(attribute, options)
+          query_all_years(attribute, options).
             select(:year).
             group(:year)
         end
 
-        def query(attribute, include_domestic_consumption = true)
-          query_all_years(attribute, include_domestic_consumption).
-            where(year: @year)
+        def query(attribute, options)
+          query_all_years(attribute, options).
+            where(year: (@year_start..@year_end))
         end
 
         def select_clause(value_table)
@@ -107,6 +114,10 @@ is_domestic_consumption",
               @other_node_index
             ]
           )
+        end
+
+        def value_table_join_clause(value_table)
+          "JOIN #{value_table} ON flows.id = #{value_table}.flow_id"
         end
 
         def group_clause

--- a/lib/api/v3/profiles/top_nodes_list.rb
+++ b/lib/api/v3/profiles/top_nodes_list.rb
@@ -2,8 +2,8 @@ module Api
   module V3
     module Profiles
       class TopNodesList < TopNodesForContextList
-        def initialize(context, year, node, data)
-          super(context, year, data)
+        def initialize(context, node, data)
+          super(context, data)
           @node = node
           @self_node_index = Api::V3::NodeType.node_index_for_id(
             @context, @node.node_type_id
@@ -13,8 +13,8 @@ module Api
         private
 
         # attribute is either a Quant or an Ind
-        def query_all_years(attribute, include_domestic_consumption = true)
-          super(attribute, include_domestic_consumption).
+        def query_all_years(attribute, options)
+          super(attribute, options).
             where('? = path[?]', @node.id, @self_node_index)
         end
       end

--- a/lib/api/v3/profiles/top_nodes_list.rb
+++ b/lib/api/v3/profiles/top_nodes_list.rb
@@ -1,113 +1,21 @@
 module Api
   module V3
     module Profiles
-      class TopNodesList
+      class TopNodesList < TopNodesForContextList
         def initialize(context, year, node, data)
-          @context = context
-          @year = year
+          super(context, year, data)
           @node = node
           @self_node_index = Api::V3::NodeType.node_index_for_id(
             @context, @node.node_type_id
           )
-          @other_node_index = Api::V3::NodeType.node_index_for_name(
-            @context, data[:other_node_type_name]
-          )
-        end
-
-        def sorted_list(attribute, include_domestic_consumption = true, limit = 10)
-          result = query(attribute, include_domestic_consumption).order('value DESC')
-          result = result.limit(limit) if limit.present?
-          result
-        end
-
-        def unsorted_list(attribute, include_domestic_consumption = true, limit = 10)
-          result = query(attribute, include_domestic_consumption)
-          result = result.limit(limit) if limit.present?
-          result
-        end
-
-        def unsorted_list_grouped_by_year(attribute, include_domestic_consumption = true, limit = 10)
-          result = query_grouped_by_year(attribute, include_domestic_consumption)
-          result = result.limit(limit) if limit.present?
-          result
-        end
-
-        def total(attribute, include_domestic_consumption = true)
-          query(attribute, include_domestic_consumption).
-            except(:group).except(:select).sum(:value)
         end
 
         private
 
         # attribute is either a Quant or an Ind
         def query_all_years(attribute, include_domestic_consumption = true)
-          attribute_type = attribute.class.name.demodulize.downcase
-          value_table = 'flow_' + attribute_type + 's'
-          query = Api::V3::Flow.select(select_clause(value_table)).
-            joins("JOIN #{value_table} ON flows.id = #{value_table}.flow_id").
-            joins(nodes_join_clause).
-            joins('JOIN node_properties ON nodes.id = node_properties.node_id').
-            where(context_id: @context.id).
-            where('NOT nodes.is_unknown').
-            where('? = path[?]', @node.id, @self_node_index).
-            where("#{value_table}.#{attribute_type}_id" => attribute.id)
-
-          unless include_domestic_consumption
-            query = query.where('NOT node_properties.is_domestic_consumption')
-          end
-          query.group(group_clause)
-        end
-
-        def query_grouped_by_year(attribute, include_domestic_consumption = true)
-          query_all_years(attribute, include_domestic_consumption).
-            select(:year).
-            group(:year)
-        end
-
-        def query(attribute, include_domestic_consumption = true)
-          query_all_years(attribute, include_domestic_consumption).
-            where(year: @year)
-        end
-
-        def select_clause(value_table)
-          ActiveRecord::Base.send(
-            :sanitize_sql_array,
-            [
-              [
-                'flows.path[?] AS node_id',
-                "SUM(#{value_table}.value)::DOUBLE PRECISION AS value",
-                'nodes.name AS name',
-                'node_properties.is_domestic_consumption AS is_domestic_consumption',
-                'nodes.geo_id'
-              ].join(', '),
-              @other_node_index
-            ]
-          )
-        end
-
-        def nodes_join_clause
-          ActiveRecord::Base.send(
-            :sanitize_sql_array,
-            [
-              'JOIN nodes ON nodes.id = flows.path[?]',
-              @other_node_index
-            ]
-          )
-        end
-
-        def group_clause
-          ActiveRecord::Base.send(
-            :sanitize_sql_array,
-            [
-              [
-                'flows.path[?]',
-                'nodes.name',
-                'nodes.geo_id',
-                'node_properties.is_domestic_consumption'
-              ].join(', '),
-              @other_node_index
-            ]
-          )
+          super(attribute, include_domestic_consumption).
+            where('? = path[?]', @node.id, @self_node_index)
         end
       end
     end

--- a/lib/tasks/gold_master.rake
+++ b/lib/tasks/gold_master.rake
@@ -33,10 +33,7 @@ namespace :gold_master do
       `sort #{gold_master_file} > #{gold_master_file_sorted}`
       actual_file_sorted = actual_file + '.sorted'
       `sort #{actual_file} > #{actual_file_sorted}`
-      diff_cmd = "diff #{gold_master_file_sorted} #{actual_file_sorted} > #{actual_file}.diff"
-      puts diff_cmd
-      diff = `#{diff_cmd}`
-      [diff.presence].compact
+      "diff #{gold_master_file_sorted} #{actual_file_sorted} > #{actual_file}.diff"
     end
   end
 
@@ -53,10 +50,7 @@ namespace :gold_master do
       File.open(actual_file_sorted, 'w') do |f|
         f << JSON.pretty_generate(actual, indent: '  ')
       end
-      diff_cmd = "diff #{gold_master_file_sorted} #{actual_file_sorted} > #{actual_file}.diff"
-      puts diff_cmd
-      diff = `#{diff_cmd}`
-      [diff.presence].compact
+      "diff #{gold_master_file_sorted} #{actual_file_sorted} > #{actual_file}.diff"
     end
   end
 
@@ -76,13 +70,17 @@ namespace :gold_master do
         puts gold_master_file
         downloaded_file = actual_file(endpoint, query, format, compressed)
         actual_file = actual_file(endpoint, query, format)
+        puts actual_url(endpoint, query)
         `curl -g "#{actual_url(endpoint, query)}" > #{downloaded_file}`
         if endpoint['compressed']
           Zipfile.extract_data_file_to_path(downloaded_file, actual_file, format)
         end
-        diff = yield(gold_master_file, actual_file)
-        if diff.any?
-          puts "DIFFERENCES DETECTED, PLEASE INSPECT #{actual_file}.diff"
+        diff_cmd = yield(gold_master_file, actual_file)
+        puts diff_cmd
+        `#{diff_cmd}`
+        diff_file = "#{actual_file}.diff"
+        if File.size(diff_file).positive?
+          puts "DIFFERENCES DETECTED, PLEASE INSPECT #{diff_file}"
         else
           puts 'SUCCESS'
         end

--- a/spec/responses/api/v3/top_nodes_spec.rb
+++ b/spec/responses/api/v3/top_nodes_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'Top nodes', type: :request do
+  include_context 'api v3 brazil flows quants'
+
+  describe 'GET /api/v3/contexts/:context_id/top_nodes' do
+    it 'has the correct response structure' do
+      get "/api/v3/contexts/#{api_v3_context.id}/top_nodes?year=2015&column_id=#{api_v3_exporter_node_type.id}"
+
+      expect(@response.status).to eq 200
+      expect(@response).to match_response_schema('v3_top_nodes')
+    end
+  end
+end

--- a/spec/responses/api/v3/top_nodes_spec.rb
+++ b/spec/responses/api/v3/top_nodes_spec.rb
@@ -4,7 +4,14 @@ RSpec.describe 'Top nodes', type: :request do
   include_context 'api v3 brazil flows quants'
 
   describe 'GET /api/v3/contexts/:context_id/top_nodes' do
-    it 'has the correct response structure' do
+    it 'has the correct response structure for countries' do
+      get "/api/v3/contexts/#{api_v3_context.id}/top_nodes?year=2015&column_id=#{api_v3_country_node_type.id}"
+
+      expect(@response.status).to eq 200
+      expect(@response).to match_response_schema('v3_top_nodes')
+    end
+
+    it 'has the correct response structure for exporters' do
       get "/api/v3/contexts/#{api_v3_context.id}/top_nodes?year=2015&column_id=#{api_v3_exporter_node_type.id}"
 
       expect(@response.status).to eq 200

--- a/spec/services/api/v3/top_nodes/response_builder_spec.rb
+++ b/spec/services/api/v3/top_nodes/response_builder_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Api::V3::TopNodes::ResponseBuilder do
     it 'should return top exporters' do
       builder = Api::V3::TopNodes::ResponseBuilder.new(
         api_v3_context,
-        2015,
-        api_v3_exporter_node_type.id
+        node_type_id: api_v3_exporter_node_type.id,
+        year_start: 2015,
+        year_end: 2015
       )
 
       builder.call
@@ -20,8 +21,9 @@ RSpec.describe Api::V3::TopNodes::ResponseBuilder do
     it 'should return top countries' do
       builder = Api::V3::TopNodes::ResponseBuilder.new(
         api_v3_context,
-        2015,
-        api_v3_country_node_type.id
+        node_type_id: api_v3_country_node_type.id,
+        year_start: 2015,
+        year_end: 2015
       )
 
       builder.call

--- a/spec/services/api/v3/top_nodes/response_builder_spec.rb
+++ b/spec/services/api/v3/top_nodes/response_builder_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::TopNodes::ResponseBuilder do
+  before(:all) { Api::V3::Flow.delete_all } # db clearing doesn't seem to work
+  include_context 'api v3 brazil flows quants'
+
+  describe :top_nodes do
+    it 'should return top exporters' do
+      builder = Api::V3::TopNodes::ResponseBuilder.new(
+        api_v3_context,
+        2015,
+        api_v3_exporter_node_type.id
+      )
+
+      builder.call
+
+      expect(builder.top_nodes.first['node_id']).to eq(api_v3_exporter1_node.id)
+    end
+
+    it 'should return top countries' do
+      builder = Api::V3::TopNodes::ResponseBuilder.new(
+        api_v3_context,
+        2015,
+        api_v3_country_node_type.id
+      )
+
+      builder.call
+
+      expect(builder.top_nodes.first['node_id']).to eq(api_v3_country_of_destination1_node.id)
+    end
+  end
+end

--- a/spec/support/gold_master_urls.yml
+++ b/spec/support/gold_master_urls.yml
@@ -63,7 +63,7 @@ json:
     name: get_map_base_data
     version: v2
     v3_ready: true
-    v3_url: /api/v3/contexts/1/map_groups
+    v3_url: /api/v3/contexts/1/map_layers
     queries:
       - params: context_id=1
         name: brazil_soy
@@ -71,7 +71,7 @@ json:
     name: get_map_base_data
     version: v2
     v3_ready: true
-    v3_url: /api/v3/contexts/2/map_groups
+    v3_url: /api/v3/contexts/2/map_layers
     queries:
       - params: context_id=2
         name: paraguay_soy

--- a/spec/support/schemas/v3_contexts.json
+++ b/spec/support/schemas/v3_contexts.json
@@ -120,6 +120,24 @@
             ],
             "type": "object"
           },
+          "worldMap": {
+            "additionalProperties": false,
+            "id": "/properties/data/items/properties/worldMap",
+            "properties": {
+              "mapColumnId": {
+                "id": "/properties/data/items/properties/worldMap/properties/mapColumnId",
+                "type": "integer"
+              },
+              "listColumnId": {
+                "id": "/properties/data/items/properties/worldMap/properties/listColumnId",
+                "type": "integer"
+              }
+            },
+            "required": [
+              "mapColumnId",
+              "listColumnId"
+            ]
+          },
           "recolorBy": {
             "id": "/properties/data/items/properties/recolorBy",
             "items": {
@@ -274,6 +292,7 @@
           }
         },
         "required": [
+          "worldMap",
           "recolorBy",
           "map",
           "commodityId",

--- a/spec/support/schemas/v3_top_nodes.json
+++ b/spec/support/schemas/v3_top_nodes.json
@@ -52,7 +52,7 @@
                 "description": "An explanation about the purpose of this instance.",
                 "default": 0,
                 "examples": [
-                  440
+                  684
                 ]
               },
               "name": {
@@ -62,7 +62,17 @@
                 "description": "An explanation about the purpose of this instance.",
                 "default": "",
                 "examples": [
-                  "BUNGE"
+                  "CHINA"
+                ]
+              },
+              "geo_id": {
+                "$id": "/properties/data/properties/targetNodes/items/properties/geo_id",
+                "type": ["string", "null"],
+                "title": "The Geo_id Schema",
+                "description": "An explanation about the purpose of this instance.",
+                "default": "",
+                "examples": [
+                  "CN"
                 ]
               },
               "height": {
@@ -72,7 +82,7 @@
                 "description": "An explanation about the purpose of this instance.",
                 "default": 0,
                 "examples": [
-                  0.16515207290649414
+                  0.42445269227027893
                 ]
               },
               "value": {
@@ -82,7 +92,7 @@
                 "description": "An explanation about the purpose of this instance.",
                 "default": 0,
                 "examples": [
-                  11548229
+                  41375772
                 ]
               }
             }

--- a/spec/support/schemas/v3_top_nodes.json
+++ b/spec/support/schemas/v3_top_nodes.json
@@ -1,0 +1,94 @@
+{
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "properties": {
+    "data": {
+      "$id": "/properties/data",
+      "type": "object",
+      "properties": {
+        "context_id": {
+          "$id": "/properties/data/properties/context_id",
+          "type": "integer",
+          "title": "The Context_id Schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": 0,
+          "examples": [
+            1
+          ]
+        },
+        "indicator": {
+          "$id": "/properties/data/properties/indicator",
+          "type": "string",
+          "title": "The Indicator Schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": "",
+          "examples": [
+            "Trade volume"
+          ]
+        },
+        "unit": {
+          "$id": "/properties/data/properties/unit",
+          "type": "string",
+          "title": "The Unit Schema",
+          "description": "An explanation about the purpose of this instance.",
+          "default": "",
+          "examples": [
+            "Tn"
+          ]
+        },
+        "targetNodes": {
+          "$id": "/properties/data/properties/targetNodes",
+          "type": "array",
+          "items": {
+            "$id": "/properties/data/properties/targetNodes/items",
+            "type": "object",
+            "properties": {
+              "id": {
+                "$id": "/properties/data/properties/targetNodes/items/properties/id",
+                "type": "integer",
+                "title": "The Id Schema",
+                "description": "An explanation about the purpose of this instance.",
+                "default": 0,
+                "examples": [
+                  440
+                ]
+              },
+              "name": {
+                "$id": "/properties/data/properties/targetNodes/items/properties/name",
+                "type": "string",
+                "title": "The Name Schema",
+                "description": "An explanation about the purpose of this instance.",
+                "default": "",
+                "examples": [
+                  "BUNGE"
+                ]
+              },
+              "height": {
+                "$id": "/properties/data/properties/targetNodes/items/properties/height",
+                "type": "number",
+                "title": "The Height Schema",
+                "description": "An explanation about the purpose of this instance.",
+                "default": 0,
+                "examples": [
+                  0.16515207290649414
+                ]
+              },
+              "value": {
+                "$id": "/properties/data/properties/targetNodes/items/properties/value",
+                "type": "number",
+                "title": "The Value Schema",
+                "description": "An explanation about the purpose of this instance.",
+                "default": 0,
+                "examples": [
+                  11548229
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I believe both the top destination countries and top exporters visualisations can be served by this endpoint, parametrised by `context_id`, `year` and `column_id` (node type id). By default returns 10 top nodes, but can be controlled with `n_nodes` parameter.

Top exporters for context:
`/api/v3/contexts/1/top_nodes?year_start=2014&year_end=2015&column_id=6`

Top destination countries for context:
`/api/v3/contexts/1/top_nodes?year_start=2014&year_end=2015&column_id=8`

```
{
   "data":{
      "context_id":1,
      "indicator":"Trade volume",
      "unit":"Tn",
      "targetNodes":[
         {
            "id":684,
            "name":"CHINA",
            "height":0.424452686663284,
            "value":41375771.5613432
         },
         {
            "id":424,
            "name":"BRAZIL",
            "height":0.2826774040085104,
            "value":27555475.7015545
         },
         {
            "id":1840,
            "name":"NETHERLANDS",
            "height":0.0402013223456854,
            "value":3918836.61501838
         },
         {
            "id":2766,
            "name":"SPAIN",
            "height":0.02792436117120467,
            "value":2722074.86280508
         },
         {
            "id":2857,
            "name":"THAILAND",
            "height":0.02705845937460778,
            "value":2637666.50339005
         },
         {
            "id":1324,
            "name":"INDIA",
            "height":0.02207863104146035,
            "value":2152231.38658876
         },
         {
            "id":1112,
            "name":"FRANCE",
            "height":0.01710709428594789,
            "value":1667604.5351911
         },
         {
            "id":1158,
            "name":"GERMANY",
            "height":0.01624610203964705,
            "value":1583674.76016934
         },
         {
            "id":2762,
            "name":"SOUTH KOREA",
            "height":0.01611762709852366,
            "value":1571150.98547712
         },
         {
            "id":1328,
            "name":"INDONESIA",
            "height":0.01597269870893941,
            "value":1557023.32383518
         }
      ]
   }
}
```

Column ids are now returned as part of the `contexts` call:

```
         "worldMap":{  
            "mapColumnId":8,
            "listColumnId":6
         },
```