### PR TITLE
Download chunking

### DIFF
--- a/app/controllers/api/v3/download_controller.rb
+++ b/app/controllers/api/v3/download_controller.rb
@@ -6,13 +6,13 @@ module Api
 
         respond_to do |format|
           format.csv do
-            send_file download.zipped_csv.path,
+            send_data download.zipped_csv,
                       type: 'application/zip',
                       filename: "#{download.download_name}.zip",
                       disposition: 'attachment'
           end
           format.json do
-            send_file download.zipped_json.path,
+            send_data download.zipped_json,
                       type: 'application/zip',
                       filename: "#{download.download_name}.zip",
                       disposition: 'attachment'

--- a/app/services/api/v3/download/zipped_csv_download.rb
+++ b/app/services/api/v3/download/zipped_csv_download.rb
@@ -9,9 +9,11 @@ module Api
           @separator = separator
         end
 
-        def content
+        private
+
+        def content(query)
           csv = PgCsv.new(
-            sql: @query.to_sql,
+            sql: query.to_sql,
             header: true,
             delimiter: @separator,
             encoding: 'UTF8',
@@ -21,8 +23,8 @@ module Api
           csv.export
         end
 
-        def filename
-          "#{@download_name}.csv"
+        def format
+          :csv
         end
       end
     end

--- a/app/services/api/v3/download/zipped_download.rb
+++ b/app/services/api/v3/download/zipped_download.rb
@@ -12,37 +12,82 @@ module Api
         def initialize(query, download_name)
           @query = query
           @download_name = download_name
+          @temp_dir = "#{Rails.root}/tmp/#{Time.now.strftime('%Y%m%d%H%M%S')}"
+        end
+
+        # @return [String] compressed data
+        def create
+          FileUtils.mkdir_p(@temp_dir)
+          create_data_entries
+          compressed_stream = compress_data_entries
+          compressed_stream.read
+        ensure
+          FileUtils.rm_rf(@temp_dir)
+        end
+
+        private
+
+        def create_data_entries
+          readme_entry = {
+            path: "#{Rails.root}/public/README.pdf", name: 'README.pdf'
+          }
+          @data_entries = [readme_entry]
+          with_chunked_query do |query, chunk_idx|
+            content = content(query)
+            filename = filename(chunk_idx)
+            path = @temp_dir + '/' + filename
+            File.open(path, 'w') { |f| f.write content }
+            @data_entries << {path: path, name: filename}
+          end
+        end
+
+        def compress_data_entries
+          compressed_stream = Zip::OutputStream.write_buffer do |stream|
+            @data_entries.each do |entry|
+              stream.put_next_entry(entry[:name])
+              stream.write File.read(entry[:path])
+            end
+          end
+          compressed_stream.rewind
+          compressed_stream
         end
 
         # @abstract
+        # @param query [ActiveRecord::Relation]
         # @return [String] content
         # @raise [NotImplementedError] when not defined in subclass
-        def content
+        def content(_query)
           raise NotImplementedError
         end
 
-        def content_tempfile(content)
-          tempfile = Tempfile.new(filename)
-          tempfile << content
-          tempfile.close
-          tempfile
+        # @return [String]
+        def filename(chunk_idx)
+          "#{@download_name}#{chunk_idx ? ".part#{chunk_idx}" : nil}.#{format}"
         end
 
         # @abstract
-        # @return [String] name of file as included in zip archive
+        # @return [String] format / extension for the file
         # @raise [NotImplementedError] when not defined in subclass
-        def filename
+        def format
           raise NotImplementedError
         end
 
-        def create
-          @zipfile = Tempfile.new("#{@download_name}.zip")
-          Zip::OutputStream.open(@zipfile) { |zos| }
-          Zip::File.open(@zipfile.path, Zip::File::CREATE) do |zipfile|
-            zipfile.add(filename, content_tempfile(content).path)
-            zipfile.add('README.pdf', "#{Rails.root}/public/README.pdf")
+        CHUNK_SIZE = 500_000
+
+        def with_chunked_query
+          total = @query.except(:select).count
+          if total < CHUNK_SIZE
+            yield(@query, nil)
+          else
+            chunk_idx = 0
+            offset = 0
+            while offset < total
+              query = @query.limit(CHUNK_SIZE).offset(offset)
+              yield(query, chunk_idx)
+              chunk_idx += 1
+              offset += CHUNK_SIZE
+            end
           end
-          @zipfile
         end
       end
     end

--- a/app/services/api/v3/download/zipped_json_download.rb
+++ b/app/services/api/v3/download/zipped_json_download.rb
@@ -2,17 +2,19 @@ module Api
   module V3
     module Download
       class ZippedJsonDownload < ZippedDownload
-        def content
+        private
+
+        def content(query)
           json_query = Api::V3::Readonly::DownloadFlow.
             select('array_to_json(array_agg(row_to_json(t)))').
-            from("(#{@query.to_sql}) t")
+            from("(#{query.to_sql}) t")
           result = Api::V3::Readonly::DownloadFlow.connection.
             execute(json_query.to_sql)
           result.getvalue(0, 0)
         end
 
-        def filename
-          "#{@download_name}.json"
+        def format
+          :json
         end
       end
     end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2186,13 +2186,6 @@ CREATE MATERIALIZED VIEW download_flows_mv AS
 
 
 --
--- Name: MATERIALIZED VIEW download_flows_mv; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON MATERIALIZED VIEW download_flows_mv IS 'Combines data from flow_paths_mv and download_attributes_values_mv in a structure that can be directly used to generate data downloads.';
-
-
---
 -- Name: download_quals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2186,6 +2186,13 @@ CREATE MATERIALIZED VIEW download_flows_mv AS
 
 
 --
+-- Name: MATERIALIZED VIEW download_flows_mv; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON MATERIALIZED VIEW download_flows_mv IS 'Combines data from flow_paths_mv and download_attributes_values_mv in a structure that can be directly used to generate data downloads.';
+
+
+--
 -- Name: download_quals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
A few changes here:
- some new indexes on `download_flows_mv` to speed up filter by context and ordering of rows in downloads
- new column `row_name` in the `download_flows_mv`; this one used to be calculated on the fly for purposes of the pivot download, so having it pre-calculated should give it a boost and also can be used for sorting rows
- sorting is important, because we now added the chunking functionality to split files longer than 500k rows; this is done using `LIMIT` and `OFFSET` and it requires a predictable sort order
- my favourite part is giving the json downloads a boost by replacing the Rails `to_json` method with native Postgres json support. It makes the query take longer but there's almost no overhead on top of the query and the total time improvement is remarkable (real time):

```
require 'benchmark'

def rails_to_json(collection_query)
  collection_query.to_json
end

def postgres_to_json(collection_query)
  json_query = Api::V3::Readonly::DownloadFlow.
    select('array_to_json(array_agg(row_to_json(t)))').
    from("(#{collection_query.to_sql}) t")
  result = Api::V3::Readonly::DownloadFlow.connection.
    execute(json_query.to_sql)
end

collection_query = Api::V3::Readonly::DownloadFlow.where(context_id: 1).limit(500000)

collection_query.size

Benchmark.bm do |x|
  x.report("Postgres to_json:") { postgres_to_json(collection_query) }
  x.report("Rails to_json:") { rails_to_json(collection_query) }
end
                          user     system      total        real
Postgres to_json:     0.390000   0.650000   1.040000 ( 14.345017)
Rails to_json:      159.350000  13.880000 173.230000 (185.115569)
```