### PR TITLE
fix: avoids race condition and removes event listeners

### DIFF
--- a/frontend/scripts/components/tool/sankey.component.js
+++ b/frontend/scripts/components/tool/sankey.component.js
@@ -18,6 +18,10 @@ export default class {
     this._build();
   }
 
+  onRemoved() {
+    this._removeEventListeners();
+  }
+
   translateNodes(relayoutOptions) {
     this._relayout(relayoutOptions);
   }
@@ -110,15 +114,17 @@ export default class {
 
     this.expandButton = document.querySelector('.js-expand');
     this.expandActionButton = document.querySelector('.js-expand-action');
-    this.expandActionButton.addEventListener('click', this._onExpandClick.bind(this));
+    this.expandActionButton.addEventListener('click', this.callbacks.onExpandClick);
     this.clearButton = document.querySelector('.js-clear');
     this.clearButton.addEventListener('click', this.callbacks.onClearClick);
 
     this._onScrollBound = this._onScroll.bind(this);
   }
 
-  _onExpandClick() {
-    this.callbacks.onExpandClick();
+  _removeEventListeners() {
+    this.sankeyColumns.on('mouseleave', null);
+    this.expandActionButton.removeEventListener('click', this.callbacks.onExpandClick);
+    this.clearButton.removeEventListener('click', this.callbacks.onClearClick);
   }
 
   _repositionExpandButton(nodesIds) {
@@ -180,7 +186,9 @@ export default class {
   }
 
   _render(selectedRecolorBy, currentQuant) {
-    this.sankeyColumns.data(this.layout.columns());
+    const cols = this.layout.columns();
+    if (cols.length === 0) return;
+    this.sankeyColumns.data(cols);
 
     this.sankeyColumns.attr('transform', d => `translate(${d.x},0)`);
 

--- a/frontend/scripts/pages/tool.page.jsx
+++ b/frontend/scripts/pages/tool.page.jsx
@@ -42,7 +42,7 @@ export const mount = (root, store) => {
   });
 
   new FlowContentContainer(store);
-  new SankeyContainer(store);
+  containers.push(new SankeyContainer(store));
   new MapContainer(store);
   new MapDimensionsContainer(store);
   new MapContextContainer(store);


### PR DESCRIPTION
This PR fixes crash when going to profile pages through the sankey and then clicking back button. Also removes event listeners for sanity's sake.