### PR TITLE
fix: choropleth bucket calculations

### DIFF
--- a/frontend/scripts/reducers/helpers/getChoropleth.js
+++ b/frontend/scripts/reducers/helpers/getChoropleth.js
@@ -48,7 +48,7 @@ export default function(selectedMapDimensionsUids, nodesDictWithMeta, mapDimensi
     isBivariate,
     titles: selectedMapDimensions.map(d => _shortenTitle(d.name)),
     bucket: selectedMapDimensions.map(
-      d => (isBivariate ? d.dualLayerBuckets.slice(0) : d.singleLayerBuckets.slice(0))
+      d => (isBivariate ? [...d.dualLayerBuckets].reverse() : [...d.singleLayerBuckets].reverse())
     )
   };
 
@@ -82,7 +82,7 @@ export default function(selectedMapDimensionsUids, nodesDictWithMeta, mapDimensi
             color = CHOROPLETH_CLASSES.default;
           } else {
             // in case only one is zero, just ignore and use lowest bucket (Math.max zero)
-            colorIndex = (2 - Math.max(0, valueA - 1)) * 3 + Math.max(0, valueB - 1);
+            colorIndex = (3 - Math.max(0, valueA - 1)) * 4 + Math.max(0, valueB - 1);
             color = colors[colorIndex];
           }
         }

--- a/frontend/scripts/reducers/helpers/getChoropleth.js
+++ b/frontend/scripts/reducers/helpers/getChoropleth.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import compact from 'lodash/compact';
+import filter from 'lodash/filter';
 import { CHOROPLETH_CLASSES, CHOROPLETH_CLASS_ZERO } from 'constants';
 
 const _shortenTitle = title => {
@@ -9,7 +10,7 @@ const _shortenTitle = title => {
 };
 
 export default function(selectedMapDimensionsUids, nodesDictWithMeta, mapDimensions, forceEmpty) {
-  const uids = _.compact(selectedMapDimensionsUids);
+  const uids = compact(selectedMapDimensionsUids);
 
   if (!uids.length) {
     return {
@@ -36,7 +37,7 @@ export default function(selectedMapDimensionsUids, nodesDictWithMeta, mapDimensi
     ? CHOROPLETH_CLASSES.bidimensional
     : CHOROPLETH_CLASSES[selectedMapDimension.colorScale || 'red'];
 
-  const geoNodes = _.filter(
+  const geoNodes = filter(
     nodesDictWithMeta,
     node => node.geoId !== undefined && node.geoId !== null && node.isGeo
   );

--- a/frontend/scripts/templates/tool/map/legend-choro.ejs
+++ b/frontend/scripts/templates/tool/map/legend-choro.ejs
@@ -17,7 +17,7 @@
 
     <% if (isBivariate && typeof bucket !== "undefined" && bucket[0] !== null && bucket[1] !== null) { %>
     <ul class="bucket-values" >
-        <% bucket[0].reverse().forEach(function(value) { %>
+        <% bucket[0].forEach(function(value) { %>
         <li ><%= abbreviateNumber(value, 3) %></li >
         <% }) %>
         <% bucket[1].forEach(function(value) { %>


### PR DESCRIPTION
This PR addresses a regression on the map choropleth and choropleth legend when it's dual dimensioned. The bucket styles needed to be updated when the buckets were expanded.