### PR TITLE
Feature/Google Analytics track not supported page

### DIFF
--- a/frontend/scripts/analytics/data.events.js
+++ b/frontend/scripts/analytics/data.events.js
@@ -1,4 +1,3 @@
-import isFunction from 'lodash/isFunction';
 import {
   GA_TRACK_DOWNLOAD_FILE_TYPE,
   GA_TRACK_DOWNLOAD_FILTERS,
@@ -6,7 +5,7 @@ import {
   GA_TRACK_DOWNLOAD_OUTPUT_TYPE
 } from './analytics.actions';
 
-export const GA_ACTION_WHITELIST = [
+export default [
   {
     type: GA_TRACK_DOWNLOAD_FILTERS,
     category: 'Download',
@@ -84,32 +83,3 @@ export const GA_ACTION_WHITELIST = [
     getPayload: action => action.payload
   }
 ];
-
-const googleAnalyticsMiddleware = store => next => action => {
-  if (typeof ga !== 'undefined') {
-    const state = store.getState();
-    const gaAction = GA_ACTION_WHITELIST.find(
-      whitelistAction => action.type === whitelistAction.type
-    );
-    if (gaAction) {
-      const gaEvent = {
-        hitType: 'event',
-        eventCategory: gaAction.category
-      };
-      if (isFunction(gaAction.action)) {
-        gaEvent.eventAction = gaAction.action(action, state);
-      } else {
-        gaEvent.eventAction = gaAction.action;
-      }
-      if (gaAction.getPayload) {
-        gaEvent.eventLabel = gaAction.getPayload(action, state);
-      }
-
-      window.ga('send', gaEvent);
-    }
-  }
-
-  return next(action);
-};
-
-export { googleAnalyticsMiddleware as default };

--- a/frontend/scripts/analytics/data.events.js
+++ b/frontend/scripts/analytics/data.events.js
@@ -34,17 +34,15 @@ export default [
             state.data.exporters.find(elem => elem.id === parseInt(exportersId, 10)).name
         );
       }
-      // TODO: this is now a nested array called filters
-      if (payload.indicators) {
-        payload.indicators = payload.indicators.map(
-          indicatorName =>
-            state.data.indicators.find(elem => elem.name === indicatorName).frontendName
+      // TODO: apply filters values?
+      if (payload.filters) {
+        payload.filters = payload.filters.map(
+          filter => state.data.indicators.find(elem => elem.name === filter.name).frontendName
         );
       }
 
       delete payload.c_ids;
       delete payload.e_ids;
-      delete payload.indicators;
       delete payload.context_id;
       delete payload.file;
       delete payload.type;
@@ -54,10 +52,11 @@ export default [
       const payloadStringComponents = [];
 
       Object.keys(payload).forEach(key => {
-        if (Array.isArray(payload[key])) {
-          payloadStringComponents.push(`${key}=${payload[key].join(',')}`);
+        const value = payload[key];
+        if (value && value.length) {
+          payloadStringComponents.push(`${key}=${value.join(',')}`);
         } else {
-          payloadStringComponents.push(`${key}=${payload[key]}`);
+          payloadStringComponents.push(`${key}=${value}`);
         }
       });
 

--- a/frontend/scripts/analytics/middleware.js
+++ b/frontend/scripts/analytics/middleware.js
@@ -1,0 +1,33 @@
+import isFunction from 'lodash/isFunction';
+import GA_TOOL_EVENTS from './tool.events';
+import GA_DATA_EVENTS from './data.events';
+
+const GA_EVENT_WHITELIST = [...GA_TOOL_EVENTS, ...GA_DATA_EVENTS];
+
+const googleAnalyticsMiddleware = store => next => action => {
+  if (typeof ga !== 'undefined') {
+    const state = store.getState();
+    const gaAction = GA_EVENT_WHITELIST.find(
+      whitelistAction => action.type === whitelistAction.type
+    );
+    if (gaAction) {
+      const gaEvent = {
+        hitType: 'event',
+        eventCategory: gaAction.category
+      };
+      if (isFunction(gaAction.action)) {
+        gaEvent.eventAction = gaAction.action(action, state);
+      } else {
+        gaEvent.eventAction = gaAction.action;
+      }
+      if (gaAction.getPayload) {
+        gaEvent.eventLabel = gaAction.getPayload(action, state);
+      }
+      window.ga('send', gaEvent);
+    }
+  }
+
+  return next(action);
+};
+
+export default googleAnalyticsMiddleware;

--- a/frontend/scripts/analytics/router.events.js
+++ b/frontend/scripts/analytics/router.events.js
@@ -1,0 +1,6 @@
+export default [
+  {
+    type: 'notSupportedOnMobile',
+    hitType: 'pageview'
+  }
+];

--- a/frontend/scripts/analytics/tool.events.js
+++ b/frontend/scripts/analytics/tool.events.js
@@ -11,9 +11,8 @@ import {
   TOGGLE_MAP,
   UPDATE_NODE_SELECTION
 } from 'actions/tool.actions';
-import isFunction from 'lodash/isFunction';
 
-export const GA_ACTION_WHITELIST = [
+export default [
   {
     type: SET_CONTEXT,
     category: 'Sankey',
@@ -82,31 +81,3 @@ export const GA_ACTION_WHITELIST = [
     getPayload: action => action.contextualLayers.join(', ')
   }
 ];
-
-const googleAnalyticsMiddleware = store => next => action => {
-  if (typeof ga !== 'undefined') {
-    const state = store.getState();
-    const gaAction = GA_ACTION_WHITELIST.find(
-      whitelistAction => action.type === whitelistAction.type
-    );
-    if (gaAction) {
-      const gaEvent = {
-        hitType: 'event',
-        eventCategory: gaAction.category
-      };
-      if (isFunction(gaAction.action)) {
-        gaEvent.eventAction = gaAction.action(action, state);
-      } else {
-        gaEvent.eventAction = gaAction.action;
-      }
-      if (gaAction.getPayload) {
-        gaEvent.eventLabel = gaAction.getPayload(action, state);
-      }
-      window.ga('send', gaEvent);
-    }
-  }
-
-  return next(action);
-};
-
-export { googleAnalyticsMiddleware as default };

--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -2,7 +2,7 @@
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import rangeTouch from 'rangetouch';
-import analyticsMiddleware from 'analytics/tool.analytics.middleware';
+import analyticsMiddleware from 'analytics/middleware';
 import { toolUrlStateMiddleware } from 'utils/stateURL';
 import router from './router/router';
 import routeSubscriber from './router/route-subscriber';


### PR DESCRIPTION
Couple things here:

- re-enable tracking of data portal events
- track not-supported page views (https://github.com/Vizzuality/trase/issues/472)

I wonder, should we enable pageview tracking for the rest of the pages?