### PR TITLE
Load map nodes attributes per selected layer

### DIFF
--- a/app/controllers/api/v3/nodes/nodes_attributes_controller.rb
+++ b/app/controllers/api/v3/nodes/nodes_attributes_controller.rb
@@ -7,7 +7,7 @@ module Api
           ensure_required_param_present(:end_year)
 
           result = Api::V3::NodeAttributes::Filter.new(
-            @context, params[:start_year].to_i, params[:end_year].to_i
+            @context, params[:start_year].to_i, params[:end_year].to_i, params[:layer_ids]
           ).result
 
           render json: {data: result}

--- a/app/controllers/api/v3/nodes/nodes_attributes_controller.rb
+++ b/app/controllers/api/v3/nodes/nodes_attributes_controller.rb
@@ -5,6 +5,7 @@ module Api
         def index
           ensure_required_param_present(:start_year)
           ensure_required_param_present(:end_year)
+          ensure_required_param_present(:layer_ids)
 
           result = Api::V3::NodeAttributes::Filter.new(
             @context, params[:start_year].to_i, params[:end_year].to_i, params[:layer_ids]

--- a/app/services/api/v3/node_attributes/filter.rb
+++ b/app/services/api/v3/node_attributes/filter.rb
@@ -28,7 +28,7 @@ module Api
 
         def attribute_values_query(attribute_type, attribute_node_values_class)
           node_values = attribute_node_values_class.table_name
-          query = attribute_node_values_class.
+          attribute_node_values_class.
             select(select_list(attribute_type, node_values)).
             joins("JOIN nodes ON nodes.id = #{node_values}.node_id").
             joins("JOIN context_node_types cnt ON \

--- a/app/services/api/v3/node_attributes/filter.rb
+++ b/app/services/api/v3/node_attributes/filter.rb
@@ -5,9 +5,10 @@ module Api
         # @param context [Api::V3::Context]
         # @param start_year [Integer]
         # @param end_year [Integer]
-        def initialize(context, start_year, end_year)
+        def initialize(context, start_year, end_year, layer_ids)
           @context = context
           @years = (start_year..end_year).to_a
+          @layer_ids = layer_ids.map(&:to_i)
         end
 
         def result
@@ -27,7 +28,7 @@ module Api
 
         def attribute_values_query(attribute_type, attribute_node_values_class)
           node_values = attribute_node_values_class.table_name
-          attribute_node_values_class.
+          query = attribute_node_values_class.
             select(select_list(attribute_type, node_values)).
             joins("JOIN nodes ON nodes.id = #{node_values}.node_id").
             joins("JOIN context_node_types cnt ON \
@@ -41,6 +42,7 @@ maa.#{attribute_type}_id = #{node_values}.#{attribute_type}_id").
               @years
             ).
             where('ma.context_id' => @context.id, 'ma.is_disabled' => false).
+            where('ma.id IN (?)', @layer_ids).
             where('ma.years IS NULL OR array_length(ma.years, 1) IS NULL OR ma.years && ARRAY[?]', @years).
             group(
               "#{node_values}.node_id",

--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -39,11 +39,12 @@ export const RESET_SELECTION = 'RESET_SELECTION';
 export const SET_CONTEXT = 'SET_CONTEXT';
 export const LOAD_INITIAL_CONTEXT = 'LOAD_INITIAL_CONTEXT';
 export const GET_COLUMNS = 'GET_COLUMNS';
-export const LOAD_LINKS = 'LOAD_LINKS';
+export const SET_FLOWS_LOADING_STATE = 'SET_FLOWS_LOADING_STATE';
+export const SET_MAP_LOADING_STATE = 'SET_MAP_LOADING_STATE';
 export const LOAD_NODES = 'LOAD_NODES';
 export const GET_LINKS = 'GET_LINKS';
-export const GET_NODE_ATTRIBUTES = 'GET_NODE_ATTRIBUTES';
-export const GET_MAP_DIMENSIONS = 'GET_MAP_DIMENSIONS';
+export const SET_NODE_ATTRIBUTES = 'SET_NODE_ATTRIBUTES';
+export const SET_MAP_DIMENSIONS_DATA = 'SET_MAP_DIMENSIONS_DATA';
 export const UPDATE_NODE_SELECTION = 'UPDATE_NODE_SELECTION';
 export const HIGHLIGHT_NODE = 'HIGHLIGHT_NODE';
 export const FILTER_LINKS_BY_NODES = 'FILTER_LINKS_BY_NODES';
@@ -55,7 +56,7 @@ export const SELECT_VIEW = 'SELECT_VIEW';
 export const SELECT_COLUMN = 'SELECT_COLUMN';
 export const GET_MAP_VECTOR_DATA = 'GET_MAP_VECTOR_DATA';
 export const GET_CONTEXT_LAYERS = 'GET_CONTEXT_LAYERS';
-export const SET_MAP_DIMENSIONS = 'SET_MAP_DIMENSIONS';
+export const SET_MAP_DIMENSIONS_SELECTION = 'SET_MAP_DIMENSIONS_SELECTION';
 export const TOGGLE_MAP_DIMENSION = 'TOGGLE_MAP_DIMENSION';
 export const SELECT_CONTEXTUAL_LAYERS = 'SELECT_CONTEXTUAL_LAYERS';
 export const SELECT_BASEMAP = 'SELECT_BASEMAP';
@@ -318,6 +319,11 @@ export function loadNodes() {
     dispatch({
       type: LOAD_NODES
     });
+
+    // dispatch({
+    //   type: SET_MAP_LOADING_STATE
+    // });
+
     const params = {
       context_id: getState().tool.selectedContextId,
       start_year: getState().tool.selectedYears[0],
@@ -369,7 +375,7 @@ export function loadNodes() {
         dispatch(setMapContextLayers(payload.mapDimensionsMetaJSON.contextualLayers));
 
         dispatch({
-          type: GET_MAP_DIMENSIONS,
+          type: SET_MAP_DIMENSIONS_DATA,
           payload
         });
 
@@ -414,7 +420,7 @@ export function loadNodes() {
 export function loadLinks() {
   return (dispatch, getState) => {
     dispatch({
-      type: LOAD_LINKS
+      type: SET_FLOWS_LOADING_STATE
     });
     const state = getState();
     const params = {
@@ -861,7 +867,7 @@ export function toggleMapDimension(uid) {
 export function setMapDimensions(uids) {
   return (dispatch, getState) => {
     dispatch({
-      type: SET_MAP_DIMENSIONS,
+      type: SET_MAP_DIMENSIONS_SELECTION,
       uids
     });
 
@@ -878,7 +884,7 @@ export function loadMapChoropeth(getState, dispatch) {
 
   if (compact(uids).length === 0) {
     dispatch({
-      type: GET_NODE_ATTRIBUTES
+      type: SET_NODE_ATTRIBUTES
     });
 
     return;
@@ -906,7 +912,7 @@ export function loadMapChoropeth(getState, dispatch) {
     })
     .then(payload => {
       dispatch({
-        type: GET_NODE_ATTRIBUTES,
+        type: SET_NODE_ATTRIBUTES,
         payload
       });
     });

--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -320,17 +320,12 @@ export function loadNodes() {
       type: LOAD_NODES
     });
 
-    // dispatch({
-    //   type: SET_MAP_LOADING_STATE
-    // });
-
     const params = {
       context_id: getState().tool.selectedContextId,
       start_year: getState().tool.selectedYears[0],
       end_year: getState().tool.selectedYears[1]
     };
 
-    // const getNodesURL = getURLFromParams(GET_NODE_ATTRIBUTES_URL, params);
     const getMapBaseDataURL = getURLFromParams(GET_MAP_BASE_DATA_URL, params);
     const selectedMapDimensions = getState().tool.selectedMapDimensions;
 

--- a/frontend/scripts/components/tool/tool-content.component.js
+++ b/frontend/scripts/components/tool/tool-content.component.js
@@ -15,19 +15,11 @@ export default class {
     this.sankeyResetButton.addEventListener('click', this.onSankeyReset);
   }
 
-  showLoaderAtInitialLoad(loading) {
-    this._toggleLoading(loading);
-  }
-
   _resetSankey() {
     this.callbacks.resetSankey();
   }
 
   showLoader(loading) {
-    this._toggleLoading(loading);
-  }
-
-  _toggleLoading(loading) {
     const toolLoading = document.querySelector('.js-tool-loading');
     if (toolLoading) toolLoading.classList.toggle('is-visible', loading);
   }

--- a/frontend/scripts/containers/tool/titlebar.container.js
+++ b/frontend/scripts/containers/tool/titlebar.container.js
@@ -8,15 +8,9 @@ const mapMethodsToState = state => ({
   selectNodes: state.tool.selectedNodesData,
   highlightNode: {
     _comparedValue: state => state.tool.highlightedNodeData,
-    _returnedValue: state => {
-      if (state.tool.highlightedNodeData.length === 0) {
-        if (!state.tool.selectedNodesData) {
-          return false;
-        }
-        return state.tool.selectedNodesData.length > 0;
-      }
-      return state.tool.highlightedNodeData.length > 0;
-    }
+    _returnedValue: state =>
+      state.tool.selectedNodesData.length > 0 ||
+      (!state.tool.highlightedNodeCoordinates && state.tool.highlightedNodeData.length > 0)
   }
 });
 

--- a/frontend/scripts/containers/tool/tool-content.container.js
+++ b/frontend/scripts/containers/tool/tool-content.container.js
@@ -6,8 +6,7 @@ import { resetSankey } from '../../actions/tool.actions';
 const mapMethodsToState = state => ({
   toggleMapVisibility: state.tool.isMapVisible,
   toggleMapLayersVisibility: state.app.isMapLayerVisible,
-  showLoaderAtInitialLoad: state.tool.initialDataLoading,
-  showLoader: state.tool.linksLoading,
+  showLoader: state.tool.flowsLoading || state.tool.mapLoading,
   toggleError: {
     _comparedValue: state => state.tool.links,
     _returnedValue: state => state.tool.links === null

--- a/frontend/scripts/reducers/helpers/getChoropleth.js
+++ b/frontend/scripts/reducers/helpers/getChoropleth.js
@@ -12,7 +12,7 @@ const _shortenTitle = title => {
 export default function(selectedMapDimensionsUids, nodesDictWithMeta, mapDimensions, forceEmpty) {
   const uids = compact(selectedMapDimensionsUids);
 
-  if (!uids.length) {
+  if (!uids.length || !mapDimensions.length) {
     return {
       choropleth: {},
       choroplethLegend: null

--- a/frontend/scripts/reducers/helpers/setNodesMeta.js
+++ b/frontend/scripts/reducers/helpers/setNodesMeta.js
@@ -6,6 +6,10 @@ export default function(nodesDict, nodesMeta, layers) {
   const layersByUID = _.keyBy(layers, 'uid');
   const nodesDictWithMeta = {};
 
+  if (!nodesMeta) {
+    return nodesDictWithMeta;
+  }
+
   nodesMeta.data.forEach(nodeMeta => {
     const nodeId = parseInt(nodeMeta.node_id, 10);
     const nodeWithMeta = nodesDictWithMeta[nodeId] || _.cloneDeep(nodesDict[nodeId]);

--- a/frontend/scripts/reducers/tool.reducer.js
+++ b/frontend/scripts/reducers/tool.reducer.js
@@ -6,11 +6,12 @@ import {
   GET_LINKED_GEOIDS,
   GET_LINKS,
   GET_MAP_VECTOR_DATA,
-  GET_NODE_ATTRIBUTES,
+  SET_NODE_ATTRIBUTES,
   HIGHLIGHT_NODE,
   LOAD_INITIAL_CONTEXT,
   LOAD_INITIAL_DATA,
-  LOAD_LINKS,
+  SET_FLOWS_LOADING_STATE,
+  SET_MAP_LOADING_STATE,
   RESET_SELECTION,
   RESET_TOOL_STATE,
   SAVE_MAP_VIEW,
@@ -23,7 +24,7 @@ import {
   SELECT_VIEW,
   SELECT_YEARS,
   SET_CONTEXT,
-  SET_MAP_DIMENSIONS,
+  SET_MAP_DIMENSIONS_SELECTION,
   SET_SANKEY_SEARCH_VISIBILITY,
   SHOW_LINKS_ERROR,
   TOGGLE_MAP,
@@ -31,7 +32,7 @@ import {
   TOGGLE_MAP_SIDEBAR_GROUP,
   TOGGLE_NODES_EXPAND,
   UPDATE_NODE_SELECTION,
-  GET_MAP_DIMENSIONS
+  SET_MAP_DIMENSIONS_DATA
 } from 'actions/tool.actions';
 import groupBy from 'lodash/groupBy';
 import isEqual from 'lodash/isEqual';
@@ -74,10 +75,11 @@ export const toolInitialState = {
   isSearchOpen: false,
   linkedGeoIds: [],
   links: [],
-  linksLoading: false,
+  flowsLoading: true,
   mapContextualLayers: [],
   mapDimensions: [],
   mapDimensionsGroups: [],
+  mapLoading: true,
   mapVectorData: null,
   mapView: null,
   nodes: [],
@@ -260,11 +262,15 @@ const toolReducer = {
     });
   },
 
-  [LOAD_LINKS](state) {
-    return Object.assign({}, state, { linksLoading: true });
+  [SET_FLOWS_LOADING_STATE](state) {
+    return Object.assign({}, state, { flowsLoading: true });
   },
 
-  [GET_NODE_ATTRIBUTES](state, action) {
+  [SET_MAP_LOADING_STATE](state) {
+    return Object.assign({}, state, { mapLoading: true });
+  },
+
+  [SET_NODE_ATTRIBUTES](state, action) {
     const nodesMeta = action.payload;
 
     // store dimension values in nodesDict as uid: dimensionValue
@@ -282,10 +288,11 @@ const toolReducer = {
     return Object.assign({}, state, {
       nodesDictWithMeta,
       choropleth,
-      choroplethLegend
+      choroplethLegend,
+      mapLoading: false
     });
   },
-  [GET_MAP_DIMENSIONS](state, action) {
+  [SET_MAP_DIMENSIONS_DATA](state, action) {
     const mapDimensionsMeta = action.payload.mapDimensionsMetaJSON;
     const rawMapDimensions = mapDimensionsMeta.dimensions;
     const mapDimensions = getMapDimensions(rawMapDimensions);
@@ -325,7 +332,7 @@ const toolReducer = {
       visibleNodes,
       visibleNodesByColumn,
       currentQuant,
-      linksLoading: false
+      flowsLoading: false
     });
   },
   [SHOW_LINKS_ERROR](state) {
@@ -452,7 +459,7 @@ const toolReducer = {
   [GET_CONTEXT_LAYERS](state, action) {
     return Object.assign({}, state, { mapContextualLayers: action.mapContextualLayers });
   },
-  [SET_MAP_DIMENSIONS](state, action) {
+  [SET_MAP_DIMENSIONS_SELECTION](state, action) {
     const selectedMapDimensions = action.uids;
 
     // TODO Remove that when server correctly implements map dimensions meta/choropleth
@@ -511,9 +518,8 @@ const toolReducer = {
     );
     return Object.assign({}, state, {
       selectedMapDimensions,
-      selectedMapDimensionsWarnings
-      // choropleth,
-      // choroplethLegend
+      selectedMapDimensionsWarnings,
+      mapLoading: true
     });
   },
   [SELECT_CONTEXTUAL_LAYERS](state, action) {
@@ -600,10 +606,11 @@ const toolReducerTypes = PropTypes => ({
   isMapVisible: PropTypes.bool,
   linkedGeoIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   links: PropTypes.arrayOf(PropTypes.object).isRequired,
-  linksLoading: PropTypes.bool,
+  flowsLoading: PropTypes.bool,
   mapContextualLayers: PropTypes.arrayOf(PropTypes.object).isRequired,
   mapDimensions: PropTypes.arrayOf(PropTypes.object).isRequired,
   mapDimensionsGroups: PropTypes.arrayOf(PropTypes.object).isRequired,
+  mapLoading: PropTypes.bool,
   mapVectorData: PropTypes.object,
   mapView: PropTypes.object,
   nodes: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/frontend/scripts/reducers/tool.reducer.js
+++ b/frontend/scripts/reducers/tool.reducer.js
@@ -502,16 +502,6 @@ const toolReducer = {
       selectedMapDimensions[uidIndex] = null;
     }
 
-    // TODO Remove that when server correctly implements map dimensions meta/choropleth
-    // ie it shouldn't return choropleth values in get_nodes over multiple years if metadata says data is unavailable
-    // const forceEmptyChoropleth = state.selectedYears[1] - state.selectedYears[0] > 0;
-
-    // const { choropleth, choroplethLegend } = getChoropleth(
-    //   selectedMapDimensions,
-    //   state.nodesDictWithMeta,
-    //   state.mapDimensions,
-    //   forceEmptyChoropleth
-    // );
     const selectedMapDimensionsWarnings = getMapDimensionsWarnings(
       state.mapDimensions,
       selectedMapDimensions

--- a/spec/responses/api/v3/nodes_attributes_spec.rb
+++ b/spec/responses/api/v3/nodes_attributes_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe 'Nodes attributes', type: :request do
     end
 
     it 'has the correct response structure' do
-      get "/api/v3/contexts/#{api_v3_context.id}/nodes/attributes", params: {start_year: 2015, end_year: 2015}
+      get "/api/v3/contexts/#{api_v3_context.id}/nodes/attributes", params: {start_year: 2015, end_year: 2015, layer_ids: [api_v3_water_scarcity_map_attribute.id]}
 
       expect(@response).to have_http_status(:ok)
       expect(@response).to match_response_schema('v3_node_attributes')
+      expect(JSON.parse(@response.body)['data'].empty?).to be false
     end
   end
 end

--- a/spec/services/api/v3/node_attributes/filter_spec.rb
+++ b/spec/services/api/v3/node_attributes/filter_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Api::V3::NodeAttributes::Filter do
   let(:municipality_land_conflicts) {
     node_attributes.find do |node_attr|
       node_attr['node_id'] == api_v3_municipality_node.id &&
-      node_attr['attribute_id'] == api_v3_land_conflicts.id &&
-      node_attr['attribute_type'] == 'quant'
+        node_attr['attribute_id'] == api_v3_land_conflicts.id &&
+        node_attr['attribute_type'] == 'quant'
     end
   }
 
@@ -22,7 +22,7 @@ RSpec.describe Api::V3::NodeAttributes::Filter do
     }
     let(:filter) {
       Api::V3::NodeAttributes::Filter.new(
-        api_v3_context, 2015, 2015
+        api_v3_context, 2015, 2015, [api_v3_land_conflicts_map_attribute.id]
       )
     }
     # buckets [6, 10, 15]
@@ -56,7 +56,7 @@ RSpec.describe Api::V3::NodeAttributes::Filter do
     }
     let(:filter) {
       Api::V3::NodeAttributes::Filter.new(
-        api_v3_context, 2014, 2015
+        api_v3_context, 2014, 2015, [api_v3_land_conflicts_map_attribute.id]
       )
     }
 


### PR DESCRIPTION
Still WIP, and tests will probably fail. Will finish it next week

Loads map chorpeth info per selected layer(s) instead of loading the whole thing at once. Should improve perceived performance on initial load of the map/sankey