### PR TITLE
Fix/missing node properties after data import

### DIFF
--- a/app/admin/api/v3/node_property.rb
+++ b/app/admin/api/v3/node_property.rb
@@ -1,0 +1,38 @@
+ActiveAdmin.register Api::V3::NodeProperty, as: 'NodeProperty' do
+  menu parent: 'General Settings', priority: 5
+
+  permit_params :node_id, :is_domestic_consumption
+
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :node,
+            as: :select,
+            required: true,
+            collection: Api::V3::Node.select_options
+      input :is_domestic_consumption,
+            as: :boolean,
+            required: true,
+            hint: object.class.column_comment('is_domestic_consumption')
+    end
+    f.actions
+  end
+
+  index do
+    column('Node') { |property| property.node&.name }
+    column('Node Type') { |property| property.node&.node_type&.name }
+    column :is_domestic_consumption
+    actions
+  end
+
+  filter :node_node_type_id, as: :select, collection: -> { Api::V3::NodeType.select_options }
+  filter :node_name_cont, as: :string, label: 'Node name'
+end

--- a/app/models/api/v3/node.rb
+++ b/app/models/api/v3/node.rb
@@ -132,6 +132,10 @@ module Api
         rel
       end
 
+      def self.select_options
+        order(:name).map { |node| [node.name, node.id] }
+      end
+
       def self.import_key
         [
           {name: :name, sql_type: 'TEXT'},

--- a/app/models/api/v3/node_property.rb
+++ b/app/models/api/v3/node_property.rb
@@ -34,6 +34,20 @@ module Api
       def refresh_dependencies
         Api::V3::Readonly::Node.refresh
       end
+
+      def self.insert_missing_node_properties
+        sql = <<-SQL
+          WITH node_ids_without_property AS (
+            SELECT nodes.id AS node_id FROM nodes
+            LEFT JOIN node_properties ON node_properties.node_id = nodes.id
+            WHERE node_properties.id IS NULL
+          )
+          INSERT INTO node_properties(node_id, is_domestic_consumption, created_at, updated_at)
+          SELECT node_id, FALSE, NOW(), NOW()
+          FROM node_ids_without_property
+        SQL
+        connection.execute sql
+      end
     end
   end
 end

--- a/app/models/api/v3/node_property.rb
+++ b/app/models/api/v3/node_property.rb
@@ -23,10 +23,16 @@ module Api
     class NodeProperty < YellowTable
       belongs_to :node
 
+      after_commit :refresh_dependencies
+
       def self.blue_foreign_keys
         [
           {name: :node_id, table_class: Api::V3::Node}
         ]
+      end
+
+      def refresh_dependencies
+        Api::V3::Readonly::Node.refresh
       end
     end
   end

--- a/app/models/api/v3/node_type.rb
+++ b/app/models/api/v3/node_type.rb
@@ -46,6 +46,10 @@ module Api
         zero_based_idx && zero_based_idx + 1 || 0
       end
 
+      def self.select_options
+        order(:name).map { |node_type| [node_type.name, node_type.id] }
+      end
+
       def self.import_key
         [
           {name: :name, sql_type: 'TEXT'}

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -130,6 +130,9 @@ module Api
             # restore dependent yellow tables
             yellow_tables.each do |yellow_table_class|
               yellow_table_cnt = RestoreYellowTable.new(yellow_table_class).call
+              if yellow_table_class == Api::V3::NodeProperty
+                Api::V3::NodeProperty.insert_missing_node_properties
+              end
               @stats[table_class.table_name][:yellow_tables][yellow_table_class.table_name][:after] = yellow_table_cnt
             end
           end
@@ -151,7 +154,7 @@ module Api
             Api::V3::Readonly::MapAttribute,
             Api::V3::Readonly::RecolorByAttribute,
             Api::V3::Readonly::ResizeByAttribute,
-            # TODO: Api::V3::Readonly::Node,
+            Api::V3::Readonly::Node,
             Api::V3::Readonly::DownloadFlow
           ].each(&:refresh)
         end

--- a/spec/controllers/admin/node_properties_controller_spec.rb
+++ b/spec/controllers/admin/node_properties_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Admin::NodePropertiesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::NodeProperty.skip_callback(:commit, :after, :refresh_dependencies)
+  end
+  after do
+    Api::V3::NodeProperty.set_callback(:commit, :after, :refresh_dependencies)
+  end
+  describe 'POST create' do
+    let(:node) { FactoryBot.create(:api_v3_node) }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_node_property, node_id: node.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_node_property: valid_attributes}
+    end
+  end
+end


### PR DESCRIPTION
Adds missing admin interface to edit node properties, makes it part of the import process to insert missing node properties.