### PR TITLE
Explore page: fix world map data mismatch

### DIFF
--- a/frontend/scripts/react-components/shared/world-map/world-map.container.js
+++ b/frontend/scripts/react-components/shared/world-map/world-map.container.js
@@ -45,9 +45,8 @@ const getContextFlows = (countries, origin) => {
   }));
 };
 
-const memoizedGetContextFlows = memoize(
-  getContextFlows,
-  (c, o, ctxId, start, end) => ctxId + start + end
+const memoizedGetContextFlows = memoize(getContextFlows, (c, o, ctxId, start, end) =>
+  [ctxId, start, end].join('_')
 );
 
 const mapStateToProps = state => {


### PR DESCRIPTION
Fixing https://github.com/Vizzuality/trase/issues/462. Data shown on the map have a mismatch to the one in the table. The data was just taken from the wrong context (example Brazil-Beef 2014).