### PR TITLE
Fix/exception when malformed flows link

### DIFF
--- a/app/controllers/api/v3/flows_controller.rb
+++ b/app/controllers/api/v3/flows_controller.rb
@@ -4,10 +4,15 @@ module Api
       before_action :set_filter_params, only: :index
 
       def index
-        @flows_result = Api::V3::Flows::Filter.new(@context, @filter_params).call
+        ensure_required_param_present(:include_columns)
+        ensure_required_param_present(:flow_quant)
+        ensure_required_param_present(:year_start)
+        @flows_result = Api::V3::Flows::Filter.new(
+          @context, @filter_params
+        ).call
 
         if @flows_result.errors.any?
-          render json: @flows_result.errors
+          render json: {errors: @flows_result.errors}, status: 400
         else
           render json: @flows_result,
                  adapter: :attributes,

--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -21,6 +21,9 @@ module Api
         end
 
         def call
+          if @errors.any?
+            return Api::V3::Flows::Result.new(self)
+          end
           initialize_node_types
           initialize_active_node_types
           initialize_biome_position
@@ -72,8 +75,11 @@ module Api
             @errors << 'Both start and end date not given'
           end
           @errors << 'Resize quant not given' unless @resize_quant
-          return unless @recolor_ind && @recolor_qual
-          @errors << 'Either ind or qual for recoloring'
+          if @recolor_ind && @recolor_qual
+            @errors << 'Either ind or qual for recoloring'
+          end
+          return if @node_types_ids.any?
+          @errors << 'No columns given'
         end
 
         def initialize_node_types

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -185,6 +185,22 @@ paths:
             type: array
             items:
               $ref: '#/definitions/FlowResult'
+        '400':
+          description: unprocessable entity
+          schema:
+            type: object
+            properties:
+              errors:
+                type: array
+                items:
+                  type: string
+        '500':
+          description: internal server error
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
   '/context/{context_id}/nodes':
     get:
       tags:

--- a/spec/controllers/api/v3/flows_controller_spec.rb
+++ b/spec/controllers/api/v3/flows_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::FlowsController, type: :controller do
+  include_context 'api v3 brazil flows quants'
+
+  describe 'GET index' do
+    let(:node_types) {
+      [
+        api_v3_municipality_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ]
+    }
+    let(:filter_params) {
+      {
+        year_start: 2015,
+        year_end: 2015,
+        include_columns: node_types.map(&:id),
+        flow_quant: api_v3_volume.name,
+        limit: 1
+      }
+    }
+    context 'when context without node types' do
+      let(:context) { FactoryBot.create(:api_v3_context) }
+
+      it 'returns 400' do
+        get :index, params: {
+          context_id: context.id
+        }.merge(filter_params)
+        expect(response).to have_http_status(400)
+      end
+    end
+  end
+end

--- a/spec/models/api/v3/download_attribute_spec.rb
+++ b/spec/models/api/v3/download_attribute_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::DownloadAttribute, type: :model do
+  before do
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
+  end
   include_context 'api v3 brazil download attributes'
 
   describe :validate do

--- a/spec/responses/api/v3/download_attributes_spec.rb
+++ b/spec/responses/api/v3/download_attributes_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Download Attributes', type: :request do
+  before do
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
+  end
   include_context 'api v3 brazil download attributes'
 
   describe 'GET /api/v3/contexts/:context_id/download_attributes' do

--- a/spec/responses/api/v3/flows_spec.rb
+++ b/spec/responses/api/v3/flows_spec.rb
@@ -5,19 +5,48 @@ RSpec.describe 'Flows', type: :request do
   include_context 'api v3 brazil flows quants'
 
   describe 'GET /api/v2/contexts/:context_id/flows' do
-    it 'has the correct response structure' do
-      node_types = [
+    let(:node_types) {
+      [
         api_v3_municipality_node_type,
         api_v3_exporter_node_type,
         api_v3_importer_node_type,
         api_v3_country_node_type
       ]
+    }
+    let(:filter_params) {
+      {
+        year_start: 2015,
+        include_columns: node_types.map(&:id),
+        flow_quant: api_v3_volume.name
+      }
+    }
+    it 'requires include_columns' do
       get "/api/v3/contexts/#{api_v3_context.id}/flows",
-          params: {
-            flow_quant: api_v3_volume.name,
-            year_start: 2015,
-            include_columns: node_types.map(&:id).join(',')
-          }
+          params: filter_params.except(:include_columns)
+      expect(@response.status).to eq 500
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param include_columns missing'
+      )
+    end
+    it 'requires flow_quant' do
+      get "/api/v3/contexts/#{api_v3_context.id}/flows",
+          params: filter_params.except(:flow_quant)
+      expect(@response.status).to eq 500
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param flow_quant missing'
+      )
+    end
+    it 'requires year_start' do
+      get "/api/v3/contexts/#{api_v3_context.id}/flows",
+          params: filter_params.except(:year_start)
+      expect(@response.status).to eq 500
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param year_start missing'
+      )
+    end
+    it 'has the correct response structure' do
+      get "/api/v3/contexts/#{api_v3_context.id}/flows",
+          params: filter_params
       expect(@response.status).to eq 200
       expect(@response).to match_response_schema('flows')
     end

--- a/spec/services/api/v3/download/flow_download_query_builder_spec.rb
+++ b/spec/services/api/v3/download/flow_download_query_builder_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::Download::FlowDownloadQueryBuilder, type: :model do
+  before do
+    Api::V3::Flow.delete_all # TODO
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
+  end
   include_context 'api v3 brazil two flows'
   describe :query do
     before(:each) do

--- a/spec/services/api/v3/flows/filter_spec.rb
+++ b/spec/services/api/v3/flows/filter_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Api::V3::Flows::Filter do
     end
 
     context 'when expanded mode' do
-      let(:expanded_nodes){
+      let(:expanded_nodes) {
         {selected_nodes_ids: [api_v3_country_of_destination1_node.id]}
       }
       context 'when no locked nodes present' do
@@ -119,6 +119,20 @@ RSpec.describe Api::V3::Flows::Filter do
           )
           filter.call
           expect(filter.active_nodes).to have_key(api_v3_diamantino_node.id)
+        end
+      end
+    end
+
+    context 'when required options missing' do
+      context 'node_type_ids missing' do
+        let(:filter) { Api::V3::Flows::Filter.new(api_v3_context, {}) }
+        it 'should have errors set' do
+          filter.call
+          expect(filter.errors).not_to be_empty
+        end
+        it 'should return no flows' do
+          filter.call
+          expect(filter.flows).to be_nil
         end
       end
     end


### PR DESCRIPTION
A query string like this:
`/api/v3/contexts/1/flows?&year_start=2015&year_end=2015&include_columns=&flow_quant=Volume&n_nodes=10`

would result in a 500 on a no method exception. I handled the case of a missing param in a similar way we do in other parts of the API, by raising `ActionController::ParameterMissing`; but that also results in a 500 and I believe this is not the best. I will propose to handle missing params using a 400 status going forward.

Once I added specs for this behaviour some other specs started failing, which I believe is due to a changed execution order. I fixed them as part of this PR, but we need to get to the bottom of this weird behaviour. The reason the errors did not manifest themselves earlier is likely to do with stale data in between spec runs, and I believe that has a lot to do with incorrect cleaning of database when using multiple connections.