### PR TITLE
reset search term when removing global search component

### DIFF
--- a/frontend/scripts/react-components/nav/top-nav/global-search/global-search.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav/global-search/global-search.component.jsx
@@ -42,6 +42,8 @@ export default class GlobalSearch extends Component {
   }
 
   componentWillUnmount() {
+    // reset search term when removing this component
+    this.debouncedInputValueChange('');
     document.removeEventListener('keydown', this.onKeydown);
   }
 


### PR DESCRIPTION
Steps to reproduce
1. On home page search Cargill and click on Map link.
2. Go back to home page and open search. Previous search results are still visible because search state was not cleared.