### PR TITLE
Fixing remove_old_tables migration

### DIFF
--- a/db/migrate/20180313091306_remove_old_tables.rb
+++ b/db/migrate/20180313091306_remove_old_tables.rb
@@ -57,6 +57,7 @@ class RemoveOldTables < ActiveRecord::Migration[5.1]
       SELECT table_name FROM information_schema.tables
       WHERE table_schema = '#{schema_name}'
       AND table_name NOT IN ('schema_migrations', 'ar_internal_metadata')
+      AND table_type = 'BASE TABLE'
     SQL
     result = execute sql
     result.map { |row| row['table_name'] }


### PR DESCRIPTION
I was recreating my local database from the latest production dump and `remove_old_tables` migration didn't work for me. The script was trying to delete `pg_stat_statements` VIEW using `DROP TABLE` command. I'm fixing the listing of tables taking only those of `BASE TABLE` type. 