### PR TITLE
profile pages: improving pdf a little bit

### DIFF
--- a/frontend/html/profile-place.ejs
+++ b/frontend/html/profile-place.ejs
@@ -7,8 +7,8 @@
     <div class="js-wrap is-hidden">
       <div class="c-overall-map hide-for-small">
         <div class="row">
-          <div class="small-4 columns">
-            <div class="row medium-collapse large-uncollapse">
+          <div class="small-4 columns map-item">
+            <div class="row">
               <div class="small-6 columns">
                 <div class="c-locator-map js-map-country"></div>
               </div>
@@ -20,8 +20,8 @@
               </div>
             </div>
           </div>
-          <div class="small-4 columns">
-            <div class="row medium-collapse large-uncollapse">
+          <div class="small-4 columns map-item">
+            <div class="row">
               <div class="small-3 columns">
                 <div class="c-locator-map js-map-biome"></div>
               </div>
@@ -33,8 +33,8 @@
               </div>
             </div>
           </div>
-          <div class="small-4 columns">
-            <div class="row medium-collapse large-uncollapse">
+          <div class="small-4 columns map-item">
+            <div class="row">
               <div class="small-3 columns">
                 <div class="c-locator-map js-map-state"></div>
               </div>

--- a/frontend/scripts/react-components/profiles/scatterplot.component.jsx
+++ b/frontend/scripts/react-components/profiles/scatterplot.component.jsx
@@ -176,16 +176,22 @@ class Scatterplot extends Component {
   }
 
   _getFormattedData(i) {
-    return this.props.data.map(item => ({
-      nodeId: item.id,
-      name: item.name,
-      y: item.y,
-      x: item.x[i]
-    }));
+    const { data, node } = this.props;
+    const currentComesLast = a => (a.isCurrent ? 1 : -1);
+
+    return data
+      .map(item => ({
+        nodeId: item.id,
+        name: item.name,
+        isCurrent: item.name.toUpperCase() === node.name.toUpperCase(),
+        y: item.y,
+        x: item.x[i]
+      }))
+      .sort(currentComesLast);
   }
 
   _getCircleClass(d) {
-    return d.name.toUpperCase() === this.props.node.name.toUpperCase() ? 'dot current' : 'dot';
+    return d.isCurrent ? 'dot current' : 'dot';
   }
 
   render() {

--- a/frontend/styles/components/profiles/info.scss
+++ b/frontend/styles/components/profiles/info.scss
@@ -27,7 +27,7 @@
     }
   }
 
-  @media screen and (max-width: $breakpoint-foundation-medium) {
+  @media (max-width: $breakpoint-foundation-medium) {
     padding-left: 15px;
   }
 }

--- a/frontend/styles/components/profiles/map.scss
+++ b/frontend/styles/components/profiles/map.scss
@@ -26,8 +26,14 @@
   &.-outline {
     stroke: $charcoal-grey-faded;
   }
+}
 
-  @media print {
-    stroke: $black;
+@media print {
+  .c-overall-map .polygon {
+    stroke-width: 0 !important;
+  }
+
+  .polygon, .polygon.-outline {
+    stroke: $white;
   }
 }

--- a/frontend/styles/layouts/l-profile-actor.scss
+++ b/frontend/styles/layouts/l-profile-actor.scss
@@ -94,8 +94,8 @@
       }
     }
 
-    @media screen and (min-width: $breakpoint-foundation-small)
-                  and (max-width: $breakpoint-foundation-medium) {
+    @media (min-width: $breakpoint-foundation-small)
+       and (max-width: $breakpoint-foundation-medium) {
       > .row .columns:not(:last-child) {
         padding-right: 0;
       }

--- a/frontend/styles/layouts/l-profile-place.scss
+++ b/frontend/styles/layouts/l-profile-place.scss
@@ -30,24 +30,19 @@
 
   .c-overall-map {
 
-    @media print {
+    .map-item {
       > .row > .columns {
         padding: 0;
+
+        svg {
+          float: right;
+        }
+
+        @media screen and (min-width: $breakpoint-foundation-medium) {
+          padding-right: 1.25rem;
+          padding-left: 1.25rem;
+        }
       }
-    }
-
-    > .map-list {
-      display: flex;
-    }
-
-    > .map-list > .map-item {
-      display: flex;
-      flex-basis: calc(100% / 3);
-      align-items: center;
-    }
-
-    .c-locator-map {
-      max-height: 100px;
     }
   }
 
@@ -70,8 +65,8 @@
       display: none;
     }
 
-    @media screen and (min-width: $breakpoint-foundation-small)
-                  and (max-width: $breakpoint-foundation-medium) {
+    @media (min-width: $breakpoint-foundation-small)
+       and (max-width: $breakpoint-foundation-medium) {
       > .row .columns:not(:last-child) {
         padding-right: 0;
       }


### PR DESCRIPTION
Following up https://github.com/Vizzuality/trase/issues/191. Minor styles changes, white outlines for maps, bringing up red dots to the front on scatterplots.

Printed examples:
- https://github.com/Vizzuality/trase/files/1894998/TRASE-1523369771420.pdf
- https://github.com/Vizzuality/trase/files/1894999/TRASE-1523369308027.pdf