### PR TITLE
Feature/cms for dashboards attributes

### DIFF
--- a/app/admin/api/v3/carto_layer.rb
+++ b/app/admin/api/v3/carto_layer.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::CartoLayer, as: 'CartoLayer' do
-  menu parent: 'Map Settings'
+  menu parent: 'Map'
 
   permit_params :contextual_layer_id, :identifier, :years_str, :raster_url
 

--- a/app/admin/api/v3/contextual_layer.rb
+++ b/app/admin/api/v3/contextual_layer.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ContextualLayer, as: 'ContextualLayer' do
-  menu parent: 'Map Settings', priority: 3
+  menu parent: 'Map', priority: 3
 
   permit_params :context_id, :title, :identifier, :position,
                 :tooltip_text, :legend, :is_default

--- a/app/admin/api/v3/dashboards_attribute.rb
+++ b/app/admin/api/v3/dashboards_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::DashboardsAttribute, as: 'DashboardsAttribute' do
-  menu parent: 'Dashboards Settings'
+  menu parent: 'Dashboards'
 
   includes [
     :dashboards_attribute_group,

--- a/app/admin/api/v3/dashboards_attribute.rb
+++ b/app/admin/api/v3/dashboards_attribute.rb
@@ -1,0 +1,65 @@
+ActiveAdmin.register Api::V3::DashboardsAttribute, as: 'DashboardsAttribute' do
+  menu parent: 'Dashboards Settings'
+
+  includes [
+    :dashboards_attribute_group,
+    :dashboards_ind,
+    :dashboards_qual,
+    :dashboards_quant
+  ]
+
+  permit_params :dashboards_attribute_group_id, :position, :chart_type,
+                :readonly_attribute_id
+
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/dashboards/indicators')
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :readonly_attribute_id,
+            as: :select,
+            collection: Api::V3::Readonly::Attribute.select_options
+      input :dashboards_attribute_group,
+            as: :select,
+            required: true,
+            collection: Api::V3::DashboardsAttributeGroup.select_options
+      input :position,
+            required: true,
+            hint: object.class.column_comment('position')
+      input :chart_type,
+            required: true,
+            hint: object.class.column_comment('chart_type')
+    end
+    f.actions
+  end
+
+  index do
+    column :readonly_attribute_display_name
+    column('Dashboards Attribute Group') { |attribute| attribute.dashboards_attribute_group&.name }
+    column :position
+    column :chart_type
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :readonly_attribute_display_name
+      row :dashboards_attribute_group
+      row :position
+      row :chart_type
+      row :created_at
+      row :updated_at
+    end
+  end
+
+  filter :dashboards_attribute_group, collection: -> {
+    Api::V3::DashboardsAttributeGroup.
+      select_options
+  }
+end

--- a/app/admin/api/v3/dashboards_attribute_group.rb
+++ b/app/admin/api/v3/dashboards_attribute_group.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::DashboardsAttributeGroup, as: 'DashboardsAttributeGroup' do
-  menu parent: 'Dashboards Settings'
+  menu parent: 'Dashboards'
 
   after_action :clear_cache, only: [:create, :update, :destroy]
 

--- a/app/admin/api/v3/dashboards_attribute_group.rb
+++ b/app/admin/api/v3/dashboards_attribute_group.rb
@@ -1,0 +1,37 @@
+ActiveAdmin.register Api::V3::DashboardsAttributeGroup, as: 'DashboardsAttributeGroup' do
+  menu parent: 'Dashboards Settings'
+
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/dashboards/indicators')
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :name, required: true, as: :string,
+                   hint: object.class.column_comment('name')
+      input :position, required: true,
+                       hint: object.class.column_comment('position')
+    end
+    f.actions
+  end
+
+  index do
+    column :name
+    column :position
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :name
+      row :position
+      row :created_at
+      row :updated_at
+    end
+  end
+end

--- a/app/admin/api/v3/dashboards_attribute_group.rb
+++ b/app/admin/api/v3/dashboards_attribute_group.rb
@@ -3,6 +3,10 @@ ActiveAdmin.register Api::V3::DashboardsAttributeGroup, as: 'DashboardsAttribute
 
   after_action :clear_cache, only: [:create, :update, :destroy]
 
+  permit_params :name,
+                :position
+
+
   controller do
     def clear_cache
       clear_cache_for_regexp('/api/v3/dashboards/indicators')

--- a/app/admin/api/v3/download_attribute.rb
+++ b/app/admin/api/v3/download_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::DownloadAttribute, as: 'DownloadAttribute' do
-  menu parent: 'Data Download Settings'
+  menu parent: 'Data Download'
 
   permit_params :context_id, :position, :display_name, :years_str,
                 :readonly_attribute_id

--- a/app/admin/api/v3/download_version.rb
+++ b/app/admin/api/v3/download_version.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::DownloadVersion, as: 'DownloadVersion' do
-  menu parent: 'Data Download Settings'
+  menu parent: 'Data Download'
 
   permit_params :context_id, :is_current, :symbol, :created_at
 

--- a/app/admin/api/v3/map_attribute.rb
+++ b/app/admin/api/v3/map_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::MapAttribute, as: 'MapAttribute' do
-  menu parent: 'Map Settings', priority: 2
+  menu parent: 'Map', priority: 2
 
   includes [
     {map_attribute_group: {context: [:country, :commodity]}},

--- a/app/admin/api/v3/map_attribute_group.rb
+++ b/app/admin/api/v3/map_attribute_group.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::MapAttributeGroup, as: 'MapAttributeGroup' do
-  menu parent: 'Map Settings', priority: 1
+  menu parent: 'Map', priority: 1
 
   permit_params :context_id, :name, :position
 

--- a/app/admin/api/v3/recolor_by_attribute.rb
+++ b/app/admin/api/v3/recolor_by_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::RecolorByAttribute, as: 'RecolorByAttribute' do
-  menu parent: 'Sankey Settings'
+  menu parent: 'Sankey'
 
   includes [
     {context: [:country, :commodity]},

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Api::V3::ResizeByAttribute, as: 'ResizeByAttribute' do
-  menu parent: 'Sankey Settings'
+  menu parent: 'Sankey'
 
   includes [
     {context: [:country, :commodity]},

--- a/app/models/api/v3/dashboards_attribute.rb
+++ b/app/models/api/v3/dashboards_attribute.rb
@@ -59,7 +59,7 @@ module Api
       end
 
       def refresh_dependents
-        Api::V3::Readonly::DashboardsAttribute.refresh_later
+        Api::V3::Readonly::DashboardsAttribute.refresh
       end
     end
   end

--- a/app/models/api/v3/dashboards_attribute.rb
+++ b/app/models/api/v3/dashboards_attribute.rb
@@ -48,7 +48,7 @@ module Api
                      scope: :dashboards_attribute_group,
                      if: :new_dashboards_quant_given?
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       manage_associated_attributes [:dashboards_ind, :dashboards_qual, :dashboards_quant]
 
@@ -58,7 +58,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::DashboardsAttribute.refresh
       end
     end

--- a/app/models/api/v3/dashboards_attribute.rb
+++ b/app/models/api/v3/dashboards_attribute.rb
@@ -59,7 +59,7 @@ module Api
       end
 
       def refresh_dependents
-        Api::V3::Readonly::DashboardsAttribute.refresh
+        Api::V3::Readonly::DashboardsAttribute.refresh_later
       end
     end
   end

--- a/app/models/api/v3/dashboards_attribute_group.rb
+++ b/app/models/api/v3/dashboards_attribute_group.rb
@@ -24,7 +24,7 @@ module Api
       after_commit :refresh_dependents
 
       def self.select_options
-        Api::V3::DashboardsAttributeGroup.all.map(&:name)
+        order(:name).map { |group| [group.name, group.id] }
       end
 
       def refresh_dependents

--- a/app/models/api/v3/dashboards_attribute_group.rb
+++ b/app/models/api/v3/dashboards_attribute_group.rb
@@ -21,13 +21,13 @@ module Api
       validates :name, presence: true
       validates :position, presence: true, uniqueness: true
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       def self.select_options
         Api::V3::DashboardsAttributeGroup.all.map(&:name)
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::DashboardsAttribute.refresh
       end
     end

--- a/app/models/api/v3/dashboards_attribute_group.rb
+++ b/app/models/api/v3/dashboards_attribute_group.rb
@@ -28,7 +28,7 @@ module Api
       end
 
       def refresh_dependents
-        Api::V3::Readonly::DashboardsAttribute.refresh
+        Api::V3::Readonly::DashboardsAttribute.refresh_later
       end
     end
   end

--- a/app/models/api/v3/dashboards_attribute_group.rb
+++ b/app/models/api/v3/dashboards_attribute_group.rb
@@ -28,7 +28,7 @@ module Api
       end
 
       def refresh_dependents
-        Api::V3::Readonly::DashboardsAttribute.refresh_later
+        Api::V3::Readonly::DashboardsAttribute.refresh
       end
     end
   end

--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -40,7 +40,7 @@ module Api
       validates_with AttributeAssociatedOnceValidator,
                      attribute: :download_quant, if: :new_download_quant_given?
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       stringy_array :years
       manage_associated_attributes [:download_qual, :download_quant]
@@ -51,7 +51,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::DownloadAttribute.refresh
         Api::V3::Readonly::DownloadFlow.refresh_later(skip_flow_paths: true)
       end

--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -53,7 +53,7 @@ module Api
 
       def refresh_dependents
         Api::V3::Readonly::DownloadAttribute.refresh
-        Api::V3::Readonly::DownloadFlow.refresh_later(skip_flow_paths: true)
+        Api::V3::Readonly::DownloadFlow.refresh_later(skip_dependencies: true)
       end
     end
   end

--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -53,7 +53,7 @@ module Api
 
       def refresh_dependents
         Api::V3::Readonly::DownloadAttribute.refresh
-        Api::V3::Readonly::DownloadFlow.refresh_later(skip_dependencies: true)
+        Api::V3::Readonly::DownloadFlow.refresh(skip_dependencies: true)
       end
     end
   end

--- a/app/models/api/v3/ind.rb
+++ b/app/models/api/v3/ind.rb
@@ -18,7 +18,7 @@ module Api
       has_one :ind_property
       has_many :node_inds
 
-      delegate :display_name, to: :ind_property
+      delegate :display_name, to: :ind_property, allow_nil: true
 
       def self.select_options
         order(:name).map { |ind| [ind.name, ind.id] }

--- a/app/models/api/v3/ind_property.rb
+++ b/app/models/api/v3/ind_property.rb
@@ -46,7 +46,7 @@ module Api
       validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
       validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       def self.blue_foreign_keys
         [
@@ -54,7 +54,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::Attribute.refresh
       end
     end

--- a/app/models/api/v3/map_attribute.rb
+++ b/app/models/api/v3/map_attribute.rb
@@ -64,7 +64,7 @@ module Api
                      attribute: :map_quant, scope: :map_attribute_group,
                      if: :new_map_quant_given?
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       stringy_array :dual_layer_buckets
       stringy_array :single_layer_buckets
@@ -77,7 +77,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::MapAttribute.refresh
       end
     end

--- a/app/models/api/v3/map_attribute_group.rb
+++ b/app/models/api/v3/map_attribute_group.rb
@@ -29,7 +29,7 @@ module Api
       validates :name, presence: true
       validates :position, presence: true, uniqueness: {scope: :context}
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       def self.select_options
         Api::V3::MapAttributeGroup.includes(
@@ -52,7 +52,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::MapAttribute.refresh
       end
     end

--- a/app/models/api/v3/node_property.rb
+++ b/app/models/api/v3/node_property.rb
@@ -25,7 +25,7 @@ module Api
 
       validates :node, presence: true, uniqueness: true
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       def self.blue_foreign_keys
         [
@@ -33,7 +33,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::Node.refresh
       end
 

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -33,13 +33,15 @@ module Api
                 uniqueness: {scope: :context_node_type},
                 inclusion: NAME
 
+      after_commit :refresh_dependents
+
       def self.blue_foreign_keys
         [
           {name: :context_node_type_id, table_class: Api::V3::ContextNodeType}
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::Node.refresh
       end
     end

--- a/app/models/api/v3/qual.rb
+++ b/app/models/api/v3/qual.rb
@@ -17,7 +17,7 @@ module Api
       has_one :qual_property
       has_many :node_quals
 
-      delegate :display_name, to: :qual_property
+      delegate :display_name, to: :qual_property, allow_nil: true
 
       def self.select_options
         order(:name).map { |qual| [qual.name, qual.id] }

--- a/app/models/api/v3/qual_property.rb
+++ b/app/models/api/v3/qual_property.rb
@@ -37,7 +37,7 @@ module Api
       validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
       validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       def self.blue_foreign_keys
         [
@@ -45,7 +45,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::Attribute.refresh
       end
     end

--- a/app/models/api/v3/quant.rb
+++ b/app/models/api/v3/quant.rb
@@ -18,7 +18,7 @@ module Api
       has_one :quant_property
       has_many :node_quants
 
-      delegate :display_name, to: :quant_property
+      delegate :display_name, to: :quant_property, allow_nil: true
 
       def self.select_options
         order(:name).map { |quant| [quant.name, quant.id] }

--- a/app/models/api/v3/quant_property.rb
+++ b/app/models/api/v3/quant_property.rb
@@ -47,7 +47,7 @@ module Api
       validates :is_temporal_on_place_profile, inclusion: {in: [true, false]}
       validates :is_temporal_on_actor_profile, inclusion: {in: [true, false]}
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       def self.blue_foreign_keys
         [
@@ -55,7 +55,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::Attribute.refresh
       end
     end

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -33,18 +33,16 @@ module Api
           order(:display_name).map { |a| [a.display_name, a.id] }
         end
 
-        def self.refresh
-          super
-          dependents.each(&:refresh)
-        end
-
-        def self.dependents
+        def self.refresh_dependents(options = {})
           [
             Api::V3::Readonly::DownloadAttribute,
             Api::V3::Readonly::MapAttribute,
             Api::V3::Readonly::RecolorByAttribute,
-            Api::V3::Readonly::ResizeByAttribute
-          ]
+            Api::V3::Readonly::ResizeByAttribute,
+            Api::V3::Readonly::DashboardsAttribute
+          ].each do |mview_klass|
+            mview_klass.refresh_by_name(mview_klass.table_name, options)
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -41,7 +41,7 @@ module Api
             Api::V3::Readonly::ResizeByAttribute,
             Api::V3::Readonly::DashboardsAttribute
           ].each do |mview_klass|
-            mview_klass.refresh_by_name(mview_klass.table_name, options)
+            mview_klass.refresh(options.merge(skip_dependencies: true))
           end
         end
       end

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -6,39 +6,57 @@ module Api
           true
         end
 
-        # Refreshes the views dependencies, the view itself and its dependents
-        # @param options
-        # @option options [Boolean] :skip_dependencies skip refreshing
-        def self.refresh(options = {})
-          # TODO: test the new :cascade options
-          refresh_dependencies unless options[:skip_dependencies]
-          refresh_by_name(table_name, options)
-          refresh_dependents(options)
+        class << self
+          # Refreshes the views dependencies, the view itself and its dependents
+          # @param options
+          # @option options [Boolean] :skip_dependencies skip refreshing
+          def refresh(options = {})
+            # rubocop:disable Style/DoubleNegation
+            sync_processing = !!options[:sync]
+            # rubocop:enable Style/DoubleNegation
+            if long_running? && !sync_processing
+              refresh_later(options)
+            else
+              refresh_now(options)
+            end
+          end
+
+          def refresh_now(options = {})
+            refresh_dependencies unless options[:skip_dependencies]
+            refresh_by_name(table_name, options)
+            refresh_dependents(options) unless options[:skip_dependents]
+          end
+
+          # this materialized view takes a long time to refresh
+          def refresh_later(options = {})
+            MaterializedViewRefreshWorker.perform_async(name, options)
+          end
+
+          private
+
+          def long_running?
+            false
+          end
+
+          # Refreshes materialized views this view depends on
+          def refresh_dependencies(options = {}); end
+
+          # Refreshes materialized views that depend on this view
+          def refresh_dependents(options = {}); end
+
+          def refresh_by_name(table_name, options)
+            # rubocop:disable Style/DoubleNegation
+            safe_concurrently = !!options[:concurrently]
+            # rubocop:enable Style/DoubleNegation
+            is_populated = IsMviewPopulated.new(table_name).call
+            # cannot refresh concurrently a view that is not populated
+            safe_concurrently = false unless is_populated
+            Scenic.database.refresh_materialized_view(
+              table_name,
+              concurrently: safe_concurrently
+            )
+          end
         end
-
-        def self.refresh_by_name(table_name, options)
-          # rubocop:disable Style/DoubleNegation
-          safe_concurrently = !!options[:concurrently]
-          # rubocop:enable Style/DoubleNegation
-          is_populated = IsMviewPopulated.new(table_name).call
-          # cannot refresh concurrently a view that is not populated
-          safe_concurrently = false unless is_populated
-          Scenic.database.refresh_materialized_view(
-            table_name,
-            concurrently: safe_concurrently
-          )
-        end
-
-        # this materialized view takes a long time to refresh
-        def self.refresh_later(options = {})
-          MaterializedViewRefreshWorker.perform_async(name, options)
-        end
-
-        # Refreshes materialized views this view depends on
-        def self.refresh_dependencies(options = {}); end
-
-        # Refreshes materialized views that depend on this view
-        def self.refresh_dependents(options = {}); end
       end
     end
   end

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -29,6 +29,11 @@ module Api
           )
         end
 
+        # this materialized view takes a long time to refresh
+        def self.refresh_later(options = {})
+          MaterializedViewRefreshWorker.perform_async(name, options)
+        end
+
         # Refreshes materialized views this view depends on
         def self.refresh_dependencies(options = {}); end
 

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -6,15 +6,34 @@ module Api
           true
         end
 
+        # Refreshes the views dependencies, the view itself and its dependents
+        # @param options
+        # @option options [Boolean] :skip_dependencies skip refreshing
         def self.refresh(options = {})
-          concurrently = options[:concurrently] || true
-          concurrently = false unless IsMviewPopulated.new(table_name).call
+          # TODO: test the new :cascade options
+          refresh_dependencies unless options[:skip_dependencies]
+          refresh_by_name(table_name, options)
+          refresh_dependents(options)
+        end
 
+        def self.refresh_by_name(table_name, options)
+          # rubocop:disable Style/DoubleNegation
+          safe_concurrently = !!options[:concurrently]
+          # rubocop:enable Style/DoubleNegation
+          is_populated = IsMviewPopulated.new(table_name).call
+          # cannot refresh concurrently a view that is not populated
+          safe_concurrently = false unless is_populated
           Scenic.database.refresh_materialized_view(
             table_name,
-            concurrently: concurrently
+            concurrently: safe_concurrently
           )
         end
+
+        # Refreshes materialized views this view depends on
+        def self.refresh_dependencies(options = {}); end
+
+        # Refreshes materialized views that depend on this view
+        def self.refresh_dependents(options = {}); end
       end
     end
   end

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -48,7 +48,7 @@ module Api
             # rubocop:disable Style/DoubleNegation
             safe_concurrently = !!options[:concurrently]
             # rubocop:enable Style/DoubleNegation
-            is_populated = IsMviewPopulated.new(table_name).call
+            is_populated = Api::V3::IsMviewPopulated.new(table_name).call
             # cannot refresh concurrently a view that is not populated
             safe_concurrently = false unless is_populated
             Scenic.database.refresh_materialized_view(

--- a/app/models/api/v3/readonly/dashboards/destination.rb
+++ b/app/models/api/v3/readonly/dashboards/destination.rb
@@ -27,13 +27,10 @@ module Api
     module Readonly
       module Dashboards
         class Destination < Api::V3::Readonly::BaseModel
+          include Refresh
+
           self.table_name = 'dashboards_destinations_mv'
           belongs_to :node
-
-          def self.refresh(options = {})
-            FlowPath.refresh unless options[:skip_flow_paths]
-            Scenic.database.refresh_materialized_view(table_name, concurrently: false)
-          end
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/flow_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards/flow_attribute.rb
@@ -1,0 +1,15 @@
+module Api
+  module V3
+    module Readonly
+      module Dashboards
+        class FlowAttribute < Api::V3::Readonly::BaseModel
+          self.table_name = 'dashboards_flow_attributes_mv'
+
+          def self.long_running?
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/dashboards/flow_path.rb
+++ b/app/models/api/v3/readonly/dashboards/flow_path.rb
@@ -26,6 +26,15 @@ module Api
       module Dashboards
         class FlowPath < Api::V3::Readonly::BaseModel
           self.table_name = 'dashboards_flow_paths_mv'
+
+          def self.refresh_dependents(options = {})
+            [
+              Api::V3::Readonly::Dashboards::FlowAttribute,
+              Api::V3::Readonly::Dashboards::NodeAttribute
+            ].each do |mview_klass|
+              mview_klass.refresh(options.merge(skip_dependencies: true))
+            end
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/node_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards/node_attribute.rb
@@ -1,0 +1,15 @@
+module Api
+  module V3
+    module Readonly
+      module Dashboards
+        class NodeAttribute < Api::V3::Readonly::BaseModel
+          self.table_name = 'dashboards_node_attributes_mv'
+
+          def self.long_running?
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/dashboards/source.rb
+++ b/app/models/api/v3/readonly/dashboards/source.rb
@@ -35,9 +35,8 @@ module Api
           belongs_to :node
 
           def self.refresh(options = {})
-            Scenic.database.refresh_materialized_view(
-              'context_node_types_mv', concurrently: false
-            )
+            # TODO: try the new :cascade option
+            refresh_by_name('context_node_types_mv', options)
             super(options)
           end
         end

--- a/app/models/api/v3/readonly/dashboards_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards_attribute.rb
@@ -28,15 +28,16 @@ module Api
         delegate :original_type, to: :readonly_attribute
         delegate :original_id, to: :readonly_attribute
 
-        def self.refresh(options = {})
-          super(options)
+        def self.refresh_dependencies(options = {})
+          Api::V3::Readonly::Attribute.refresh(options)
+        end
+
+        def self.refresh_dependents(options = {})
           [
             :dashboards_flow_attributes_mv,
             :dashboards_node_attributes_mv
-          ].each do |mview|
-            Scenic.database.refresh_materialized_view(
-              mview, concurrently: false
-            )
+          ].each do |table_name|
+            refresh_by_name(table_name, options)
           end
         end
       end

--- a/app/models/api/v3/readonly/dashboards_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards_attribute.rb
@@ -34,10 +34,10 @@ module Api
 
         def self.refresh_dependents(options = {})
           [
-            :dashboards_flow_attributes_mv,
-            :dashboards_node_attributes_mv
-          ].each do |table_name|
-            refresh_by_name(table_name, options)
+            Api::V3::Readonly::Dashboards::FlowAttribute,
+            Api::V3::Readonly::Dashboards::NodeAttribute
+          ].each do |mview_klass|
+            mview_klass.refresh(options.merge(skip_dependencies: true))
           end
         end
       end

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -32,6 +32,10 @@ module Api
         delegate :unit_type, to: :readonly_attribute
         delegate :original_type, to: :readonly_attribute
         delegate :original_id, to: :readonly_attribute
+
+        def self.refresh_dependencies(options = {})
+          Api::V3::Readonly::Attribute.refresh(options)
+        end
       end
     end
   end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -56,7 +56,7 @@ module Api
           DownloadFlowsRefreshWorker.perform_async(options)
         end
 
-        def self.refresh_dependencies(options = {})
+        def self.refresh_dependencies(_options = {})
           refresh_by_name('flow_paths_mv', concurrently: false) # no unique index
         end
       end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -51,11 +51,6 @@ module Api
         self.table_name = 'download_flows_mv'
         self.primary_key = 'id'
 
-        # this materialized view takes a long time to refresh
-        def self.refresh_later(options = {})
-          DownloadFlowsRefreshWorker.perform_async(options)
-        end
-
         def self.refresh_dependencies(_options = {})
           refresh_by_name('flow_paths_mv', concurrently: false) # no unique index
         end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -51,6 +51,10 @@ module Api
         self.table_name = 'download_flows_mv'
         self.primary_key = 'id'
 
+        def self.long_running?
+          true
+        end
+
         def self.refresh_dependencies(_options = {})
           refresh_by_name('flow_paths_mv', concurrently: false) # no unique index
         end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -51,18 +51,13 @@ module Api
         self.table_name = 'download_flows_mv'
         self.primary_key = 'id'
 
-        def self.refresh(options = {})
-          unless options[:skip_flow_paths]
-            Scenic.database.refresh_materialized_view(
-              'flow_paths_mv', concurrently: false
-            )
-          end
-          super(options.slice(:concurrently))
-        end
-
         # this materialized view takes a long time to refresh
         def self.refresh_later(options = {})
           DownloadFlowsRefreshWorker.perform_async(options)
+        end
+
+        def self.refresh_dependencies(options = {})
+          refresh_by_name('flow_paths_mv', concurrently: false) # no unique index
         end
       end
     end

--- a/app/models/api/v3/readonly/map_attribute.rb
+++ b/app/models/api/v3/readonly/map_attribute.rb
@@ -37,6 +37,10 @@ module Api
         self.table_name = 'map_attributes_mv'
 
         belongs_to :map_attribute_group
+
+        def self.refresh_dependencies(options = {})
+          Api::V3::Readonly::Attribute.refresh(options)
+        end
       end
     end
   end

--- a/app/models/api/v3/readonly/recolor_by_attribute.rb
+++ b/app/models/api/v3/readonly/recolor_by_attribute.rb
@@ -38,6 +38,10 @@ module Api
         delegate :display_name, to: :readonly_attribute
         delegate :original_type, to: :readonly_attribute
         delegate :original_id, to: :readonly_attribute
+
+        def self.refresh_dependencies(options = {})
+          Api::V3::Readonly::Attribute.refresh(options)
+        end
       end
     end
   end

--- a/app/models/api/v3/readonly/resize_by_attribute.rb
+++ b/app/models/api/v3/readonly/resize_by_attribute.rb
@@ -32,6 +32,10 @@ module Api
         delegate :display_name, to: :readonly_attribute
         delegate :original_type, to: :readonly_attribute
         delegate :original_id, to: :readonly_attribute
+
+        def self.refresh_dependencies(options = {})
+          Api::V3::Readonly::Attribute.refresh(options)
+        end
       end
     end
   end

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -87,7 +87,7 @@ module Api
                      attribute: :recolor_by_qual,
                      if: :new_recolor_by_qual_given?
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       stringy_array :years
       manage_associated_attributes [:recolor_by_ind, :recolor_by_qual]
@@ -98,7 +98,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::RecolorByAttribute.refresh
       end
     end

--- a/app/models/api/v3/resize_by_attribute.rb
+++ b/app/models/api/v3/resize_by_attribute.rb
@@ -45,7 +45,7 @@ module Api
                      attribute: :resize_by_quant,
                      if: :new_resize_by_quant_given?
 
-      after_commit :refresh_dependencies
+      after_commit :refresh_dependents
 
       stringy_array :years
       manage_associated_attributes [:resize_by_quant]
@@ -56,7 +56,7 @@ module Api
         ]
       end
 
-      def refresh_dependencies
+      def refresh_dependents
         Api::V3::Readonly::ResizeByAttribute.refresh
       end
     end

--- a/app/models/concerns/api/v3/readonly/dashboards/refresh.rb
+++ b/app/models/concerns/api/v3/readonly/dashboards/refresh.rb
@@ -6,11 +6,8 @@ module Api
           extend ActiveSupport::Concern
 
           class_methods do
-            def refresh(options = {})
-              unless options[:skip_flow_paths]
-                FlowPath.refresh(options.slice(:concurrently))
-              end
-              super(options.slice(:concurrently))
+            def refresh_dependencies(options = {})
+              FlowPath.refresh(concurrently: false) # no unique index
             end
           end
         end

--- a/app/models/concerns/api/v3/readonly/dashboards/refresh.rb
+++ b/app/models/concerns/api/v3/readonly/dashboards/refresh.rb
@@ -6,7 +6,7 @@ module Api
           extend ActiveSupport::Concern
 
           class_methods do
-            def refresh_dependencies(options = {})
+            def refresh_dependencies(_options = {})
               FlowPath.refresh(concurrently: false) # no unique index
             end
           end

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -153,6 +153,7 @@ module Api
         end
 
         def refresh_mviews
+          Api::V3::Readonly::DownloadFlow.refresh # with dependencies
           [
             Api::V3::Readonly::Attribute,
             Api::V3::Readonly::DownloadAttribute,
@@ -161,16 +162,13 @@ module Api
             Api::V3::Readonly::ResizeByAttribute,
             Api::V3::Readonly::DashboardsAttribute,
             Api::V3::Readonly::Node,
-            Api::V3::Readonly::DownloadFlow,
-            Api::V3::Readonly::Dashboards::FlowPath
-          ].each(&:refresh)
-          [
+            Api::V3::Readonly::Dashboards::FlowPath,
             Api::V3::Readonly::Dashboards::Commodity,
             Api::V3::Readonly::Dashboards::Country,
             Api::V3::Readonly::Dashboards::Source,
             Api::V3::Readonly::Dashboards::Company,
             Api::V3::Readonly::Dashboards::Destination
-          ].each { |mview| mview.refresh(skip_flow_paths: true) }
+          ].each { |mview| mview.refresh(skip_dependencies: true) }
         end
       end
     end

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -153,22 +153,26 @@ module Api
         end
 
         def refresh_mviews
-          Api::V3::Readonly::DownloadFlow.refresh # with dependencies
+          # synchronously, with dependencies
           [
             Api::V3::Readonly::Attribute,
+            Api::V3::Readonly::Node,
+            Api::V3::Readonly::DownloadFlow,
+            Api::V3::Readonly::Dashboards::FlowPath
+          ].each { |mview| mview.refresh(sync: true, skip_dependents: true) }
+          # synchronously, skip dependencies (already refreshed)
+          [
             Api::V3::Readonly::DownloadAttribute,
             Api::V3::Readonly::MapAttribute,
             Api::V3::Readonly::RecolorByAttribute,
             Api::V3::Readonly::ResizeByAttribute,
             Api::V3::Readonly::DashboardsAttribute,
-            Api::V3::Readonly::Node,
-            Api::V3::Readonly::Dashboards::FlowPath,
             Api::V3::Readonly::Dashboards::Commodity,
             Api::V3::Readonly::Dashboards::Country,
             Api::V3::Readonly::Dashboards::Source,
             Api::V3::Readonly::Dashboards::Company,
             Api::V3::Readonly::Dashboards::Destination
-          ].each { |mview| mview.refresh(skip_dependencies: true) }
+          ].each { |mview| mview.refresh(sync: true, skip_dependencies: true) }
         end
       end
     end

--- a/app/workers/materialized_view_refresh_worker.rb
+++ b/app/workers/materialized_view_refresh_worker.rb
@@ -1,4 +1,4 @@
-class DownloadFlowsRefreshWorker
+class MaterializedViewRefreshWorker
   include Sidekiq::Worker
   sidekiq_options queue: :database,
                   retry: 0,
@@ -7,7 +7,9 @@ class DownloadFlowsRefreshWorker
                   run_lock_expiration: 150, # 2.5 mins
                   log_duplicate_payload: true
 
-  def perform(options)
-    Api::V3::Readonly::DownloadFlow.refresh(options)
+  # @param mview_class_name [String] e.g. Api::V3::Readonly::DownloadFlow
+  def perform(mview_class_name, options)
+    mview_class = mview_class_name.constantize
+    mview_class.refresh(options)
   end
 end

--- a/app/workers/materialized_view_refresh_worker.rb
+++ b/app/workers/materialized_view_refresh_worker.rb
@@ -7,6 +7,10 @@ class MaterializedViewRefreshWorker
                   run_lock_expiration: 150, # 2.5 mins
                   log_duplicate_payload: true
 
+  def self.unique_args(args)
+    [args[0]]
+  end
+
   # @param mview_class_name [String] e.g. Api::V3::Readonly::DownloadFlow
   def perform(mview_class_name, options)
     mview_class = mview_class_name.constantize

--- a/app/workers/materialized_view_refresh_worker.rb
+++ b/app/workers/materialized_view_refresh_worker.rb
@@ -10,6 +10,6 @@ class MaterializedViewRefreshWorker
   # @param mview_class_name [String] e.g. Api::V3::Readonly::DownloadFlow
   def perform(mview_class_name, options)
     mview_class = mview_class_name.constantize
-    mview_class.refresh(options)
+    mview_class.refresh_now(options)
   end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -228,9 +228,10 @@ config.namespace :admin do |admin|
     menu.add label: 'Content', priority: 2
     menu.add label: 'Database', priority: 4
     menu.add label: 'General Settings', priority: 5
-    menu.add label: 'Sankey Settings', priority: 6
-    menu.add label: 'Map Settings', priority: 7
-    menu.add label: 'Data Download Settings', priority: 8
+    menu.add label: 'Sankey', priority: 6
+    menu.add label: 'Map', priority: 7
+    menu.add label: 'Data Download', priority: 8
+    menu.add label: 'Dashboards', priority: 9
   end
 end
 

--- a/db/migrate/20180223141212_expand_and_rename_buckets_in_map_attributes.rb
+++ b/db/migrate/20180223141212_expand_and_rename_buckets_in_map_attributes.rb
@@ -20,7 +20,7 @@ class ExpandAndRenameBucketsInMapAttributes < ActiveRecord::Migration[5.1]
       execute 'REFRESH MATERIALIZED VIEW map_attributes_mv'
     end
 
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
 
     Api::V3::MapAttribute.all.each do |ma|
       old_buckets = ma.dual_layer_buckets
@@ -34,7 +34,7 @@ class ExpandAndRenameBucketsInMapAttributes < ActiveRecord::Migration[5.1]
       end
     end
 
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
 
     Api::V3::Readonly::MapAttribute.refresh
   end
@@ -57,7 +57,7 @@ class ExpandAndRenameBucketsInMapAttributes < ActiveRecord::Migration[5.1]
       execute 'REFRESH MATERIALIZED VIEW map_attributes_mv'
     end
 
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
 
     Api::V3::MapAttribute.all.each do |ma|
       old_buckets = ma.dual_layer_buckets
@@ -69,7 +69,7 @@ class ExpandAndRenameBucketsInMapAttributes < ActiveRecord::Migration[5.1]
       end
     end
 
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
 
     Api::V3::Readonly::MapAttribute.refresh
   end

--- a/lib/tasks/dashboards_attributes_reload.rake
+++ b/lib/tasks/dashboards_attributes_reload.rake
@@ -63,6 +63,7 @@ namespace :dashboards do
             COFFEE_YIELD_
             SOY_AREAPERC
           ),
+
           quals: %w(
             Commodity
           ),

--- a/lib/tasks/dashboards_attributes_reload.rake
+++ b/lib/tasks/dashboards_attributes_reload.rake
@@ -2,8 +2,8 @@ namespace :dashboards do
   namespace :attributes do
     desc 'Reloads dashboards attributes tables'
     task reload: :environment do
-      Api::V3::DashboardsAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
-      Api::V3::DashboardsAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::DashboardsAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+      Api::V3::DashboardsAttribute.skip_callback(:commit, :after, :refresh_dependents)
 
       Api::V3::DashboardsInd.delete_all
       Api::V3::DashboardsQual.delete_all
@@ -15,8 +15,8 @@ namespace :dashboards do
         reload_group(properties, idx)
       end
 
-      Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
-      Api::V3::DashboardsAttribute.set_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+      Api::V3::DashboardsAttribute.set_callback(:commit, :after, :refresh_dependents)
 
       Api::V3::Readonly::DashboardsAttribute.refresh
     end

--- a/spec/controllers/admin/dashboards_attribute_groups_controller_spec.rb
+++ b/spec/controllers/admin/dashboards_attribute_groups_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Admin::DashboardsAttributeGroupsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::DashboardsAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+  end
+  after do
+    Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+  end
+  describe 'POST create' do
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_dashboards_attribute_group, chart_type: 'line'
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_chart_attribute_group: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/dashboards_attributes_controller_spec.rb
+++ b/spec/controllers/admin/dashboards_attributes_controller_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe Admin::DashboardsAttributesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  before do
+    Api::V3::DashboardsAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::DashboardsAttribute.skip_callback(:commit, :after, :refresh_dependents)
+  end
+  after do
+    Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::DashboardsAttribute.set_callback(:commit, :after, :refresh_dependents)
+  end
+  describe 'POST create' do
+    let(:dashboards_attribute_group) {
+      FactoryBot.create(:api_v3_dashboards_attribute_group)
+    }
+    let(:valid_attributes) {
+      FactoryBot.attributes_for(
+        :api_v3_dashboards_attribute, dashboards_attribute_group_id: dashboards_attribute_group.id
+      )
+    }
+    it 'clears cache' do
+      expect(controller).to receive(:clear_cache_for_regexp)
+      post :create, params: {api_v3_dashboards_attribute: valid_attributes}
+    end
+  end
+end

--- a/spec/controllers/admin/download_attributes_controller_spec.rb
+++ b/spec/controllers/admin/download_attributes_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::DownloadAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }

--- a/spec/controllers/admin/ind_properties_controller_spec.rb
+++ b/spec/controllers/admin/ind_properties_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::IndPropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::IndProperty.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::IndProperty.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::IndProperty.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::IndProperty.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:ind) { FactoryBot.create(:api_v3_ind) }

--- a/spec/controllers/admin/map_attribute_groups_controller_spec.rb
+++ b/spec/controllers/admin/map_attribute_groups_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::MapAttributeGroupsController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }

--- a/spec/controllers/admin/map_attributes_controller_spec.rb
+++ b/spec/controllers/admin/map_attributes_controller_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Admin::MapAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:map_attribute_group) {

--- a/spec/controllers/admin/node_properties_controller_spec.rb
+++ b/spec/controllers/admin/node_properties_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::NodePropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::NodeProperty.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::NodeProperty.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::NodeProperty.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::NodeProperty.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:node) { FactoryBot.create(:api_v3_node) }

--- a/spec/controllers/admin/qual_properties_controller_spec.rb
+++ b/spec/controllers/admin/qual_properties_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::QualPropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::QualProperty.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::QualProperty.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::QualProperty.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::QualProperty.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:qual) { FactoryBot.create(:api_v3_qual) }

--- a/spec/controllers/admin/quant_properties_controller_spec.rb
+++ b/spec/controllers/admin/quant_properties_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::QuantPropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::QuantProperty.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::QuantProperty.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::QuantProperty.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::QuantProperty.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:quant) { FactoryBot.create(:api_v3_quant) }

--- a/spec/controllers/admin/recolor_by_attributes_controller_spec.rb
+++ b/spec/controllers/admin/recolor_by_attributes_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::RecolorByAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }

--- a/spec/controllers/admin/resize_by_attributes_controller_spec.rb
+++ b/spec/controllers/admin/resize_by_attributes_controller_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Admin::ResizeByAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before do
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }

--- a/spec/models/api/v3/download_attribute_spec.rb
+++ b/spec/models/api/v3/download_attribute_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::DownloadAttribute, type: :model do
   before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil download attributes'
 

--- a/spec/models/api/v3/map_attribute_group_spec.rb
+++ b/spec/models/api/v3/map_attribute_group_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::MapAttributeGroup, type: :model do
   before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil map attribute groups'
 

--- a/spec/models/api/v3/map_attribute_spec.rb
+++ b/spec/models/api/v3/map_attribute_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::MapAttribute, type: :model do
   before do
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil map attributes'
 

--- a/spec/models/api/v3/recolor_by_attribute_spec.rb
+++ b/spec/models/api/v3/recolor_by_attribute_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::RecolorByAttribute, type: :model do
   before do
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil recolor by attributes'
 

--- a/spec/models/api/v3/resize_by_attribute_spec.rb
+++ b/spec/models/api/v3/resize_by_attribute_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::ResizeByAttribute, type: :model do
   before do
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil resize by attributes'
 

--- a/spec/responses/api/v3/contexts_spec.rb
+++ b/spec/responses/api/v3/contexts_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'Get contexts', type: :request do
   before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil soy nodes'
   include_context 'api v3 brazil download attributes'

--- a/spec/responses/api/v3/dashboards/attributes_spec.rb
+++ b/spec/responses/api/v3/dashboards/attributes_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Attributes', type: :request do
 
   describe 'GET /api/v3/dashboards/attributes' do
     before(:each) do
-      Api::V3::Readonly::Attribute.refresh
       Api::V3::Readonly::DashboardsAttribute.refresh
     end
 

--- a/spec/responses/api/v3/dashboards/attributes_spec.rb
+++ b/spec/responses/api/v3/dashboards/attributes_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Attributes', type: :request do
   describe 'GET /api/v3/dashboards/attributes' do
     before(:each) do
       Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::DashboardsAttribute.refresh(concurrently: false)
+      Api::V3::Readonly::DashboardsAttribute.refresh
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/dashboards/commodities_spec.rb
+++ b/spec/responses/api/v3/dashboards/commodities_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Commodities', type: :request do
 
   describe 'GET /api/v3/dashboards/commodities' do
     before(:each) do
-      Api::V3::Readonly::Dashboards::Commodity.refresh(concurrently: false)
+      Api::V3::Readonly::Dashboards::Commodity.refresh
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/dashboards/companies_spec.rb
+++ b/spec/responses/api/v3/dashboards/companies_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Companies', type: :request do
 
   describe 'GET /api/v3/dashboards/companies' do
     before(:each) do
-      Api::V3::Readonly::Dashboards::Company.refresh(concurrently: false)
+      Api::V3::Readonly::Dashboards::Company.refresh
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/dashboards/countries_spec.rb
+++ b/spec/responses/api/v3/dashboards/countries_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Countries', type: :request do
 
   describe 'GET /api/v3/dashboards/countries' do
     before(:each) do
-      Api::V3::Readonly::Dashboards::Country.refresh(concurrently: false)
+      Api::V3::Readonly::Dashboards::Country.refresh
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/dashboards/destinations_spec.rb
+++ b/spec/responses/api/v3/dashboards/destinations_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'destinations', type: :request do
 
   describe 'GET /api/v3/dashboards/destinations' do
     before(:each) do
-      Api::V3::Readonly::Dashboards::Destination.refresh(concurrently: false)
+      Api::V3::Readonly::Dashboards::Destination.refresh
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/dashboards/sources_spec.rb
+++ b/spec/responses/api/v3/dashboards/sources_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'sources', type: :request do
 
   describe 'GET /api/v3/dashboards/sources' do
     before(:each) do
-      Api::V3::Readonly::Dashboards::Source.refresh(concurrently: false)
+      Api::V3::Readonly::Dashboards::Source.refresh
     end
 
     it 'requires countries_ids' do

--- a/spec/responses/api/v3/download_attributes_spec.rb
+++ b/spec/responses/api/v3/download_attributes_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Download Attributes', type: :request do
   before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil download attributes'
   include_context 'api v3 brazil municipality qual values'

--- a/spec/responses/api/v3/map_layers_spec.rb
+++ b/spec/responses/api/v3/map_layers_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 
 RSpec.describe 'Map layers', type: :request do
   before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
   include_context 'api v3 brazil contextual layers'
   include_context 'api v3 brazil map attributes'

--- a/spec/services/api/v3/database_validation/checks/active_record_check_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/active_record_check_spec.rb
@@ -4,10 +4,10 @@ require 'services/api/v3/database_validation/checks/shared_check_examples'
 RSpec.describe Api::V3::DatabaseValidation::Checks::ActiveRecordCheck do
   context 'when checking recolor_by attributes' do
     before do
-      Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
     end
     after do
-      Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
     end
 
     let(:context) { FactoryBot.create(:api_v3_context) }

--- a/spec/services/api/v3/database_validation/checks/declared_years_match_data_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/declared_years_match_data_spec.rb
@@ -4,10 +4,10 @@ require 'services/api/v3/database_validation/checks/shared_check_examples'
 RSpec.describe Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchData do
   context 'when checking resize_by_attributes' do
     before do
-      Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
     end
     after do
-      Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
     end
 
     let(:context) { FactoryBot.create(:api_v3_context) }

--- a/spec/services/api/v3/database_validation/checks/has_at_least_one_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/has_at_least_one_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe Api::V3::DatabaseValidation::Checks::HasAtLeastOne do
 
   context 'when checking context resize_by_attributes' do
     before do
-      Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
     end
     after do
-      Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
     end
 
     let(:check) {

--- a/spec/services/api/v3/database_validation/checks/has_exactly_one_of_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/has_exactly_one_of_spec.rb
@@ -4,12 +4,12 @@ require 'services/api/v3/database_validation/checks/shared_check_examples'
 RSpec.describe Api::V3::DatabaseValidation::Checks::HasExactlyOneOf do
   context 'when checking map attributes' do
     before do
-      Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
-      Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+      Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
     end
     after do
-      Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
-      Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
+      Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+      Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
     end
 
     let(:map_attribute) {

--- a/spec/services/api/v3/database_validation/report_spec.rb
+++ b/spec/services/api/v3/database_validation/report_spec.rb
@@ -1,17 +1,17 @@
 RSpec.describe Api::V3::DatabaseValidation::Report do
   before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
   end
   after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependencies)
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependencies)
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
 
   let(:report) {


### PR DESCRIPTION
- CMS pages to configure attributes available in dashboards (shortened menu names)
- sorting out mview refreshing, so that long running refreshes are processed in background
- some cleanup of convoluted refreshing logic