### PR TITLE
Feature/improvements to explore page

### DIFF
--- a/frontend/scripts/react-components/explore/explore.thunks.js
+++ b/frontend/scripts/react-components/explore/explore.thunks.js
@@ -29,8 +29,14 @@ export const redirectToExplore = (dispatch, getState, { action }) => {
     }
   };
 
+  const urlHasSankeyState = !!(
+    action.meta &&
+    action.meta.query &&
+    action.meta.query.selectedContextId
+  );
+
   if (toolPages.includes(action.type)) {
-    if (!previouslyVisitedExplorePage.get()) {
+    if (!previouslyVisitedExplorePage.get() && !urlHasSankeyState) {
       previouslyVisitedExplorePage.set(Date.now());
       //     dispatch(setContextIsUserSelected(false));
       dispatch(redirect({ type: 'explore' }));

--- a/frontend/scripts/react-components/explore/explore.thunks.js
+++ b/frontend/scripts/react-components/explore/explore.thunks.js
@@ -32,7 +32,7 @@ export const redirectToExplore = (dispatch, getState, { action }) => {
   if (toolPages.includes(action.type)) {
     if (!previouslyVisitedExplorePage.get()) {
       previouslyVisitedExplorePage.set(Date.now());
-      dispatch(setContextIsUserSelected(false));
+      //     dispatch(setContextIsUserSelected(false));
       dispatch(redirect({ type: 'explore' }));
     }
   } else if (type === 'explore') {

--- a/frontend/scripts/react-components/shared/world-map/world-map.container.js
+++ b/frontend/scripts/react-components/shared/world-map/world-map.container.js
@@ -53,7 +53,8 @@ const mapStateToProps = state => {
   const pageType = state.location.type;
   const { selectedYears } = state.tool;
   const { selectedContext, contextIsUserSelected } = state.app;
-  const origin = selectedContext && COUNTRY_ID_ORIGIN[selectedContext.countryId];
+  const origin =
+    contextIsUserSelected && selectedContext ? COUNTRY_ID_ORIGIN[selectedContext.countryId] : null;
   const selectedContextId = selectedContext ? selectedContext.id : null;
 
   const topNodesKey = getTopNodesKey(selectedContextId, 8, ...selectedYears);

--- a/frontend/scripts/reducers/app.reducer.js
+++ b/frontend/scripts/reducers/app.reducer.js
@@ -23,7 +23,7 @@ const initialState = {
   isAppMenuVisible: false,
   tooltipCheck: 0,
   tooltips: null,
-  contextIsUserSelected: false,
+  contextIsUserSelected: true,
   currentDropdown: null,
   modal: {
     visibility: false,


### PR DESCRIPTION
- Fix issue where loading the big map on /explore would color brazil as selected
- Always show a "context explore" page on /explore, hiding the big map view (so you have to take my word for it on the 1st issue
- Have 1st time users with stateful links not be redirected to the explore page