### PR TITLE
feat: limit years based on resize by and recolor by

### DIFF
--- a/frontend/scripts/react-components/nav/filters-nav/recolor-by-selector/recolor-by-selector.component.jsx
+++ b/frontend/scripts/react-components/nav/filters-nav/recolor-by-selector/recolor-by-selector.component.jsx
@@ -62,7 +62,9 @@ class RecolorBySelector extends Component {
     // Renders a dropdown item using recolorBy data
     const getRecolorByItem = (recolorBy, index) => {
       const isEnabled =
-        !recolorBy.isDisabled && difference(selectedYears, recolorBy.years).length === 0;
+        !recolorBy.isDisabled &&
+        (recolorBy.years.length === 0 || difference(selectedYears, recolorBy.years).length === 0);
+
       return (
         <li
           key={index}

--- a/frontend/scripts/react-components/nav/filters-nav/resize-by-selector/resize-by-selector.component.jsx
+++ b/frontend/scripts/react-components/nav/filters-nav/resize-by-selector/resize-by-selector.component.jsx
@@ -24,8 +24,11 @@ class ResizeBySelector extends Component {
               <li key={`separator-${index}`} className="dropdown-item -separator" />
             );
           }
+
           const isEnabled =
-            !resizeBy.isDisabled && difference(selectedYears, resizeBy.years).length === 0;
+            !resizeBy.isDisabled &&
+            (resizeBy.years.length === 0 || difference(selectedYears, resizeBy.years).length === 0);
+
           resizeByElements.push(
             <li
               key={index}

--- a/frontend/scripts/react-components/nav/filters-nav/years-selector/years-selector.container.js
+++ b/frontend/scripts/react-components/nav/filters-nav/years-selector/years-selector.container.js
@@ -2,12 +2,20 @@ import { connect } from 'react-redux';
 import { toggleDropdown } from 'actions/app.actions';
 import { selectYears } from 'actions/tool.actions';
 import YearsSelector from 'react-components/nav/filters-nav/years-selector/years-selector.component';
+import intersection from 'lodash/intersection';
 
-const mapStateToProps = state => ({
-  currentDropdown: state.app.currentDropdown,
-  selectedYears: state.tool.selectedYears,
-  years: state.tool.selectedContext.years
-});
+const mapStateToProps = state => {
+  const { selectedResizeBy, selectedRecolorBy, selectedContext, selectedYears } = state.tool;
+  const availableYearsResize = intersection(selectedResizeBy.years, selectedContext.years);
+  const availableYearsRecolor = intersection(selectedRecolorBy.years, selectedContext.years);
+  const years = intersection(availableYearsRecolor, availableYearsResize);
+
+  return {
+    years,
+    selectedYears,
+    currentDropdown: state.app.currentDropdown
+  };
+};
 
 const mapDispatchToProps = dispatch => ({
   onToggle: id => {

--- a/frontend/scripts/react-components/nav/filters-nav/years-selector/years-selector.container.js
+++ b/frontend/scripts/react-components/nav/filters-nav/years-selector/years-selector.container.js
@@ -6,9 +6,18 @@ import intersection from 'lodash/intersection';
 
 const mapStateToProps = state => {
   const { selectedResizeBy, selectedRecolorBy, selectedContext, selectedYears } = state.tool;
-  const availableYearsResize = intersection(selectedResizeBy.years, selectedContext.years);
-  const availableYearsRecolor = intersection(selectedRecolorBy.years, selectedContext.years);
-  const years = intersection(availableYearsRecolor, availableYearsResize);
+
+  const availableContextYears = selectedContext.years;
+  const availableResizeByYears =
+    selectedResizeBy.years.length > 0 ? selectedResizeBy.years : availableContextYears;
+  const availableRecolorByYears =
+    selectedRecolorBy.years.length > 0 ? selectedRecolorBy.years : availableContextYears;
+
+  const years = intersection(
+    availableContextYears,
+    availableResizeByYears,
+    availableRecolorByYears
+  );
 
   return {
     years,


### PR DESCRIPTION
OK so this PR makes sure, you can't select a year if the selected resize-by or recolor-by doesn't have data. I'm not a big fan of this, because limits what the user can do on the map (doesn't it?).

Please test and review.