### PR TITLE
Fix/improvements for global search

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3895,7 +3895,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "dev": true,
       "requires": {
@@ -5561,9 +5561,9 @@
       }
     },
     "downshift": {
-      "version": "1.31.2",
-      "resolved": "https://registry.npmjs.org/downshift/-/downshift-1.31.2.tgz",
-      "integrity": "sha512-z8by12jDYb8i/5vbDA3fH/dQMIUIGcb/tuijT5WTPnbL/51YUA0iaKkdJORhnp6SfeRt8briMpOcMGFRtoABzw=="
+      "version": "1.31.12",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-1.31.12.tgz",
+      "integrity": "sha512-v9OCGFX6Zp/PUW6dlX7qTn5ee4ykdqCGwYQfwdKbehxdJB1heRdsms0Anmu/Eu0yH/0lF1JEYtXgODMjVfaPUA=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,7 +94,7 @@
     "d3-geo-projection": "^2.3.2",
     "d3-plugins-sankey": "^1.2.1",
     "dotenv": "^4.0.0",
-    "downshift": "^1.31.2",
+    "downshift": "^1.31.12",
     "find-parent": "^2.0.2",
     "highlight-words-core": "^1.2.0",
     "leaflet": "^1.3.1",

--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -134,13 +134,13 @@ export function loadSearchResults(searchTerm) {
       .then(results => {
         dispatch({
           type: LOAD_SEARCH_RESULTS,
-          payload: results.data
+          payload: { term: searchTerm, results: results.data }
         });
       })
       .catch(() => {
         dispatch({
           type: LOAD_SEARCH_RESULTS,
-          payload: []
+          payload: { term: searchTerm, results: [] }
         });
       });
   };

--- a/frontend/scripts/react-components/nav/top-nav/global-search/global-search-result.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav/global-search/global-search-result.component.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import camelcase from 'lodash/camelCase';
@@ -6,68 +6,77 @@ import camelcase from 'lodash/camelCase';
 import LinkButton from 'react-components/shared/link-button.component';
 import HighlightTextFragments from 'react-components/shared/highlight-text-fragments.component';
 
-function GlobalSearchResult({ value, itemProps, isHighlighted, item }) {
-  return (
-    <li {...itemProps} className={cx('c-search-result', { '-highlighted': isHighlighted })}>
-      <div className="search-node-text-container">
-        <span className="search-node-type">{item.nodeTypeText}</span>
-        <span className="search-node-name">
-          <HighlightTextFragments text={item.name} highlight={value} />
-        </span>
-      </div>
-      <div className="search-node-actions-container">
-        <LinkButton
-          className="-medium-large -charcoal"
-          to={{
-            type: 'tool',
-            payload: {
-              query: {
-                state: {
-                  selectedContextId: item.contextId,
-                  selectedNodesIds: item.nodes.map(i => i.id)
-                }
-              }
-            }
-          }}
-        >
-          Supply Chain
-        </LinkButton>
-        <LinkButton
-          className="-medium-large"
-          to={{
-            type: 'tool',
-            payload: {
-              query: {
-                state: {
-                  isMapVisible: true,
-                  selectedContextId: item.contextId,
-                  selectedNodesIds: item.nodes.map(i => i.id)
-                }
-              }
-            }
-          }}
-        >
-          Production Region
-        </LinkButton>
+class GlobalSearchResult extends Component {
+  shouldComponentUpdate(nextProps) {
+    return !nextProps.isLoading && this.props.isLoading;
+  }
 
-        {item.nodes.filter(n => n.profile).map(node => (
+  render() {
+    const { value, itemProps, isHighlighted, item } = this.props;
+
+    return (
+      <li {...itemProps} className={cx('c-search-result', { '-highlighted': isHighlighted })}>
+        <div className="search-node-text-container">
+          <span className="search-node-type">{item.nodeTypeText}</span>
+          <span className="search-node-name">
+            <HighlightTextFragments text={item.name} highlight={value} />
+          </span>
+        </div>
+        <div className="search-node-actions-container">
           <LinkButton
-            className="-medium-large"
-            key={node.id}
+            className="-medium-large -charcoal"
             to={{
-              type: camelcase(`profile-${node.profile}`),
-              query: { nodeId: node.id }
+              type: 'tool',
+              payload: {
+                query: {
+                  state: {
+                    selectedContextId: item.contextId,
+                    selectedNodesIds: item.nodes.map(i => i.id)
+                  }
+                }
+              }
             }}
           >
-            See {node.nodeType} profile
+            Supply Chain
           </LinkButton>
-        ))}
-      </div>
-    </li>
-  );
+          <LinkButton
+            className="-medium-large"
+            to={{
+              type: 'tool',
+              payload: {
+                query: {
+                  state: {
+                    isMapVisible: true,
+                    selectedContextId: item.contextId,
+                    selectedNodesIds: item.nodes.map(i => i.id)
+                  }
+                }
+              }
+            }}
+          >
+            Production Region
+          </LinkButton>
+
+          {item.nodes.filter(n => n.profile).map(node => (
+            <LinkButton
+              className="-medium-large"
+              key={node.id}
+              to={{
+                type: camelcase(`profile-${node.profile}`),
+                query: { nodeId: node.id }
+              }}
+            >
+              See {node.nodeType} profile
+            </LinkButton>
+          ))}
+        </div>
+      </li>
+    );
+  }
 }
 
 GlobalSearchResult.propTypes = {
+  isLoading: PropTypes.bool,
   value: PropTypes.string,
   itemProps: PropTypes.object,
   isHighlighted: PropTypes.bool,

--- a/frontend/scripts/react-components/nav/top-nav/global-search/global-search-result.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav/global-search/global-search-result.component.jsx
@@ -8,7 +8,10 @@ import HighlightTextFragments from 'react-components/shared/highlight-text-fragm
 
 class GlobalSearchResult extends Component {
   shouldComponentUpdate(nextProps) {
-    return !nextProps.isLoading && this.props.isLoading;
+    return (
+      (!nextProps.isLoading && this.props.isLoading) ||
+      nextProps.isHighlighted !== this.props.isHighlighted
+    );
   }
 
   render() {

--- a/frontend/scripts/react-components/nav/top-nav/global-search/global-search-result.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav/global-search/global-search-result.component.jsx
@@ -17,7 +17,7 @@ function GlobalSearchResult({ value, itemProps, isHighlighted, item }) {
       </div>
       <div className="search-node-actions-container">
         <LinkButton
-          className="-medium-large"
+          className="-medium-large -charcoal"
           to={{
             type: 'tool',
             payload: {

--- a/frontend/scripts/react-components/nav/top-nav/global-search/global-search.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav/global-search/global-search.component.jsx
@@ -64,7 +64,7 @@ export default class GlobalSearch extends Component {
   }
 
   render() {
-    const { isLoading, className, searchResults = [], searchTerm } = this.props;
+    const { isLoading, className, searchResults = [], searchTerm, onItemSelected } = this.props;
     const { isSearchOpen } = this.state;
     const noResults = !searchResults.length && !isLoading && !isEmpty(searchTerm);
 
@@ -91,7 +91,7 @@ export default class GlobalSearch extends Component {
         <div className="search-wrapper">
           <Downshift
             itemToString={i => (i === null ? '' : i.name)}
-            onSelect={this.onSelected}
+            onSelect={onItemSelected}
             onInputValueChange={this.onInputValueChange}
             ref={this.setDownshiftRef}
           >
@@ -143,6 +143,7 @@ GlobalSearch.propTypes = {
   className: PropTypes.string,
   isLoading: PropTypes.bool,
   onInputValueChange: PropTypes.func,
+  onItemSelected: PropTypes.func,
   searchResults: PropTypes.array,
   searchTerm: PropTypes.string
 };

--- a/frontend/scripts/react-components/nav/top-nav/global-search/global-search.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav/global-search/global-search.component.jsx
@@ -95,7 +95,7 @@ export default class GlobalSearch extends Component {
             onInputValueChange={this.onInputValueChange}
             ref={this.setDownshiftRef}
           >
-            {({ getInputProps, getItemProps, isOpen, inputValue, highlightedIndex }) => (
+            {({ getInputProps, getItemProps, isOpen, highlightedIndex }) => (
               <div className="search-container" onClick={e => e.stopPropagation()}>
                 <div className="search-bar">
                   <input
@@ -115,7 +115,8 @@ export default class GlobalSearch extends Component {
                         .map((item, row) => (
                           <GlobalSearchResult
                             key={row}
-                            value={inputValue}
+                            value={searchTerm}
+                            isLoading={isLoading}
                             isHighlighted={row === highlightedIndex}
                             item={item}
                             itemProps={getItemProps({ item })}

--- a/frontend/scripts/react-components/nav/top-nav/global-search/global-search.container.js
+++ b/frontend/scripts/react-components/nav/top-nav/global-search/global-search.container.js
@@ -47,7 +47,20 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      onInputValueChange: inputValue => loadSearchResults(inputValue)
+      onInputValueChange: inputValue => loadSearchResults(inputValue),
+      onItemSelected: item =>
+        dispatch({
+          type: 'tool',
+          payload: {
+            query: {
+              state: {
+                selectedContextId: item.contextId,
+                selectedNodesIds: item.nodes.map(i => i.id),
+                expandedNodesIds: item.nodes.map(i => i.id)
+              }
+            }
+          }
+        })
     },
     dispatch
   );

--- a/frontend/scripts/reducers/app.reducer.js
+++ b/frontend/scripts/reducers/app.reducer.js
@@ -70,7 +70,14 @@ const appReducer = {
     return { ...state, search: { ...state.search, ...action.payload } };
   },
   [LOAD_SEARCH_RESULTS](state, action) {
-    return { ...state, search: { ...state.search, results: action.payload, isLoading: false } };
+    // if current search term is different than the one for results
+    // that means we can ignore those results as not the latest ones
+    if (state.search.term !== action.payload.term) return state;
+
+    return {
+      ...state,
+      search: { ...state.search, results: action.payload.results, isLoading: false }
+    };
   }
 };
 


### PR DESCRIPTION
https://github.com/Vizzuality/trase/issues/468
 
- [x] Have a default action when clicking on a result -> take to sankey
- [x] Results lose highlight between result reloads
- [x] We have to make sure we only show the latest results/for current search term
- [x] Keep search content on blur (for example when user look at the other browser tab, and go back to the page)

![global-search](https://user-images.githubusercontent.com/1286444/39242831-c4a05708-488b-11e8-8185-313d2dd7830b.gif)
