### PR TITLE
Disable database updates & database validations in production

### DIFF
--- a/app/admin/api/v3/database_update.rb
+++ b/app/admin/api/v3/database_update.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register_page 'Database Update' do
-  menu parent: 'Database'
+  menu parent: 'Database', unless: proc { Rails.env.production? }
 
   content do
     current_update = Api::V3::DatabaseUpdate.where(status: Api::V3::DatabaseUpdate::STARTED).first

--- a/app/admin/api/v3/database_update.rb
+++ b/app/admin/api/v3/database_update.rb
@@ -1,5 +1,9 @@
 ActiveAdmin.register_page 'Database Update' do
-  menu parent: 'Database', unless: proc { Rails.env.production? }
+  menu parent: 'Database'
+
+  controller do
+    before_action :ensure_data_update_supported
+  end
 
   content do
     current_update = Api::V3::DatabaseUpdate.where(status: Api::V3::DatabaseUpdate::STARTED).first

--- a/app/admin/api/v3/database_validation.rb
+++ b/app/admin/api/v3/database_validation.rb
@@ -1,5 +1,9 @@
 ActiveAdmin.register_page 'Data Validation' do
-  menu parent: 'Database', unless: proc { Rails.env.production? }
+  menu parent: 'Database'
+
+  controller do
+    before_action :ensure_data_update_supported
+  end
 
   content do
     database_validations = Api::V3::DatabaseValidationReport.

--- a/app/admin/api/v3/database_validation.rb
+++ b/app/admin/api/v3/database_validation.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register_page 'Data Validation' do
-  menu parent: 'Database'
+  menu parent: 'Database', unless: proc { Rails.env.production? }
 
   content do
     database_validations = Api::V3::DatabaseValidationReport.

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -12,40 +12,42 @@ ActiveAdmin.register_page 'Dashboard' do
           end
         end
 
-        panel 'Last data update' do
-          last_update = Api::V3::DatabaseUpdate.order(created_at: :desc).first
+        unless Rails.env.production?
+          panel 'Last data update' do
+            last_update = Api::V3::DatabaseUpdate.order(created_at: :desc).first
 
-          div do
-            if last_update.present?
-              attributes_table_for last_update do
-                row :created_at
-                row :finished_at
-                row(:status) { |update| status_tag(update.status) }
-              end
-            else
-              div 'None'
-            end
             div do
-              link_to 'Data updates', admin_database_update_path
+              if last_update.present?
+                attributes_table_for last_update do
+                  row :created_at
+                  row :finished_at
+                  row(:status) { |update| status_tag(update.status) }
+                end
+              else
+                div 'None'
+              end
+              div do
+                link_to 'Data updates', admin_database_update_path
+              end
             end
           end
-        end
 
-        panel 'Last data validation' do
-          last_validation = Api::V3::DatabaseValidationReport.
-            order(created_at: :desc).first
-          div do
-            if last_validation.present?
-              attributes_table_for last_validation do
-                row :created_at
-                row :finished_at
-                row(:status) { |validation| status_tag(validation.status) }
-              end
-            else
-              div 'None'
-            end
+          panel 'Last data validation' do
+            last_validation = Api::V3::DatabaseValidationReport.
+              order(created_at: :desc).first
             div do
-              link_to 'Data validations', admin_data_validation_path
+              if last_validation.present?
+                attributes_table_for last_validation do
+                  row :created_at
+                  row :finished_at
+                  row(:status) { |validation| status_tag(validation.status) }
+                end
+              else
+                div 'None'
+              end
+              div do
+                link_to 'Data validations', admin_data_validation_path
+              end
             end
           end
         end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register_page 'Dashboard' do
           end
         end
 
-        unless Rails.env.production?
+        if controller.data_update_supported?
           panel 'Last data update' do
             last_update = Api::V3::DatabaseUpdate.order(created_at: :desc).first
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,10 @@ class ApplicationController < ActionController::Base
     render json: {error: exception.message}, status: 500
   end
 
+  def data_update_supported?
+    !Rails.env.production?
+  end
+
   private
 
   def load_context
@@ -19,5 +23,10 @@ class ApplicationController < ActionController::Base
 
   def set_caching_headers
     expires_in 2.hours, public: true
+  end
+
+  def ensure_data_update_supported
+    return true if data_update_supported?
+    redirect_to admin_root_url and return false
   end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -226,7 +226,7 @@ config.namespace :admin do |admin|
   admin.build_menu do |menu|
     menu.add label: 'Dashboard', priority: 1
     menu.add label: 'Content', priority: 2
-    menu.add label: 'Database', priority: 4
+    menu.add label: 'Database', priority: 4, if: proc { controller.data_update_supported? }
     menu.add label: 'General Settings', priority: 5
     menu.add label: 'Sankey Settings', priority: 6
     menu.add label: 'Map Settings', priority: 7

--- a/spec/controllers/admin/data_validation_controller_spec.rb
+++ b/spec/controllers/admin/data_validation_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Admin::DataValidationController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'GET index' do
+    it 'redirects when data update not supported' do
+      allow(controller).to receive(:data_update_supported?).and_return(false)
+      get :index
+      expect(response).to redirect_to(admin_root_url)
+    end
+  end
+end

--- a/spec/controllers/admin/database_update_controller_spec.rb
+++ b/spec/controllers/admin/database_update_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Admin::DatabaseUpdateController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'GET index' do
+    it 'redirects when data update not supported' do
+      allow(controller).to receive(:data_update_supported?).and_return(false)
+      get :index
+      expect(response).to redirect_to(admin_root_url)
+    end
+  end
+end

--- a/spec/factories/content/user.rb
+++ b/spec/factories/content/user.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user, class: 'Content::User' do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password 'test123'
+  end
+end


### PR DESCRIPTION
Just so that no-one is tempted, this hides the relevant sections of the admin menu in production. Those operations are only meant to be run in integration environment.