### PR TITLE
Fix - map size sometimes not invalidated

### DIFF
--- a/frontend/scripts/components/tool/map.component.js
+++ b/frontend/scripts/components/tool/map.component.js
@@ -618,9 +618,26 @@ export default class {
   invalidate() {
     // recalculates map size once CSS transition ends
     this.map.invalidateSize(true);
-    setTimeout(() => {
+    const mapContainer = this.map.getContainer();
+    let oldWidth = mapContainer.clientWidth;
+
+    const invalidateSizeDebounced = debounce(() => {
       this.map.invalidateSize(true);
-    }, 850);
+    }, 200);
+
+    const interval = window.setInterval(() => {
+      if (mapContainer) {
+        const width = mapContainer.clientWidth;
+        if (width !== oldWidth) {
+          oldWidth = width;
+          invalidateSizeDebounced();
+        }
+      }
+    }, 50);
+
+    window.setTimeout(() => {
+      window.clearInterval(interval);
+    }, 3000);
   }
 
   filterByBiome({


### PR DESCRIPTION
This PR fixes one of the issues found desribed [here](https://basecamp.com/1756858/projects/12498794/todos/327056118) - the map size sometimes is not invalidated after CSS opening transistion. As we were giving [850ms for transisition to end](https://github.com/Vizzuality/trase/blob/develop/frontend/scripts/components/tool/map.component.js#L623), sometimes that was not enough. I was able to reproduce that most of the time doing following, from Home page search Sorriso Logistic Hub -> Click Supply Chain -> Go back to home -> find sorriso logistic hub -> Click Map.

