### PR TITLE
Feat: translate links

### DIFF
--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -111,6 +111,8 @@ export const PROFILE_CHOROPLETH_CLASSES = [
   'ch-red-4'
 ];
 
+export const DOCUMENT_POST_TYPES = ['INFO BRIEF', 'ISSUE BRIEF'];
+
 export const NODE_SELECTION_LINKS_NUM_COLORS = 10;
 export const SANKEY_TRANSITION_TIME = 1000;
 

--- a/frontend/scripts/react-components/home/slider-section.component.jsx
+++ b/frontend/scripts/react-components/home/slider-section.component.jsx
@@ -76,7 +76,7 @@ class SliderSection extends React.PureComponent {
     const { className, name, slides } = this.props;
     const { visiblePages, currentSlide } = this.state;
     const smallScreen = visiblePages === 1;
-    const numColums = slides.length <= visiblePages && visiblePages < 3 ? 6 : 4;
+    const numColumns = slides.length <= visiblePages && visiblePages < 3 ? 6 : 4;
 
     if (slides.length === 0) return null;
     return (
@@ -95,7 +95,7 @@ class SliderSection extends React.PureComponent {
             {slides.map(slide => (
               <div
                 key={slide.title || slide.quote}
-                className={`column small-12 medium-${numColums}`}
+                className={`column small-12 medium-${numColumns}`}
               >
                 <div className={cx('slide', { '-actionable': !slide.quote })}>
                   {slide.quote ? (

--- a/frontend/scripts/react-components/home/slider-section.component.jsx
+++ b/frontend/scripts/react-components/home/slider-section.component.jsx
@@ -101,7 +101,11 @@ class SliderSection extends React.PureComponent {
                   {slide.quote ? (
                     <QuoteTile slide={slide} />
                   ) : (
-                    <StoryTile slide={slide} action={SliderSection.getActionName(slide.category)} />
+                    <StoryTile
+                      slide={slide}
+                      action={SliderSection.getActionName(slide.category)}
+                      translateUrl={SliderSection.getActionName(slide.category) === 'Open document'}
+                    />
                   )}
                 </div>
               </div>

--- a/frontend/scripts/react-components/home/slider-section.component.jsx
+++ b/frontend/scripts/react-components/home/slider-section.component.jsx
@@ -5,6 +5,7 @@ import cx from 'classnames';
 import QuoteTile from 'react-components/home/quote-tile.component';
 import StoryTile from 'react-components/home/story-tile.component';
 import debounce from 'lodash/debounce';
+import { DOCUMENT_POST_TYPES } from 'scripts/constants';
 
 class SliderSection extends React.PureComponent {
   static getPerPage() {
@@ -20,7 +21,7 @@ class SliderSection extends React.PureComponent {
   }
 
   static getActionName(category) {
-    if (['INFO BRIEF', 'ISSUE BRIEF'].includes(category)) {
+    if (DOCUMENT_POST_TYPES.includes(category)) {
       return 'Open document';
     }
     return 'See More';
@@ -101,11 +102,7 @@ class SliderSection extends React.PureComponent {
                   {slide.quote ? (
                     <QuoteTile slide={slide} />
                   ) : (
-                    <StoryTile
-                      slide={slide}
-                      action={SliderSection.getActionName(slide.category)}
-                      translateUrl={SliderSection.getActionName(slide.category) === 'Open document'}
-                    />
+                    <StoryTile slide={slide} action={SliderSection.getActionName(slide.category)} />
                   )}
                 </div>
               </div>

--- a/frontend/scripts/react-components/home/story-tile.component.jsx
+++ b/frontend/scripts/react-components/home/story-tile.component.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 function StoryTile(props) {
-  const { slide, action } = props;
+  const { slide, action, translateUrl } = props;
 
   return (
     <React.Fragment>
@@ -11,6 +11,7 @@ function StoryTile(props) {
         href={slide.completePostUrl}
         target="_blank"
         rel="noopener noreferrer"
+        tx-content={translateUrl && 'translate_urls'}
       >
         <figure className="slide-image" style={{ backgroundImage: `url(${slide.imageUrl})` }} />
       </a>
@@ -24,6 +25,7 @@ function StoryTile(props) {
           target="_blank"
           rel="noopener noreferrer"
           href={slide.completePostUrl}
+          tx-content={translateUrl && 'translate_urls'}
         >
           {action}
         </a>
@@ -39,7 +41,8 @@ StoryTile.propTypes = {
     imageUrl: PropTypes.string,
     completePostUrl: PropTypes.string
   }).isRequired,
-  action: PropTypes.string.isRequired
+  action: PropTypes.string.isRequired,
+  translateUrl: PropTypes.bool
 };
 
 export default StoryTile;

--- a/frontend/scripts/react-components/home/story-tile.component.jsx
+++ b/frontend/scripts/react-components/home/story-tile.component.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 function StoryTile(props) {
-  const { slide, action, translateUrl } = props;
+  const { slide, action } = props;
 
   return (
     <React.Fragment>
@@ -11,7 +11,7 @@ function StoryTile(props) {
         href={slide.completePostUrl}
         target="_blank"
         rel="noopener noreferrer"
-        tx-content={translateUrl && 'translate_urls'}
+        tx-content="translate_urls"
       >
         <figure className="slide-image" style={{ backgroundImage: `url(${slide.imageUrl})` }} />
       </a>
@@ -25,7 +25,7 @@ function StoryTile(props) {
           target="_blank"
           rel="noopener noreferrer"
           href={slide.completePostUrl}
-          tx-content={translateUrl && 'translate_urls'}
+          tx-content="translate_urls"
         >
           {action}
         </a>
@@ -41,8 +41,7 @@ StoryTile.propTypes = {
     imageUrl: PropTypes.string,
     completePostUrl: PropTypes.string
   }).isRequired,
-  action: PropTypes.string.isRequired,
-  translateUrl: PropTypes.bool
+  action: PropTypes.string.isRequired
 };
 
 export default StoryTile;

--- a/frontend/scripts/react-components/static-content/markdown-renderer/markdown-renderer.component.jsx
+++ b/frontend/scripts/react-components/static-content/markdown-renderer/markdown-renderer.component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import remark from 'remark';
 import remarkReact from 'remark-react';
 import cx from 'classnames';
+import Link from 'redux-first-router-link';
 
 const MarkdownRenderer = props => {
   const { content, className } = props;
@@ -10,8 +11,19 @@ const MarkdownRenderer = props => {
   const MarkdownContainer = p => (
     <div className={cx('markdown-content', className)}>{p.children}</div>
   );
+  const SmartLink = p => {
+    const isAbsoluteLink = /^http(s)?:\/\//.test(p.href);
+    if (!isAbsoluteLink) {
+      return <Link to={p.href}>{p.children}</Link>;
+    }
+    return (
+      <a href={p.href} target="_blank" rel="noopener noreferrer" tx-content="translate_urls">
+        {p.children}
+      </a>
+    );
+  };
   return remark()
-    .use(remarkReact, { remarkReactComponents: { div: MarkdownContainer } })
+    .use(remarkReact, { remarkReactComponents: { div: MarkdownContainer, a: SmartLink } })
     .processSync(content).contents;
 };
 

--- a/frontend/scripts/react-components/static-content/markdown-renderer/markdown-renderer.component.jsx
+++ b/frontend/scripts/react-components/static-content/markdown-renderer/markdown-renderer.component.jsx
@@ -13,7 +13,8 @@ const MarkdownRenderer = props => {
   );
   const SmartLink = p => {
     const isAbsoluteLink = /^http(s)?:\/\//.test(p.href);
-    if (!isAbsoluteLink) {
+    const isEmail = /^mailto:/.test(p.href);
+    if (!isAbsoluteLink && !isEmail) {
       return <Link to={p.href}>{p.children}</Link>;
     }
     return (


### PR DESCRIPTION
This PR includes behaviour to allow us to translate links urls. How does it work?
It will add a special transifex property to the `<a>` tags that need translating their href.

This is applied for document links only, so it's limited to the links in the home slider that point to documents and to the absolute links in the static pages.

We we're able to achieve this in the markdown pages thanks to glorious `remark-react` 🙌 . We provide a custom component for the `<a>` tags, and will use it to render all markdown links. This also allowed us to using `redux-first-router-link` `<Link />` for internal links.

Tested on transifex platform and the links are replaced by placeholders that need translating, so basically it _just works™_.
 