### PR TITLE
fix: avoids map fitbounds dancing

### DIFF
--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -654,11 +654,13 @@ export function selectNode(param, isAggregated = false) {
         dispatch({
           type: FILTER_LINKS_BY_NODES
         });
-
-        // load related geoIds to show on the map
-        dispatch(loadLinkedGeoIDs());
       }
     });
+    if (!isAggregated) {
+      // load related geoIds to show on the map
+      return dispatch(loadLinkedGeoIDs());
+    }
+    return undefined;
   };
 }
 
@@ -802,7 +804,7 @@ export function loadLinkedGeoIDs() {
         type: GET_LINKED_GEOIDS,
         payload: []
       });
-      return;
+      return undefined;
     }
     const params = {
       context_id: state.tool.selectedContextId,
@@ -812,14 +814,19 @@ export function loadLinkedGeoIDs() {
     };
     const url = getURLFromParams(GET_LINKED_GEO_IDS_URL, params);
 
-    fetch(url)
-      .then(res => res.text())
-      .then(payload => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === XMLHttpRequest.DONE && xhr.status >= 200 && xhr.status < 400) {
         dispatch({
           type: GET_LINKED_GEOIDS,
-          payload: JSON.parse(payload)
+          payload: JSON.parse(xhr.response)
         });
-      });
+      }
+    };
+
+    xhr.send();
+    return xhr;
   };
 }
 

--- a/frontend/scripts/components/tool/sankey.component.js
+++ b/frontend/scripts/components/tool/sankey.component.js
@@ -14,6 +14,10 @@ const placeNodeText = node =>
   `translate(0,${-7 + node.renderedHeight / 2 - (node.label.length - 1) * 7})`;
 
 export default class {
+  constructor() {
+    this.onNodeClickedRequest = null;
+  }
+
   onCreated() {
     this._build();
   }
@@ -211,7 +215,8 @@ export default class {
         this._onNodeOut();
       })
       .on('click', node => {
-        this.callbacks.onNodeClicked(node.id, node.isAggregated);
+        if (this.onNodeClickedRequest) this.onNodeClickedRequest.abort();
+        this.onNodeClickedRequest = this.callbacks.onNodeClicked(node.id, node.isAggregated);
       });
 
     nodesEnter


### PR DESCRIPTION
This PR includes a fix to avoid map fitbounds dance 👯.
Basically, we abort requests that haven't been returned to prevent old requests squashing newer ones.