### PR TITLE
Cache invalidation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,10 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
+Lint/RescueWithoutErrorClass:
+  Exclude:
+    - 'app/controllers/concerns/cache_utils.rb'
+
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - 'lib/tasks/**/*'
+    - 'app/admin/**/*'
 
 Metrics/LineLength:
   Max: 80

--- a/app/admin/api/v3/carto_layer.rb
+++ b/app/admin/api/v3/carto_layer.rb
@@ -3,6 +3,14 @@ ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
 
   permit_params :contextual_layer_id, :identifier, :years_str, :raster_url
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts/.+/map_layers')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypeProperty' do
-  menu parent: 'Map Settings'
+  menu parent: 'General Settings', priority: 3
 
   permit_params :context_node_type_id, :column_group, :is_default,
                 :is_geo_column, :is_choropleth_disabled

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -4,6 +4,14 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
   permit_params :context_node_type_id, :column_group, :is_default,
                 :is_geo_column, :is_choropleth_disabled
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/context_property.rb
+++ b/app/admin/api/v3/context_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
-  menu parent: 'General Settings'
+  menu parent: 'General Settings', priority: 2
 
   permit_params :context_id, :default_basemap, :is_disabled, :is_default,
                 :is_subnational

--- a/app/admin/api/v3/context_property.rb
+++ b/app/admin/api/v3/context_property.rb
@@ -4,6 +4,14 @@ ActiveAdmin.register Api::V3::ContextProperty, as: 'ContextProperty' do
   permit_params :context_id, :default_basemap, :is_disabled, :is_default,
                 :is_subnational
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/contextual_layer.rb
+++ b/app/admin/api/v3/contextual_layer.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
-  menu parent: 'Map Settings'
+  menu parent: 'Map Settings', priority: 3
 
   permit_params :context_id, :title, :identifier, :position,
                 :tooltip_text, :legend, :is_default

--- a/app/admin/api/v3/contextual_layer.rb
+++ b/app/admin/api/v3/contextual_layer.rb
@@ -4,6 +4,14 @@ ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
   permit_params :context_id, :title, :identifier, :position,
                 :tooltip_text, :legend, :is_default
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts/.+/map_layers')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/country_property.rb
+++ b/app/admin/api/v3/country_property.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
-  menu parent: 'General Settings'
+  menu parent: 'General Settings', priority: 1
 
   permit_params :country_id, :latitude, :longitude, :zoom
 

--- a/app/admin/api/v3/country_property.rb
+++ b/app/admin/api/v3/country_property.rb
@@ -3,6 +3,14 @@ ActiveAdmin.register Api::V3::CountryProperty, as: 'CountryProperty' do
 
   permit_params :country_id, :latitude, :longitude, :zoom
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_url(api_v3_contexts_url)
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -4,6 +4,14 @@ ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
   permit_params :context_id, :position, :display_name, :years_str,
                 :readonly_attribute_id
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts/.+/download_attributes')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/ind_property.rb
+++ b/app/admin/api/v3/ind_property.rb
@@ -5,6 +5,15 @@ ActiveAdmin.register Api::V3::IndProperty, as: 'IndProperty' do
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,
                 :is_temporal_on_place_profile, :is_temporal_on_actor_profile
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+      Dictionary::Ind.instance.reset
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -11,6 +11,14 @@ ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
                 :single_layer_buckets_str, :color_scale, :years_str, :is_disabled,
                 :is_default, :readonly_attribute_id
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts/.+/map_layers')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
-  menu parent: 'Map Settings'
+  menu parent: 'Map Settings', priority: 2
 
   includes [
     {map_attribute_group: {context: [:country, :commodity]}},

--- a/app/admin/api/v3/map_attribute_group.rb
+++ b/app/admin/api/v3/map_attribute_group.rb
@@ -3,6 +3,14 @@ ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
 
   permit_params :context_id, :name, :position
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts/.+/map_layers')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/map_attribute_group.rb
+++ b/app/admin/api/v3/map_attribute_group.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
-  menu parent: 'Map Settings'
+  menu parent: 'Map Settings', priority: 1
 
   permit_params :context_id, :name, :position
 

--- a/app/admin/api/v3/profile.rb
+++ b/app/admin/api/v3/profile.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
-  menu parent: 'General Settings'
+  menu parent: 'General Settings', priority: 4
 
   permit_params :context_node_type_id, :name
 

--- a/app/admin/api/v3/profile.rb
+++ b/app/admin/api/v3/profile.rb
@@ -3,6 +3,14 @@ ActiveAdmin.register Api::V3::Profile, as: 'Profile' do
 
   permit_params :context_node_type_id, :name
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts/')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/qual_property.rb
+++ b/app/admin/api/v3/qual_property.rb
@@ -5,6 +5,15 @@ ActiveAdmin.register Api::V3::QualProperty, as: 'QualProperty' do
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,
                 :is_temporal_on_place_profile, :is_temporal_on_actor_profile
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+      Dictionary::Qual.instance.reset
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/quant_property.rb
+++ b/app/admin/api/v3/quant_property.rb
@@ -5,6 +5,15 @@ ActiveAdmin.register Api::V3::QuantProperty, as: 'QuantProperty' do
                 :is_visible_on_place_profile, :is_visible_on_actor_profile,
                 :is_temporal_on_place_profile, :is_temporal_on_actor_profile
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+      Dictionary::Quant.instance.reset
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -12,6 +12,14 @@ ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
                 :divisor, :tooltip_text, :years_str, :is_disabled, :is_default,
                 :readonly_attribute_id
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -9,6 +9,14 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
   permit_params :context_id, :group_number, :position, :tooltip_text,
                 :years_str, :is_disabled, :is_default, :readonly_attribute_id
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/content/page.rb
+++ b/app/admin/content/page.rb
@@ -1,7 +1,8 @@
 ActiveAdmin.register Content::Page, as: 'Page' do
+  menu parent: 'Content'
+
   permit_params :name, :content
   config.sort_order = :name
-  menu parent: 'Content'
 
   form do |f|
     f.semantic_errors

--- a/app/admin/content/page.rb
+++ b/app/admin/content/page.rb
@@ -4,6 +4,15 @@ ActiveAdmin.register Content::Page, as: 'Page' do
   permit_params :name, :content
   config.sort_order = :name
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      return unless @page&.name
+      clear_cache_for_url(content_url(name: @page.name))
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/content/post.rb
+++ b/app/admin/content/post.rb
@@ -1,7 +1,8 @@
 ActiveAdmin.register Content::Post, as: 'Post' do
+  menu parent: 'Content'
+
   permit_params :title, :date, :image, :post_url, :category, :state, :highlighted
   config.sort_order = 'date_desc'
-  menu parent: 'Content'
 
   form do |f|
     f.semantic_errors

--- a/app/admin/content/post.rb
+++ b/app/admin/content/post.rb
@@ -4,6 +4,14 @@ ActiveAdmin.register Content::Post, as: 'Post' do
   permit_params :title, :date, :image, :post_url, :category, :state, :highlighted
   config.sort_order = 'date_desc'
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_url(content_posts_url)
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/content/site_dive.rb
+++ b/app/admin/content/site_dive.rb
@@ -3,6 +3,15 @@ ActiveAdmin.register Content::SiteDive, as: 'Site Dive' do
 
   permit_params :title, :page_url, :description
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      return unless @site_dive&.id
+      clear_cache_for_url(content_site_dive_url(@site_dive))
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/content/staff_group.rb
+++ b/app/admin/content/staff_group.rb
@@ -3,6 +3,14 @@ ActiveAdmin.register Content::StaffGroup, as: 'Staff Group' do
 
   permit_params :name, :position
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_url(content_staff_groups_url)
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/content/staff_member.rb
+++ b/app/admin/content/staff_member.rb
@@ -5,6 +5,14 @@ ActiveAdmin.register Content::StaffMember, as: 'Staff Member' do
 
   permit_params :staff_group_id, :name, :image, :position, :bio
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_url(content_staff_groups_url)
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/admin/content/testimonial.rb
+++ b/app/admin/content/testimonial.rb
@@ -3,6 +3,14 @@ ActiveAdmin.register Content::Testimonial, as: 'Testimonial' do
 
   permit_params :quote, :author_name, :author_title, :image
 
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_url(content_testimonials_url)
+    end
+  end
+
   form do |f|
     f.semantic_errors
     inputs do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
 
   def set_caching_headers
     return true unless Rails.env.production?
-    expires_in 2.hours, public: true
+    expires_in 15.minutes, private: true, 's-maxage' => 5.minutes
   end
 
   def ensure_data_update_supported

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_caching_headers
+    return true unless Rails.env.production?
     expires_in 2.hours, public: true
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
     render json: {error: exception.message}, status: 400
   end
 
+  include CacheUtils
+
   def data_update_supported?
     !Rails.env.production?
   end

--- a/app/controllers/concerns/cache_utils.rb
+++ b/app/controllers/concerns/cache_utils.rb
@@ -1,0 +1,40 @@
+module CacheUtils
+  extend ActiveSupport::Concern
+
+  # Uses PURGE to remove objects from cache by url
+  # @param url [String]
+  def clear_cache_for_url(url)
+    with_uri(url) do |uri|
+      Rails.logger.debug "Purging: #{uri}"
+      Net::HTTP::Purge.new uri.request_uri
+    end
+  end
+
+  # Uses BAN to remove objects from cache by regexp
+  # @param regexp [String]
+  def clear_cache_for_regexp(regexp)
+    with_uri(admin_root_url) do |uri|
+      Rails.logger.debug "Banning: #{regexp}"
+      request = Net::HTTP::Ban.new uri.request_uri
+      request['X-Ban-Url'] = regexp
+      request
+    end
+  end
+
+  private
+
+  def with_uri(url)
+    return unless Rails.env.staging? || Rails.env.production?
+    uri = URI(url)
+    Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      request = yield(uri)
+      response = http.request request
+      Rails.logger.debug "#{response.code}: #{response.message}"
+      unless (200...400).cover?(response.code.to_i)
+        Rails.logger.error 'A problem occurred. Operation was not performed.'
+      end
+    end
+  rescue => e
+    Appsignal.send_error(e)
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -3,12 +3,13 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
+ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'
 #   inflect.uncountable %w( fish sheep )
-# end
+  inflect.irregular 'site_dive', 'site_dives'
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/config/initializers/varnish_cache_invalidation_http_methods.rb
+++ b/config/initializers/varnish_cache_invalidation_http_methods.rb
@@ -1,0 +1,15 @@
+require 'net/http'
+
+module Net
+  class HTTP::Purge < HTTPRequest
+    METHOD='PURGE'
+    REQUEST_HAS_BODY = false
+    RESPONSE_HAS_BODY = true
+  end
+
+  class HTTP::Ban < HTTPRequest
+    METHOD='BAN'
+    REQUEST_HAS_BODY = false
+    RESPONSE_HAS_BODY = true
+  end
+end

--- a/spec/controllers/admin/carto_layers_controller_spec.rb
+++ b/spec/controllers/admin/carto_layers_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Admin::CartoLayersController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:contextual_layer) { FactoryBot.create(:api_v3_contextual_layer) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_carto_layer, contextual_layer_id: contextual_layer.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_carto_layer: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/context_node_type_properties_controller_spec.rb
+++ b/spec/controllers/admin/context_node_type_properties_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Admin::ContextNodeTypePropertiesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:context_node_type) { FactoryBot.create(:api_v3_context_node_type) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_context_node_type_property,
+        context_node_type_id: context_node_type.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {
+        api_v3_context_node_type_property: valid_attributes
+      }
+    end
+  end
+end

--- a/spec/controllers/admin/context_properties_controller_spec.rb
+++ b/spec/controllers/admin/context_properties_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ContextPropertiesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_context_property, context_id: context.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_context_property: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/contextual_layers_controller_spec.rb
+++ b/spec/controllers/admin/contextual_layers_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ContextualLayersController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_contextual_layer, context_id: context.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_contextual_layer: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/country_properties_controller_spec.rb
+++ b/spec/controllers/admin/country_properties_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Admin::CountryPropertiesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:country) { FactoryBot.create(:api_v3_country) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_country_property, country_id: country.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_url)
+      post :create, params: {api_v3_country_property: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/download_attributes_controller_spec.rb
+++ b/spec/controllers/admin/download_attributes_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::DownloadAttributesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_download_attribute, context_id: context.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_download_attribute: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/ind_properties_controller_spec.rb
+++ b/spec/controllers/admin/ind_properties_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::IndPropertiesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::IndProperty.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::IndProperty.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:ind) { FactoryBot.create(:api_v3_ind) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_ind_property, ind_id: ind.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_ind_property: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/map_attribute_groups_controller_spec.rb
+++ b/spec/controllers/admin/map_attribute_groups_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::MapAttributeGroupsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_map_attribute_group, context_id: context.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_map_attribute_group: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/map_attributes_controller_spec.rb
+++ b/spec/controllers/admin/map_attributes_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Admin::MapAttributesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:map_attribute_group) {
+      FactoryBot.create(:api_v3_map_attribute_group)
+    }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_map_attribute, map_attribute_group_id: map_attribute_group.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_map_attribute: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/pages_controller_spec.rb
+++ b/spec/controllers/admin/pages_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PagesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:valid_attributes) { FactoryBot.attributes_for(:page) }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_url)
+      post :create, params: {content_page: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/posts_controller_spec.rb
+++ b/spec/controllers/admin/posts_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PostsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:valid_attributes) { FactoryBot.attributes_for(:post) }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_url)
+      post :create, params: {post: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/profiles_controller_spec.rb
+++ b/spec/controllers/admin/profiles_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Admin::ProfilesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:context_node_type) { FactoryBot.create(:api_v3_context_node_type) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_profile,
+        context_node_type_id: context_node_type.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {
+        api_v3_profile: valid_attributes
+      }
+    end
+  end
+end

--- a/spec/controllers/admin/qual_properties_controller_spec.rb
+++ b/spec/controllers/admin/qual_properties_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::QualPropertiesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::QualProperty.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::QualProperty.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:qual) { FactoryBot.create(:api_v3_qual) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_qual_property, qual_id: qual.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_qual_property: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/quant_properties_controller_spec.rb
+++ b/spec/controllers/admin/quant_properties_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::QuantPropertiesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::QuantProperty.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::QuantProperty.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:quant) { FactoryBot.create(:api_v3_quant) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_quant_property, quant_id: quant.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_quant_property: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/recolor_by_attributes_controller_spec.rb
+++ b/spec/controllers/admin/recolor_by_attributes_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::RecolorByAttributesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_recolor_by_attribute, context_id: context.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_recolor_by_attribute: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/resize_by_attributes_controller_spec.rb
+++ b/spec/controllers/admin/resize_by_attributes_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ResizeByAttributesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_resize_by_attribute, context_id: context.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_resize_by_attribute: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/site_dives_controller_spec.rb
+++ b/spec/controllers/admin/site_dives_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Admin::SiteDivesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:valid_attributes) { FactoryBot.attributes_for(:site_dive) }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_url)
+      post :create, params: {content_site_dive: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/staff_groups_controller_spec.rb
+++ b/spec/controllers/admin/staff_groups_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Admin::StaffGroupsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:valid_attributes) { FactoryBot.attributes_for(:staff_group) }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_url)
+      post :create, params: {content_staff_group: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/staff_members_controller_spec.rb
+++ b/spec/controllers/admin/staff_members_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Admin::StaffMembersController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(:staff_member).except(:image)
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_url)
+      post :create, params: {content_staff_member: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/testimonials_controller_spec.rb
+++ b/spec/controllers/admin/testimonials_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Admin::TestimonialsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'POST create' do
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(:testimonial).except(:image)
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_url)
+      post :create, params: {content_testimonial: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/content/pages_controller_spec.rb
+++ b/spec/controllers/content/pages_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Content::PagesController, type: :controller do
-  describe 'GET index' do
+  describe 'GET show' do
     it 'assigns requested page' do
       index = FactoryBot.create(:page, name: 'index')
       get :show, params: {name: 'index'}


### PR DESCRIPTION
Expected behaviour: "when I'm using the admin tool to make changes to content on the website, I can see the effect of my changes immediately". That is currently not working because of cache configuration.

This PR adds Varnish cache invalidation using PURGE and BAN requests. The first type is used to clear exact urls, the second one to clear all urls matching a regexp. Purging has been added to all relevant admin controllers.

Also, cache headers are now only set in production, so that in staging it's easy to reload values from the API.

**Important**: required changes to Varnish configuration are described in README. Those have been already applied on staging, need to be yet applied on production: https://github.com/Vizzuality/trase/issues/372
