### PR TITLE
Prefix static content routes with /content

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,12 +15,11 @@ Rails.application.routes.draw do
     resources :tweets, only: [:index]
     resources :testimonials, only: [:index]
     resources :staff_groups, only: [:index]
+    get "about/:name",
+      controller: :pages,
+      action: :show,
+      defaults: {format: 'md'}
   end
-
-  get "static-content/about/:name",
-    controller: 'content/pages',
-    action: :show,
-    defaults: {format: 'md'}
 
   namespace :api do
     namespace :v3 do

--- a/frontend/scripts/utils/getURLFromParams.js
+++ b/frontend/scripts/utils/getURLFromParams.js
@@ -52,7 +52,7 @@ const API_ENDPOINTS = {
     endpoint: '/testimonials',
     mock: 'mocks/v3_get_testimonials.json'
   },
-  [GET_MARKDOWN_CONTENT_URL]: { api: 'markdown', endpoint: 'static-content' },
+  [GET_MARKDOWN_CONTENT_URL]: { api: 'markdown', endpoint: 'content' },
   [GET_TEAM_URL]: {
     api: 'content',
     endpoint: '/staff_groups',
@@ -138,7 +138,7 @@ export function getURLFromParams(endpointKey, params = {}, mock = false) {
       case 'content':
         return `${API_V2_URL}/content${endpointData.endpoint}`;
       case 'markdown':
-        return `${API_V2_URL}/static-content/${params.filename}.md`;
+        return `${API_V2_URL}/content/${params.filename}.md`;
       default:
         console.warn('Unmatched route found at router');
         return null;


### PR DESCRIPTION
routes starting with /content so that requests are correctly routed to backend