### PR TITLE
Fixing fitting map to selected geo nodes and linked nodes

### DIFF
--- a/frontend/scripts/components/tool/map.component.js
+++ b/frontend/scripts/components/tool/map.component.js
@@ -147,12 +147,13 @@ export default class {
 
     if (forceDefaultMapView === true) {
       this.setMapView(defaultMapView);
-    } else if (
-      this.vectorOutline !== undefined &&
-      selectedGeoIds.length &&
-      this.currentPolygonTypeLayer &&
-      (!linkedGeoIds || linkedGeoIds.length === 0)
-    ) {
+    } else if (!linkedGeoIds || linkedGeoIds.length === 0) {
+      this._fitBoundsToSelectedPolygons(selectedGeoIds);
+    }
+  }
+
+  _fitBoundsToSelectedPolygons(selectedGeoIds) {
+    if (this.vectorOutline !== undefined && selectedGeoIds.length && this.currentPolygonTypeLayer) {
       if (!this.currentPolygonTypeLayer.isPoint) {
         this.map.fitBounds(this.vectorOutline.getBounds());
       } else {
@@ -370,7 +371,7 @@ export default class {
     });
   }
 
-  showLinkedGeoIds({ linkedGeoIds, defaultMapView, forceDefaultMapView }) {
+  showLinkedGeoIds({ linkedGeoIds, selectedGeoIds, defaultMapView, forceDefaultMapView }) {
     if (!this.currentPolygonTypeLayer) {
       return;
     }
@@ -395,6 +396,8 @@ export default class {
       const boundsCenterZoom = this.map._getBoundsCenterZoom(bounds);
       boundsCenterZoom.zoom = Math.max(boundsCenterZoom.zoom, defaultMapView.zoom);
       this.map.setView(boundsCenterZoom.center, boundsCenterZoom.zoom);
+    } else {
+      this._fitBoundsToSelectedPolygons(selectedGeoIds);
     }
   }
 

--- a/frontend/scripts/components/tool/map.component.js
+++ b/frontend/scripts/components/tool/map.component.js
@@ -123,7 +123,7 @@ export default class {
 
     this.selectPolygonType({ selectedColumnsIds: currentPolygonType, biomeFilter });
     if (selectedNodesGeoIds) {
-      this.selectPolygons({ selectedGeoIds: selectedNodesGeoIds });
+      this.selectPolygons({ selectedGeoIds: selectedNodesGeoIds, linkedGeoIds });
     }
 
     // under normal circumstances, choropleth (depends on loadNodes) and linkedGeoIds (depends on loadLinks)
@@ -136,7 +136,13 @@ export default class {
     }
   }
 
-  selectPolygons({ selectedGeoIds, highlightedGeoId, forceDefaultMapView, defaultMapView }) {
+  selectPolygons({
+    selectedGeoIds,
+    linkedGeoIds,
+    highlightedGeoId,
+    forceDefaultMapView,
+    defaultMapView
+  }) {
     this._outlinePolygons({ selectedGeoIds, highlightedGeoId });
 
     if (forceDefaultMapView === true) {
@@ -144,7 +150,8 @@ export default class {
     } else if (
       this.vectorOutline !== undefined &&
       selectedGeoIds.length &&
-      this.currentPolygonTypeLayer
+      this.currentPolygonTypeLayer &&
+      (!linkedGeoIds || linkedGeoIds.length === 0)
     ) {
       if (!this.currentPolygonTypeLayer.isPoint) {
         this.map.fitBounds(this.vectorOutline.getBounds());

--- a/frontend/scripts/containers/tool/map.container.js
+++ b/frontend/scripts/containers/tool/map.container.js
@@ -58,6 +58,7 @@ const mapMethodsToState = state => ({
     _comparedValue: state => state.tool.linkedGeoIds,
     _returnedValue: state => ({
       linkedGeoIds: state.tool.linkedGeoIds,
+      selectedGeoIds: state.tool.selectedNodesGeoIds,
       defaultMapView: state.tool.selectedContext ? state.tool.selectedContext.map : null,
       // get back to context default map view if no nodes are selected
       forceDefaultMapView: !state.tool.selectedNodesIds.length

--- a/frontend/scripts/containers/tool/map.container.js
+++ b/frontend/scripts/containers/tool/map.container.js
@@ -34,6 +34,7 @@ const mapMethodsToState = state => ({
     _comparedValue: state => state.tool.selectedNodesGeoIds,
     _returnedValue: state => ({
       selectedGeoIds: state.tool.selectedNodesGeoIds,
+      linkedGeoIds: state.tool.linkedGeoIds,
       defaultMapView: state.tool.selectedContext ? state.tool.selectedContext.map : null,
       forceDefaultMapView: !state.tool.selectedNodesIds.length
     })


### PR DESCRIPTION
Fixing https://github.com/Vizzuality/trase/issues/420. If there are any selected linked nodes then map should not try to fit bounds to all selected nodes.