### PR TITLE
Improvement/node attributes performance

### DIFF
--- a/db/migrate/20180320141501_create_partial_index_on_map_attributes_mv.rb
+++ b/db/migrate/20180320141501_create_partial_index_on_map_attributes_mv.rb
@@ -1,0 +1,26 @@
+class CreatePartialIndexOnMapAttributesMv < ActiveRecord::Migration[5.1]
+  def up
+    with_search_path(schema_search_path) do
+      remove_index :map_attributes_mv, [:context_id]
+      add_index :map_attributes_mv, [:context_id, :is_disabled],
+        where: "(is_disabled IS FALSE)",
+        name: 'map_attributes_mv_context_id_is_disabled_idx'
+    end
+  end
+
+  def down
+    with_search_path(schema_search_path) do
+      remove_index :map_attributes_mv, [:context_id, :is_disabled]
+      add_index :map_attributes_mv, [:context_id],
+        name: 'map_attributes_mv_context_id_idx'
+    end
+  end
+
+  def schema_search_path
+    if schema_exists?('revamp')
+      'revamp'
+    else
+      'public'
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6402,13 +6402,6 @@ CREATE INDEX index_map_attribute_groups_on_context_id ON map_attribute_groups US
 
 
 --
--- Name: index_map_attributes_mv_on_context_id; Type: INDEX; Schema: revamp; Owner: -
---
-
-CREATE INDEX index_map_attributes_mv_on_context_id ON map_attributes_mv USING btree (context_id);
-
-
---
 -- Name: index_map_attributes_on_map_attribute_group_id; Type: INDEX; Schema: revamp; Owner: -
 --
 
@@ -6546,6 +6539,13 @@ CREATE INDEX index_resize_by_quants_on_quant_id ON resize_by_quants USING btree 
 --
 
 CREATE INDEX index_resize_by_quants_on_resize_by_attribute_id ON resize_by_quants USING btree (resize_by_attribute_id);
+
+
+--
+-- Name: map_attributes_mv_context_id_is_disabled_idx; Type: INDEX; Schema: revamp; Owner: -
+--
+
+CREATE INDEX map_attributes_mv_context_id_is_disabled_idx ON map_attributes_mv USING btree (context_id, is_disabled) WHERE (is_disabled IS FALSE);
 
 
 --
@@ -7398,6 +7398,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180212120524'),
 ('20180221144544'),
 ('20180223141212'),
-('20180226094007');
+('20180226094007'),
+('20180320141501');
 
 


### PR DESCRIPTION
The node attributes endpoint is sometimes very slow to respond, which is why I took a look at the query to see if there's anything obvious to do.

The most important change is to the joins, where it turns out it is better to add another join with `map[inds/quants]` in order to be able to join with map_attributes_mv on id rather than on the multi column id/type index. The gain is not huge though; one more thing to do is probably increase `work_mem` on the server, because this query sometimes is significantly slower than at other times, which makes me think it might be running operations on disk rather than in memory in some cases.

this was applied on staging:

```
max_connections = 50
work_mem = 10485kB
maintenance_work_mem = 128MB
```