### PR TITLE
Fix Indonesia port's trade volume shadow tooltip display

### DIFF
--- a/frontend/scripts/components/tool/map.component.js
+++ b/frontend/scripts/components/tool/map.component.js
@@ -359,11 +359,17 @@ export default class {
       fillOpacity: 1
     };
 
+    // don't add point layers to canvas
+    // we have problem with port shadow layer being obscured  by canvas layer
+    // which does not pass any pointer events through - and we need to show tooltip
+    const pane = this.canvasRender && !isPoint ? MAP_PANES.overlayPane : MAP_PANES.vectorMain;
+
     const topoLayer = new L.GeoJSON(geoJSON, {
-      pane: this.canvasRender ? MAP_PANES.overlayPane : MAP_PANES.vectorMain,
+      pane,
       style,
       pointToLayer: (feature, latlng) =>
         L.circleMarker(latlng, {
+          pane,
           radius: POINT_RADIUS
         })
     });

--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -159,7 +159,7 @@ export const MAP_PANES_Z = {
   [MAP_PANES.vectorOutline]: 412,
   [MAP_PANES.context]: 420,
   [MAP_PANES.basemapLabels]: 490,
-  [MAP_PANES.overlayPane]: 410
+  [MAP_PANES.overlayPane]: 408 // when using canvas mode, better should be behind all vector layers, canvas not passing through pointer events
 };
 
 export const BASEMAPS = {


### PR DESCRIPTION
Quickest way is to not display points on canvas.