### PR TITLE
Fix/sidekiq limit unique job execution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'twitter', '~> 6.1'
 
 gem 'appsignal'
 gem 'sidekiq'
+gem 'sidekiq-unique-jobs'
 
 group :development, :test do
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.0.0)
     http_parser.rb (0.6.0)
-    i18n (0.9.3)
+    i18n (0.9.4)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -248,7 +248,7 @@ GEM
     powerpack (0.1.1)
     public_suffix (3.0.1)
     puma (3.10.0)
-    rack (2.0.3)
+    rack (2.0.4)
     rack-cors (0.4.1)
     rack-protection (2.0.0)
       rack
@@ -283,7 +283,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.2.1)
+    rake (12.3.0)
     ransack (1.8.4)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
@@ -339,11 +339,14 @@ GEM
     scenic (1.4.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    sidekiq (5.0.5)
+    sidekiq (5.1.1)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
-      redis (>= 3.3.4, < 5)
+      redis (>= 3.3.5, < 5)
+    sidekiq-unique-jobs (5.0.10)
+      sidekiq (>= 4.0, <= 6.0)
+      thor (~> 0)
     simple_oauth (0.3.1)
     simplecov (0.15.1)
       docile (~> 1.1.0)
@@ -362,7 +365,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sshkit (1.15.0)
+    sshkit (1.16.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     thor (0.20.0)
@@ -441,6 +444,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   scenic
   sidekiq
+  sidekiq-unique-jobs
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ The project's main configuration values can be set using [environment variables]
 * TRASE_LOCAL_FDW_SCHEMA=main # this schema in local database where remote tables are mapped
 * TRASE_LOCAL_SCHEMA=revamp # this schema in local database where target tables are
 
+## Background jobs
+
+We use sidekiq to process long running jobs in the background.
+
+Currently we're using it for 2 types of database jobs:
+- updating `download_flows_mv`, which takes around 2 minutes and is triggered by updates to a number of "yellow" tables, e.g. downlaod_attributes
+- importing new data from main database, which takes around two hours and is triggered either by clicking a button in the admin tool or running a rake task
+
+In both cases the times might grow as the dataset grows, which is important to keep in mind because the current configuration might need tuning when that happens.
+
+Our use case of sidekiq does not benefit from high concurrency, because both workers need to run one at a time. Therefore, concurrency settings in `config/sidekiq.yml` and `config/initializers/sidekiq.rb` are low to match that and avoid using up resources unnecessarily. Again, if we at any point later add more background jobs with different concurrency characteristics, this may need to be revised.
+
+To ensure only one database job can run at any single time we use `sidekiq-unique-jobs` gem. It works at 2 stages:
+- when adding a job to the queue,
+- when pulling the job from the queue to start execution.
+
+It can be configured to lock execution according to a number of predefined strategies and the one we use is called `:until_and_while_executing`. It works as follows: you can enqueue a duplicate job A' unless job A is already enqueued; A' will not start executing until A is finished, at which point it will be possible to enqueue another job A''. It is also important to understand that the unique locks have an expiration time, which I set to match average execution time. It seems that without this in place it is possible that an enqueued job will start executing too early (after a default timeout of 60 seconds).
+
+In practice this means that if the admin makes 3 updates in a short time frame ( < lock expiration time) to e.g. Download Attributes, normally the `DownloadFlowsRefreshWorker` would be enqueued and executed 3 times, possibly concurrently. With the unique lock in place, it will enqueue the first one and if possible start executing immediately, possibly allowing to enqueue the second one while first one is in progress; the third one will never be enqueued. Once the first one has completed the second one will be executed.
+
 ## Test
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project uses:
 - Nodejs 8.2+
 - PostgreSQL 9.5+ with `intarray`, `tablefunc` and `postgres_fdw` extensions
 - [Bundler](http://bundler.io/)
-- redis
+- redis >= 3
 
 ## Setup
 
@@ -51,6 +51,10 @@ For the frontend application:
 - Install dependencies using `npm install`
 
 You can start the development server with `npm start`
+
+You can start background job processing with:
+- `redis-server`
+- `bundle exec sidekiq`
 
 ## Deployment
 

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -10,7 +10,7 @@ module Api
 
         def self.refresh
           Scenic.database.refresh_materialized_view(table_name, concurrently: false)
-          # Api::V3::Readonly::DownloadFlow.refresh_later(skip_flow_paths: true)
+          Api::V3::Readonly::DownloadFlow.refresh_later(skip_flow_paths: true)
         end
       end
     end

--- a/app/workers/database_update_worker.rb
+++ b/app/workers/database_update_worker.rb
@@ -1,6 +1,11 @@
 class DatabaseUpdateWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 0, backtrace: true, unique: :until_and_while_executing
+  sidekiq_options queue: :database,
+                  retry: 0,
+                  backtrace: true,
+                  unique: :until_executed,
+                  run_lock_expiration: 60 * 60 * 2, # 2 hrs
+                  log_duplicate_payload: true
 
   def perform(database_update_id)
     database_update = Api::V3::DatabaseUpdate.find(database_update_id)

--- a/app/workers/database_update_worker.rb
+++ b/app/workers/database_update_worker.rb
@@ -1,6 +1,6 @@
 class DatabaseUpdateWorker
   include Sidekiq::Worker
-  sidekiq_options retry: false
+  sidekiq_options retry: 0, backtrace: true, unique: :until_and_while_executing
 
   def perform(database_update_id)
     database_update = Api::V3::DatabaseUpdate.find(database_update_id)

--- a/app/workers/download_flows_refresh_worker.rb
+++ b/app/workers/download_flows_refresh_worker.rb
@@ -1,6 +1,11 @@
 class DownloadFlowsRefreshWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 0, backtrace: true, unique: :until_and_while_executing
+  sidekiq_options queue: :database,
+                  retry: 0,
+                  backtrace: true,
+                  unique: :until_and_while_executing,
+                  run_lock_expiration: 150, # 2.5 mins
+                  log_duplicate_payload: true
 
   def perform(options)
     Api::V3::Readonly::DownloadFlow.refresh(options)

--- a/app/workers/download_flows_refresh_worker.rb
+++ b/app/workers/download_flows_refresh_worker.rb
@@ -1,10 +1,8 @@
 class DownloadFlowsRefreshWorker
   include Sidekiq::Worker
-  sidekiq_options retry: false
+  sidekiq_options retry: 0, backtrace: true, unique: :until_and_while_executing
 
   def perform(options)
-    # first check if there any jobs of this type already queued
-    # TODO
     Api::V3::Readonly::DownloadFlow.refresh(options)
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,4 +6,10 @@ Sidekiq.configure_server do |config|
     du = Api::V3::DatabaseUpdate.where(jid: jid).first
     du&.update_attribute(:status, Api::V3::DatabaseUpdate::FAILED)
   end
+
+  config.redis = {size: 4}
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {size: 2}
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,10 @@
+verbose: true
+logfile: ./log/sidekiq.log
+development:
+  :concurrency: 2
+staging:
+  :concurrency: 2
+production:
+  :concurrency: 2
+:queues:
+  - database


### PR DESCRIPTION
Adds more control to the sidekiq configuration and a way of ensuring long running database jobs do not execute simultaneously. Details about how that works in README.