### PR TITLE
Prevent before_save callback from setting highlighted to false

### DIFF
--- a/app/models/content/post.rb
+++ b/app/models/content/post.rb
@@ -34,7 +34,8 @@ module Content
     validates_attachment_content_type :image, content_type: /\Aimage\/.*\z/
 
     after_initialize :set_default_date
-    before_save :reset_highlighted_flag
+    before_save :reset_highlighted_flag,
+                if: -> { highlighted && highlighted_changed? }
 
     def complete_post_url
       return post_url if post_url.start_with?('http://', 'https://')
@@ -46,7 +47,6 @@ module Content
     end
 
     def reset_highlighted_flag
-      return true unless highlighted && highlighted_changed?
       Content::Post.update_all(highlighted: false)
     end
   end

--- a/app/models/content/post.rb
+++ b/app/models/content/post.rb
@@ -46,7 +46,7 @@ module Content
     end
 
     def reset_highlighted_flag
-      return true unless highlighted
+      return true unless highlighted && highlighted_changed?
       Content::Post.update_all(highlighted: false)
     end
   end

--- a/spec/models/content/post_spec.rb
+++ b/spec/models/content/post_spec.rb
@@ -10,10 +10,16 @@ RSpec.describe Content::Post, type: :model do
   end
 
   context 'when saving with highlighted flag unset' do
-    it 'does not de-highlight previously highlighted post' do
-      old_post = FactoryBot.create(:post, highlighted: true)
+    it 'keeps post highlighted when another post created' do
+      highlighted_post = FactoryBot.create(:post, highlighted: true)
       FactoryBot.create(:post, highlighted: false)
-      expect(old_post.reload).to be_highlighted
+      expect(highlighted_post.reload).to be_highlighted
+    end
+
+    it 'keeps post highlighted when another property updated' do
+      highlighted_post = FactoryBot.create(:post, highlighted: true)
+      highlighted_post.update_attributes(title: 'zonk')
+      expect(highlighted_post.reload).to be_highlighted
     end
   end
 end


### PR DESCRIPTION
this happened when you edited a highlighted post and did not change the value of the highlighted flag - it would de-highlight itself because of the `before_save` callback