### PR TITLE
Fix/mview refreshing issue

### DIFF
--- a/app/models/api/v3/dashboard_template_company.rb
+++ b/app/models/api/v3/dashboard_template_company.rb
@@ -15,7 +15,9 @@ module Api
       belongs_to :dashboard_template
       belongs_to :node
 
-      belongs_to :readonly_dashboards_company, class_name: Api::V3::Readonly::Dashboards::Company, foreign_key: 'node_id'
+      belongs_to :readonly_dashboards_company,
+                 class_name: 'Api::V3::Readonly::Dashboards::Company',
+                 foreign_key: 'node_id'
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/dashboard_template_destination.rb
+++ b/app/models/api/v3/dashboard_template_destination.rb
@@ -15,7 +15,9 @@ module Api
       belongs_to :dashboard_template
       belongs_to :node
 
-      belongs_to :readonly_dashboards_destination, class_name: Api::V3::Readonly::Dashboards::Destination, foreign_key: 'node_id'
+      belongs_to :readonly_dashboards_destination,
+                 class_name: 'Api::V3::Readonly::Dashboards::Destination',
+                 foreign_key: 'node_id'
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/dashboard_template_source.rb
+++ b/app/models/api/v3/dashboard_template_source.rb
@@ -15,7 +15,9 @@ module Api
       belongs_to :dashboard_template
       belongs_to :node
 
-      belongs_to :readonly_dashboards_source, class_name: Api::V3::Readonly::Dashboards::Source, foreign_key: 'node_id'
+      belongs_to :readonly_dashboards_source,
+                 class_name: 'Api::V3::Readonly::Dashboards::Source',
+                 foreign_key: 'node_id'
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -22,7 +22,7 @@ module Api
           end
 
           def refresh_now(options = {})
-            refresh_dependencies unless options[:skip_dependencies]
+            refresh_dependencies(options) unless options[:skip_dependencies]
             refresh_by_name(table_name, options)
             refresh_dependents(options) unless options[:skip_dependents]
           end

--- a/app/models/api/v3/readonly/dashboards_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards_attribute.rb
@@ -29,7 +29,7 @@ module Api
         delegate :original_id, to: :readonly_attribute
 
         def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options)
+          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
         end
 
         def self.refresh_dependents(options = {})

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -34,7 +34,7 @@ module Api
         delegate :original_id, to: :readonly_attribute
 
         def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options)
+          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
         end
       end
     end

--- a/app/models/api/v3/readonly/map_attribute.rb
+++ b/app/models/api/v3/readonly/map_attribute.rb
@@ -39,7 +39,7 @@ module Api
         belongs_to :map_attribute_group
 
         def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options)
+          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
         end
       end
     end

--- a/app/models/api/v3/readonly/recolor_by_attribute.rb
+++ b/app/models/api/v3/readonly/recolor_by_attribute.rb
@@ -40,7 +40,7 @@ module Api
         delegate :original_id, to: :readonly_attribute
 
         def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options)
+          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
         end
       end
     end

--- a/app/models/api/v3/readonly/resize_by_attribute.rb
+++ b/app/models/api/v3/readonly/resize_by_attribute.rb
@@ -34,7 +34,7 @@ module Api
         delegate :original_id, to: :readonly_attribute
 
         def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options)
+          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
         end
       end
     end

--- a/lib/tasks/dashboards_attributes_reload.rake
+++ b/lib/tasks/dashboards_attributes_reload.rake
@@ -18,7 +18,7 @@ namespace :dashboards do
       Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
       Api::V3::DashboardsAttribute.set_callback(:commit, :after, :refresh_dependents)
 
-      Api::V3::Readonly::DashboardsAttribute.refresh
+      Api::V3::Readonly::DashboardsAttribute.refresh(sync: true)
     end
 
     def reload_group(properties, idx)


### PR DESCRIPTION
Fixes a few issues around mviews:
- Readonly::BaseModel#refresh: options now passed to refresh_dependencies
- refresh_dependencies: removed circular dependency refresh
- refresh mviews synchronously when running the dashboards reload rake task
- also fixed a warning: class_name in AR associations should be given as string