### PR TITLE
Profile: remove grey color from the palette, for mobile view each line different color

### DIFF
--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -113,6 +113,8 @@ export const PROFILE_CHOROPLETH_CLASSES = [
   'ch-red-4'
 ];
 
+export const PROFILE_CHOROPLETH_COLORS = ['#4e0008', '#900e1d', '#d12d3d', '#f66c76', '#f5b7ad'];
+
 export const DOCUMENT_POST_TYPES = ['INFO BRIEF', 'ISSUE BRIEF'];
 
 export const NODE_SELECTION_LINKS_NUM_COLORS = 10;

--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -113,8 +113,6 @@ export const PROFILE_CHOROPLETH_CLASSES = [
   'ch-red-4'
 ];
 
-export const PROFILE_CHOROPLETH_COLORS = ['#4e0008', '#900e1d', '#d12d3d', '#f66c76', '#f5b7ad'];
-
 export const DOCUMENT_POST_TYPES = ['INFO BRIEF', 'ISSUE BRIEF'];
 
 export const NODE_SELECTION_LINKS_NUM_COLORS = 10;

--- a/frontend/scripts/pages/profile-actor.page.jsx
+++ b/frontend/scripts/pages/profile-actor.page.jsx
@@ -185,8 +185,7 @@ const _build = (data, { nodeId, year, print }, onLinkClick, store) => {
       );
     },
     hideTooltipCallback: tooltip.hide,
-    lineClassNameCallback: (lineData, lineDefaultStyle) =>
-      `${lineDefaultStyle} line-${lineData[0].value9}`
+    lineClassNameCallback: (lineIndex, lineDefaultStyle) => `${lineDefaultStyle} line-${lineIndex}`
   };
 
   if (data.top_sources && data.top_sources.municipality.lines.length) {

--- a/frontend/scripts/react-components/profiles/line.component.jsx
+++ b/frontend/scripts/react-components/profiles/line.component.jsx
@@ -10,9 +10,8 @@ import { extent as d3_extent } from 'd3-array';
 import { area as d3_area, line as d3_line } from 'd3-shape';
 import { format as d3_format } from 'd3-format';
 import { timeFormat as d3_timeFormat } from 'd3-time-format';
-import chroma from 'chroma-js';
 
-import { LINE_LABEL_HEIGHT, PROFILE_CHOROPLETH_COLORS } from 'constants';
+import { LINE_LABEL_HEIGHT } from 'constants';
 import abbreviateNumber from 'utils/abbreviateNumber';
 import i18n from 'utils/transifex';
 import { Responsive } from 'react-components/shared/responsive.hoc';
@@ -109,7 +108,6 @@ class Line extends Component {
       return a.values[last] - b.values[last];
     });
     const numLines = lines.length;
-    const colorScaleForMobile = chroma.scale(PROFILE_CHOROPLETH_COLORS).colors(numLines);
 
     lines.forEach((lineData, i) => {
       const lineValuesWithFormat = this.prepareData(xValues, lineData);
@@ -160,20 +158,14 @@ class Line extends Component {
           pathContainers = d3Container
             .datum(lineValuesWithFormat[0])
             .append('g')
-            .attr('id', lineData.geo_id);
+            .attr('id', lineData.geo_id)
+            .attr('class', d => {
+              const lineIndex = isSmallChart ? i : d[0].value9;
 
-          if (isSmallChart) {
-            pathContainers.attr('class', `${style} generated-color`);
-            pathContainers.attr('stroke', colorScaleForMobile[lineNumber - 1]);
-          } else {
-            pathContainers.attr(
-              'class',
-              d =>
-                isFunction(settings.lineClassNameCallback)
-                  ? settings.lineClassNameCallback(d, style)
-                  : style
-            );
-          }
+              return isFunction(settings.lineClassNameCallback)
+                ? settings.lineClassNameCallback(lineIndex, style)
+                : style;
+            });
 
           pathContainers
             .selectAll('path')
@@ -315,21 +307,15 @@ class Line extends Component {
     const lineOnMouseLeave = lineData => {
       this.chart.querySelector(`#${lineData.geo_id}`).classList.remove('selected');
     };
-    const colorScaleForMobile = chroma.scale(PROFILE_CHOROPLETH_COLORS).colors(lines.length);
 
     return (
       <ul className="line-bottom-legend">
         {lines.map((lineData, index) => {
           const style = typeof data.style !== 'undefined' ? data.style.style : lineData.style;
-          const strokeColor = isSmallChart ? colorScaleForMobile[index] : null;
-          let lineClassName = style;
-
-          if (isSmallChart) {
-            lineClassName = `${style} generated-color`;
-          } else if (isFunction(settings.lineClassNameCallback)) {
-            lineClassName = settings.lineClassNameCallback([lineData], style);
-          }
-
+          const lineIndex = isSmallChart ? lines.length - index - 1 : lineData.value9;
+          const lineClassName = isFunction(settings.lineClassNameCallback)
+            ? settings.lineClassNameCallback(lineIndex, style)
+            : style;
           const isLink =
             typeof onLinkClick !== 'undefined' && lineData.node_id && lineData.profile_type;
           const linkOnClick = () => {
@@ -346,7 +332,7 @@ class Line extends Component {
               onMouseLeave={() => lineOnMouseLeave(lineData)}
             >
               <svg height="6" width="20" className="line-color">
-                <g className={lineClassName} stroke={strokeColor}>
+                <g className={lineClassName}>
                   <path d="M0 3 20 3" />
                 </g>
               </svg>

--- a/frontend/scripts/react-components/profiles/line.component.jsx
+++ b/frontend/scripts/react-components/profiles/line.component.jsx
@@ -101,8 +101,7 @@ class Line extends Component {
       .rangeRound([height, 0])
       .domain(d3_extent([0, ...allYValues]));
 
-    let lastNumberY = height + LINE_LABEL_HEIGHT;
-    let lastNameY = height + LINE_LABEL_HEIGHT;
+    let lastY = height + LINE_LABEL_HEIGHT;
 
     const lines = this.getLines().sort((a, b) => {
       const last = xValues.length - 1;
@@ -178,40 +177,29 @@ class Line extends Component {
             const texts = pathContainers
               .selectAll('text')
               .data(d => [d])
-              .enter();
-
-            texts
-              .append('text')
+              .enter()
+              .append('g')
               .attr('transform', d => {
                 const last = d.length - 1;
                 const { value } = d[last];
                 let newNumberY = y(value) + 4;
-                if (newNumberY + LINE_LABEL_HEIGHT > lastNumberY) {
-                  newNumberY = lastNumberY - LINE_LABEL_HEIGHT - 1;
+                if (newNumberY + LINE_LABEL_HEIGHT > lastY) {
+                  newNumberY = lastY - LINE_LABEL_HEIGHT - 1;
                 }
-                lastNumberY = newNumberY;
+                lastY = newNumberY;
                 return `translate(${width + 6},${newNumberY})`;
-              })
+              });
 
-              .text(`${numLines - i}.`);
+            texts.append('text').text(`${numLines - i}.`);
 
             texts
               .append('text')
+              .attr('transform', 'translate(16,0)')
               .attr('class', d => {
                 if (typeof onLinkClick !== 'undefined' && d[0].nodeId && data.profile_type) {
                   return 'link';
                 }
                 return '';
-              })
-              .attr('transform', d => {
-                const last = d.length - 1;
-                const { value } = d[last];
-                let newNameY = y(value) + 4;
-                if (newNameY + LINE_LABEL_HEIGHT > lastNameY) {
-                  newNameY = lastNameY - LINE_LABEL_HEIGHT - 1;
-                }
-                lastNameY = newNameY;
-                return `translate(${width + 20},${newNameY})`;
               })
               .on('click', d => {
                 if (typeof onLinkClick !== 'undefined' && d[0].nodeId && data.profile_type) {
@@ -306,7 +294,7 @@ class Line extends Component {
   }
 
   renderLegend() {
-    const { data, settings, xValues } = this.props;
+    const { data, settings, xValues, onLinkClick, targetLink, year } = this.props;
     const lines = this.getLines().sort((a, b) => {
       const last = xValues.length - 1;
       return b.values[last] - a.values[last];
@@ -325,6 +313,14 @@ class Line extends Component {
           const lineStyle = isFunction(settings.lineClassNameCallback)
             ? settings.lineClassNameCallback([lineData], style)
             : style;
+          const isLink =
+            typeof onLinkClick !== 'undefined' && lineData.node_id && lineData.profile_type;
+          const linkOnClick = () => {
+            onLinkClick(targetLink, {
+              nodeId: lineData.node_id,
+              year
+            });
+          };
 
           return (
             <li
@@ -337,9 +333,14 @@ class Line extends Component {
                   <path d="M0 3 20 3" />
                 </g>
               </svg>
-              <span>
-                {index + 1}.{capitalize(i18n(lineData.name))}
-              </span>
+              <span>{index + 1}.</span>
+              {isLink ? (
+                <span className="link" onClick={linkOnClick}>
+                  {capitalize(i18n(lineData.name))}
+                </span>
+              ) : (
+                <span>{capitalize(i18n(lineData.name))}</span>
+              )}
             </li>
           );
         })}

--- a/frontend/styles/_settings.scss
+++ b/frontend/styles/_settings.scss
@@ -180,14 +180,14 @@ $ch-red-4: #4F0008;
 // profile choropleth
 // For now we'll use the same color scheme as in the tool, when we include more buckets this has to change.
 $ch-profile-n-a: $metal-grey;
-$ch-profile-red-0: $ch-red-0; // #f6f5ed;
-$ch-profile-red-1: $ch-red-1; // #f5decd;
-$ch-profile-red-2: $ch-red-2; // #f6928d;
-$ch-profile-red-3: $ch-red-3; // #f65e6e;
-$ch-profile-red-4: $ch-red-4; // #e1384a;
-$ch-profile-red-5: $ch-red-4; // #b41728;
-$ch-profile-red-6: $ch-red-4; // #790916;
-$ch-profile-red-7: $ch-red-4; // #4e0008;
+$ch-profile-red-0: $ch-red-0;
+$ch-profile-red-1: $ch-red-1;
+$ch-profile-red-2: $ch-red-2;
+$ch-profile-red-3: $ch-red-3;
+$ch-profile-red-4: $ch-red-4;
+$ch-profile-red-5: $ch-red-4;
+$ch-profile-red-6: $ch-red-4;
+$ch-profile-red-7: $ch-red-4;
 
 $choropleth-colors: (
   ch-red-0: $ch-red-0,

--- a/frontend/styles/components/profiles/line.scss
+++ b/frontend/styles/components/profiles/line.scss
@@ -72,6 +72,10 @@
     &.line-6 { path, circle { stroke: $ch-profile-red-6; } };
     &.line-7 { path, circle { stroke: $ch-profile-red-7; } };
 
+    &.generated-color {
+      path, circle { stroke: unset; }
+    }
+
     path {
       stroke-width: 3px;
     }

--- a/frontend/styles/components/profiles/line.scss
+++ b/frontend/styles/components/profiles/line.scss
@@ -121,6 +121,13 @@ ul.line-bottom-legend {
   letter-spacing: -0.6px;
   color: $charcoal-grey;
 
+  .link {
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
+    }
+  }
+
   .line-color {
     margin-right: 5px;
   }

--- a/frontend/styles/components/profiles/line.scss
+++ b/frontend/styles/components/profiles/line.scss
@@ -72,10 +72,6 @@
     &.line-6 { path, circle { stroke: $ch-profile-red-6; } };
     &.line-7 { path, circle { stroke: $ch-profile-red-7; } };
 
-    &.generated-color {
-      path, circle { stroke: unset; }
-    }
-
     path {
       stroke-width: 3px;
     }

--- a/frontend/styles/layouts/l-profile-actor.scss
+++ b/frontend/styles/layouts/l-profile-actor.scss
@@ -124,6 +124,12 @@
         }
       }
     }
+
+    .js-top-municipalities-title-container {
+      @media screen and (max-width: $breakpoint-foundation-small) {
+        margin-left: 1.25rem;
+      }
+    }
   }
 
   .js-top-municipalities, .js-top-destination {

--- a/spec/support/schemas/importer_profile.json
+++ b/spec/support/schemas/importer_profile.json
@@ -247,7 +247,6 @@
             "included_years",
             "style",
             "lines",
-            "profile_type",
             "buckets",
             "unit"
           ],


### PR DESCRIPTION
This is for https://github.com/Vizzuality/trase/issues/385

I removed barely visible grey color from the palette (@juancarlosalonso please review)

![image](https://user-images.githubusercontent.com/1286444/40718154-521998bc-640f-11e8-8348-61d0ed90fd76.png)

On mobile view, as there is no map there and no reference to buckets, each line has different color - generated from the same color palette.

![image](https://user-images.githubusercontent.com/1286444/40718110-26bc4dd6-640f-11e8-9edd-9d56765f44c0.png)


