### PR TITLE
Fix Tool: reset selection should clear selected nodes on the map

### DIFF
--- a/frontend/scripts/react-components/tool/tool.reducer.js
+++ b/frontend/scripts/react-components/tool/tool.reducer.js
@@ -118,6 +118,7 @@ const toolReducer = {
       highlightedGeoIds: [],
       selectedNodesData: [],
       selectedNodesIds: [],
+      selectedNodesGeoIds: [],
       expandedNodesIds: [],
       selectedBiomeFilter: { value: 'none' },
       recolorByNodeIds: []


### PR DESCRIPTION
One-liner. Steps to reproduce the issue

1. Select any region on the map.
2. Use "Clear Selection" button - the region is still selected on the map.