### PR TITLE
Fix/speed up slow migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Layout/MultilineOperationIndentation:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-Lint/RescueWithoutErrorClass:
+Style/RescueStandardError:
   Enabled: false
 
 Metrics/BlockLength:

--- a/app/admin/api/v3/dashboards_attribute_group.rb
+++ b/app/admin/api/v3/dashboards_attribute_group.rb
@@ -6,7 +6,6 @@ ActiveAdmin.register Api::V3::DashboardsAttributeGroup, as: 'DashboardsAttribute
   permit_params :name,
                 :position
 
-
   controller do
     def clear_cache
       clear_cache_for_regexp('/api/v3/dashboards/indicators')

--- a/app/controllers/api/v3/dashboards/templates_controller.rb
+++ b/app/controllers/api/v3/dashboards/templates_controller.rb
@@ -5,7 +5,7 @@ module Api
         skip_before_action :load_context
 
         def index
-          dashboardTemplates = Api::V3::DashboardTemplate.
+          dashboard_templates = Api::V3::DashboardTemplate.
             includes(
               :countries,
               :commodities,
@@ -15,7 +15,7 @@ module Api
               sources: :node_type
             )
 
-          render json: dashboardTemplates,
+          render json: dashboard_templates,
                  root: 'data',
                  each_serializer: Api::V3::Dashboards::TemplateSerializer
         end

--- a/app/controllers/concerns/api/v3/dashboards/pagination_headers.rb
+++ b/app/controllers/concerns/api/v3/dashboards/pagination_headers.rb
@@ -45,12 +45,14 @@ module Api
         def current_page
           page = params[:page]&.to_i
           return 1 if page.nil? || page.negative?
+
           page
         end
 
         def current_per_page
           per_page = params[:per_page]&.to_i
           return 25 if per_page.nil? || per_page.negative?
+
           per_page
         end
       end

--- a/app/models/api/v3/readonly/dashboards/flow_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards/flow_attribute.rb
@@ -12,13 +12,6 @@
 #  dashboards_attribute_group_id :bigint(8)
 #  position                      :integer
 #
-# Indexes
-#
-#  dashboards_flow_attributes_mv_commodity_id_idx              (commodity_id)
-#  dashboards_flow_attributes_mv_country_id_idx                (country_id)
-#  dashboards_flow_attributes_mv_path_idx                      (path) USING gist
-#  dashboards_flow_attributes_mv_unique_attr_flow_context_idx  (attribute_id,path,commodity_id,country_id) UNIQUE
-#
 
 module Api
   module V3

--- a/app/models/api/v3/readonly/dashboards/node_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards/node_attribute.rb
@@ -10,10 +10,6 @@
 #  dashboards_attribute_group_id :bigint(8)
 #  position                      :integer
 #
-# Indexes
-#
-#  dashboards_node_attributes_mv_node_id_attribute_id_idx  (node_id,attribute_id) UNIQUE
-#
 
 module Api
   module V3

--- a/app/services/api/v3/dashboards/chart_data_from_node_attributes.rb
+++ b/app/services/api/v3/dashboards/chart_data_from_node_attributes.rb
@@ -8,6 +8,7 @@ module Api
           @commodities_ids = commodities_ids
           @nodes_ids = nodes_ids
           raise 'Node missing' unless @nodes_ids.any?
+
           initialize_nodes_ids_with_data
           initialize_query
         end

--- a/app/services/api/v3/dashboards/retrieve_attributes.rb
+++ b/app/services/api/v3/dashboards/retrieve_attributes.rb
@@ -71,6 +71,7 @@ module Api
 
         def case_sql(conditions)
           return 'FALSE AS is_disabled' if conditions.blank?
+
           <<~SQL
             CASE
               WHEN #{conditions} THEN FALSE
@@ -110,6 +111,7 @@ module Api
 
         def node_attributes_conditions_for_case
           return unless @nodes_ids.any?
+
           Api::V3::Readonly::Attribute.send(
             :sanitize_sql_for_conditions,
             ['node_id IN (?)', @nodes_ids]

--- a/app/services/api/v3/dashboards/retrieve_attributes.rb
+++ b/app/services/api/v3/dashboards/retrieve_attributes.rb
@@ -37,7 +37,6 @@ module Api
               :dashboards_attribute_group_id,
               'NOT BOOL_OR(NOT is_disabled) AS is_disabled'
             ).
-            where('display_name IS NOT NULL').
             group(
               :id,
               :display_name,

--- a/db/migrate/20181002105509_create_dashboards_node_attributes_mv.rb
+++ b/db/migrate/20181002105509_create_dashboards_node_attributes_mv.rb
@@ -1,9 +1,5 @@
 class CreateDashboardsNodeAttributesMv < ActiveRecord::Migration[5.1]
   def change
-    create_view :dashboards_node_attributes_mv, materialized: true
-    add_index :dashboards_node_attributes_mv,
-      [:node_id, :attribute_id],
-      unique: true,
-      name: 'dashboards_node_attributes_mv_node_id_attribute_id_idx'
+    # no-op
   end
 end

--- a/db/migrate/20181002105912_create_dashboards_flow_attributes_mv.rb
+++ b/db/migrate/20181002105912_create_dashboards_flow_attributes_mv.rb
@@ -1,23 +1,5 @@
 class CreateDashboardsFlowAttributesMv < ActiveRecord::Migration[5.1]
   def change
-    create_view :dashboards_flow_attributes_mv, materialized: true
-    add_index :dashboards_flow_attributes_mv,
-      [:attribute_id, :path],
-      unique: true,
-      name: 'dashboards_flow_attributes_mv_flow_id_attribute_id_idx'
-    add_index :dashboards_flow_attributes_mv,
-      :country_id,
-      name: 'dashboards_flow_attributes_mv_country_id_idx'
-    add_index :dashboards_flow_attributes_mv,
-      :commodity_id,
-      name: 'dashboards_flow_attributes_mv_commodity_id_idx'
-    reversible do |dir|
-      dir.up do
-        add_index :dashboards_flow_attributes_mv,
-          'path gist__int_ops',
-          using: 'gist',
-          name: 'dashboards_flow_attributes_mv_path_idx'
-      end
-    end
+    # no-op
   end
 end

--- a/db/migrate/20181019222226_speed_up_dashboards_flow_attributes_refresh.rb
+++ b/db/migrate/20181019222226_speed_up_dashboards_flow_attributes_refresh.rb
@@ -1,0 +1,6 @@
+class SpeedUpDashboardsFlowAttributesRefresh < ActiveRecord::Migration[5.1]
+  def up
+    drop_view :dashboards_flow_attributes_mv, materialized: true
+    create_view :dashboards_flow_attributes_mv, materialized: true, version: 2
+  end
+end

--- a/db/migrate/20181019232447_speed_up_dashboards_node_attributes_refresh.rb
+++ b/db/migrate/20181019232447_speed_up_dashboards_node_attributes_refresh.rb
@@ -1,0 +1,6 @@
+class SpeedUpDashboardsNodeAttributesRefresh < ActiveRecord::Migration[5.1]
+  def up
+    drop_view :dashboards_node_attributes_mv, materialized: true
+    create_view :dashboards_node_attributes_mv, materialized: true, version: 2
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1644,47 +1644,56 @@ CREATE TABLE public.flow_quants (
 --
 
 CREATE MATERIALIZED VIEW public.dashboards_flow_attributes_mv AS
- WITH all_attributes(id, display_name, tooltip_text, chart_type, dashboards_attribute_group_id, "position", original_id, original_type) AS (
-         SELECT a.id,
-            a.display_name,
-            a.tooltip_text,
-            da.chart_type,
-            da.dashboards_attribute_group_id,
-            da."position",
-            a.original_id,
-            a.original_type
-           FROM (public.dashboards_attributes_mv da
-             JOIN public.attributes_mv a ON ((a.id = da.attribute_id)))
-        ), combinations(flow_id, original_id, original_type) AS (
-         SELECT DISTINCT flow_inds.flow_id,
-            flow_inds.ind_id,
-            'Ind'::text AS text
-           FROM public.flow_inds
-        UNION ALL
-         SELECT DISTINCT flow_quals.flow_id,
-            flow_quals.qual_id,
-            'Qual'::text AS text
-           FROM public.flow_quals
-        UNION ALL
-         SELECT DISTINCT flow_quants.flow_id,
-            flow_quants.quant_id,
-            'Quant'::text AS text
-           FROM public.flow_quants
-        )
  SELECT DISTINCT contexts.country_id,
     contexts.commodity_id,
     flows.path,
-    all_attributes.id AS attribute_id,
-    all_attributes.display_name,
-    all_attributes.tooltip_text,
-    all_attributes.chart_type,
-    all_attributes.dashboards_attribute_group_id,
-    all_attributes."position"
-   FROM (((all_attributes
-     JOIN combinations ON (((all_attributes.original_id = combinations.original_id) AND (all_attributes.original_type = combinations.original_type))))
-     JOIN public.flows ON ((combinations.flow_id = flows.id)))
+    a.id AS attribute_id,
+    a.display_name,
+    a.tooltip_text,
+    da.chart_type,
+    da.dashboards_attribute_group_id,
+    da."position"
+   FROM (((((public.flows
      JOIN public.contexts ON ((flows.context_id = contexts.id)))
-  GROUP BY contexts.country_id, contexts.commodity_id, flows.path, all_attributes.id, all_attributes.display_name, all_attributes.tooltip_text, all_attributes.chart_type, all_attributes.dashboards_attribute_group_id, all_attributes."position"
+     JOIN public.flow_inds ON ((flows.id = flow_inds.flow_id)))
+     JOIN public.dashboards_inds di ON ((flow_inds.ind_id = di.ind_id)))
+     JOIN public.dashboards_attributes da ON ((da.id = di.dashboards_attribute_id)))
+     JOIN public.attributes_mv a ON (((a.original_id = di.ind_id) AND (a.original_type = 'Ind'::text))))
+  WHERE (a.display_name IS NOT NULL)
+UNION ALL
+ SELECT DISTINCT contexts.country_id,
+    contexts.commodity_id,
+    flows.path,
+    a.id AS attribute_id,
+    a.display_name,
+    a.tooltip_text,
+    da.chart_type,
+    da.dashboards_attribute_group_id,
+    da."position"
+   FROM (((((public.flows
+     JOIN public.contexts ON ((flows.context_id = contexts.id)))
+     JOIN public.flow_quals ON ((flows.id = flow_quals.flow_id)))
+     JOIN public.dashboards_quals dq ON ((flow_quals.qual_id = dq.qual_id)))
+     JOIN public.dashboards_attributes da ON ((da.id = dq.dashboards_attribute_id)))
+     JOIN public.attributes_mv a ON (((a.original_id = dq.qual_id) AND (a.original_type = 'Qual'::text))))
+  WHERE (a.display_name IS NOT NULL)
+UNION ALL
+ SELECT DISTINCT contexts.country_id,
+    contexts.commodity_id,
+    flows.path,
+    a.id AS attribute_id,
+    a.display_name,
+    a.tooltip_text,
+    da.chart_type,
+    da.dashboards_attribute_group_id,
+    da."position"
+   FROM (((((public.flows
+     JOIN public.contexts ON ((flows.context_id = contexts.id)))
+     JOIN public.flow_quants ON ((flows.id = flow_quants.flow_id)))
+     JOIN public.dashboards_quants dq ON ((flow_quants.quant_id = dq.quant_id)))
+     JOIN public.dashboards_attributes da ON ((da.id = dq.dashboards_attribute_id)))
+     JOIN public.attributes_mv a ON (((a.original_id = dq.quant_id) AND (a.original_type = 'Quant'::text))))
+  WHERE (a.display_name IS NOT NULL)
   WITH NO DATA;
 
 
@@ -4665,34 +4674,6 @@ CREATE UNIQUE INDEX dashboards_destinations_mv_unique_idx ON public.dashboards_d
 
 
 --
--- Name: dashboards_flow_attributes_mv_commodity_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX dashboards_flow_attributes_mv_commodity_id_idx ON public.dashboards_flow_attributes_mv USING btree (commodity_id);
-
-
---
--- Name: dashboards_flow_attributes_mv_country_id_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX dashboards_flow_attributes_mv_country_id_idx ON public.dashboards_flow_attributes_mv USING btree (country_id);
-
-
---
--- Name: dashboards_flow_attributes_mv_path_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX dashboards_flow_attributes_mv_path_idx ON public.dashboards_flow_attributes_mv USING gist (path);
-
-
---
--- Name: dashboards_flow_attributes_mv_unique_attr_flow_context_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX dashboards_flow_attributes_mv_unique_attr_flow_context_idx ON public.dashboards_flow_attributes_mv USING btree (attribute_id, path, commodity_id, country_id);
-
-
---
 -- Name: dashboards_flow_paths_mv_category_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4823,6 +4804,20 @@ CREATE UNIQUE INDEX download_flows_mv_row_name_attribute_type_attribute_id_idx O
 --
 
 CREATE INDEX flow_inds_ind_id_idx ON public.flow_inds USING btree (ind_id);
+
+
+--
+-- Name: flow_paths_mv_flow_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX flow_paths_mv_flow_id_idx ON public.flow_paths_mv USING btree (flow_id);
+
+
+--
+-- Name: flow_paths_mv_flow_id_position_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX flow_paths_mv_flow_id_position_idx ON public.flow_paths_mv USING btree (flow_id, column_position);
 
 
 --
@@ -5075,13 +5070,6 @@ CREATE UNIQUE INDEX index_download_versions_on_context_id_and_is_current ON publ
 --
 
 CREATE INDEX index_flow_inds_on_flow_id ON public.flow_inds USING btree (flow_id);
-
-
---
--- Name: index_flow_paths_mv_on_flow_id_and_column_position; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_flow_paths_mv_on_flow_id_and_column_position ON public.flow_paths_mv USING btree (flow_id, column_position);
 
 
 --
@@ -6022,6 +6010,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181008101006'),
 ('20181009102913'),
 ('20181011103455'),
-('20181017053240');
+('20181017053240'),
+('20181019222226');
 
 

--- a/db/views/dashboards_flow_attributes_mv_v02.sql
+++ b/db/views/dashboards_flow_attributes_mv_v02.sql
@@ -1,0 +1,57 @@
+SELECT DISTINCT
+  contexts.country_id,
+  contexts.commodity_id,
+  flows.path,
+  a.id AS attribute_id,
+  a.display_name,
+  a.tooltip_text,
+  da.chart_type,
+  da.dashboards_attribute_group_id,
+  da.position
+FROM flows
+JOIN contexts ON flows.context_id = contexts.id
+JOIN flow_inds ON flows.id = flow_inds.flow_id
+JOIN dashboards_inds di ON flow_inds.ind_id = di.ind_id
+JOIN dashboards_attributes da ON da.id = di.dashboards_attribute_id
+JOIN attributes_mv a ON a.original_id = di.ind_id AND a.original_type = 'Ind'
+WHERE a.display_name IS NOT NULL
+
+UNION ALL
+
+SELECT DISTINCT
+  contexts.country_id,
+  contexts.commodity_id,
+  flows.path,
+  a.id AS attribute_id,
+  a.display_name,
+  a.tooltip_text,
+  da.chart_type,
+  da.dashboards_attribute_group_id,
+  da.position
+FROM flows
+JOIN contexts ON flows.context_id = contexts.id
+JOIN flow_quals ON flows.id = flow_quals.flow_id
+JOIN dashboards_quals dq ON flow_quals.qual_id = dq.qual_id
+JOIN dashboards_attributes da ON da.id = dq.dashboards_attribute_id
+JOIN attributes_mv a ON a.original_id = dq.qual_id AND a.original_type = 'Qual'
+WHERE a.display_name IS NOT NULL
+
+UNION ALL
+
+SELECT DISTINCT
+  contexts.country_id,
+  contexts.commodity_id,
+  flows.path,
+  a.id AS attribute_id,
+  a.display_name,
+  a.tooltip_text,
+  da.chart_type,
+  da.dashboards_attribute_group_id,
+  da.position
+FROM flows
+JOIN contexts ON flows.context_id = contexts.id
+JOIN flow_quants ON flows.id = flow_quants.flow_id
+JOIN dashboards_quants dq ON flow_quants.quant_id = dq.quant_id
+JOIN dashboards_attributes da ON da.id = dq.dashboards_attribute_id
+JOIN attributes_mv a ON a.original_id = dq.quant_id AND a.original_type = 'Quant'
+WHERE a.display_name IS NOT NULL;

--- a/db/views/dashboards_node_attributes_mv_v02.sql
+++ b/db/views/dashboards_node_attributes_mv_v02.sql
@@ -1,0 +1,60 @@
+SELECT DISTINCT
+  --contexts.country_id,
+  --contexts.commodity_id,
+  node_inds.node_id,
+  a.id AS attribute_id,
+  a.display_name,
+  a.tooltip_text,
+  da.chart_type,
+  da.dashboards_attribute_group_id,
+  da.position
+FROM node_inds
+--JOIN nodes ON node_inds.node_id = nodes.id
+--JOIN context_node_types ON nodes.node_type_id = context_node_types.node_type_id
+--JOIN contexts ON context_node_types.context_id = contexts.id
+JOIN dashboards_inds di ON node_inds.ind_id = di.ind_id
+JOIN dashboards_attributes da ON da.id = di.dashboards_attribute_id
+JOIN attributes_mv a ON a.original_id = di.ind_id AND a.original_type = 'Ind'
+WHERE a.display_name IS NOT NULL
+
+UNION ALL
+
+SELECT DISTINCT
+  --contexts.country_id,
+  --contexts.commodity_id,
+  node_quals.node_id,
+  a.id AS attribute_id,
+  a.display_name,
+  a.tooltip_text,
+  da.chart_type,
+  da.dashboards_attribute_group_id,
+  da.position
+FROM node_quals
+--JOIN nodes ON node_quals.node_id = nodes.id
+--JOIN context_node_types ON nodes.node_type_id = context_node_types.node_type_id
+--JOIN contexts ON context_node_types.context_id = contexts.id
+JOIN dashboards_quals dq ON node_quals.qual_id = dq.qual_id
+JOIN dashboards_attributes da ON da.id = dq.dashboards_attribute_id
+JOIN attributes_mv a ON a.original_id = dq.qual_id AND a.original_type = 'Qual'
+WHERE a.display_name IS NOT NULL
+
+UNION ALL
+
+SELECT DISTINCT
+  --contexts.country_id,
+  --contexts.commodity_id,
+  node_quants.node_id,
+  a.id AS attribute_id,
+  a.display_name,
+  a.tooltip_text,
+  da.chart_type,
+  da.dashboards_attribute_group_id,
+  da.position
+FROM node_quants
+--JOIN nodes ON node_quants.node_id = nodes.id
+--JOIN context_node_types ON nodes.node_type_id = context_node_types.node_type_id
+--JOIN contexts ON context_node_types.context_id = contexts.id
+JOIN dashboards_quants dq ON node_quants.quant_id = dq.quant_id
+JOIN dashboards_attributes da ON da.id = dq.dashboards_attribute_id
+JOIN attributes_mv a ON a.original_id = dq.quant_id AND a.original_type = 'Quant'
+WHERE a.display_name IS NOT NULL;

--- a/spec/controllers/admin/dashboards_attribute_groups_controller_spec.rb
+++ b/spec/controllers/admin/dashboards_attribute_groups_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::DashboardsAttributeGroupsController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::DashboardsAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:valid_attributes) {
       FactoryBot.attributes_for(

--- a/spec/controllers/admin/dashboards_attributes_controller_spec.rb
+++ b/spec/controllers/admin/dashboards_attributes_controller_spec.rb
@@ -3,14 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::DashboardsAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::DashboardsAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::DashboardsAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::DashboardsAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:dashboards_attribute_group) {
       FactoryBot.create(:api_v3_dashboards_attribute_group)

--- a/spec/controllers/admin/download_attributes_controller_spec.rb
+++ b/spec/controllers/admin/download_attributes_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::DownloadAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }
     let(:valid_attributes) {

--- a/spec/controllers/admin/ind_properties_controller_spec.rb
+++ b/spec/controllers/admin/ind_properties_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::IndPropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::IndProperty.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::IndProperty.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:ind) { FactoryBot.create(:api_v3_ind) }
     let(:valid_attributes) {

--- a/spec/controllers/admin/map_attribute_groups_controller_spec.rb
+++ b/spec/controllers/admin/map_attribute_groups_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::MapAttributeGroupsController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }
     let(:valid_attributes) {

--- a/spec/controllers/admin/map_attributes_controller_spec.rb
+++ b/spec/controllers/admin/map_attributes_controller_spec.rb
@@ -3,14 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::MapAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:map_attribute_group) {
       FactoryBot.create(:api_v3_map_attribute_group)

--- a/spec/controllers/admin/node_properties_controller_spec.rb
+++ b/spec/controllers/admin/node_properties_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::NodePropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::NodeProperty.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::NodeProperty.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:node) { FactoryBot.create(:api_v3_node) }
     let(:valid_attributes) {

--- a/spec/controllers/admin/qual_properties_controller_spec.rb
+++ b/spec/controllers/admin/qual_properties_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::QualPropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::QualProperty.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::QualProperty.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:qual) { FactoryBot.create(:api_v3_qual) }
     let(:valid_attributes) {

--- a/spec/controllers/admin/quant_properties_controller_spec.rb
+++ b/spec/controllers/admin/quant_properties_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::QuantPropertiesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::QuantProperty.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::QuantProperty.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:quant) { FactoryBot.create(:api_v3_quant) }
     let(:valid_attributes) {

--- a/spec/controllers/admin/recolor_by_attributes_controller_spec.rb
+++ b/spec/controllers/admin/recolor_by_attributes_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::RecolorByAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }
     let(:valid_attributes) {

--- a/spec/controllers/admin/resize_by_attributes_controller_spec.rb
+++ b/spec/controllers/admin/resize_by_attributes_controller_spec.rb
@@ -3,12 +3,7 @@ require 'rails_helper'
 RSpec.describe Admin::ResizeByAttributesController, type: :controller do
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
-  before do
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
+
   describe 'POST create' do
     let(:context) { FactoryBot.create(:api_v3_context) }
     let(:valid_attributes) {

--- a/spec/controllers/api/v3/dashboards/commodities_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/commodities_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Api::V3::Dashboards::CommoditiesController, type: :controller do
   include_context 'api v3 brazil flows quants'
 
   before(:each) do
-    Api::V3::Readonly::Dashboards::Commodity.refresh
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Commodity.refresh(sync: true, skip_dependencies: true)
   end
 
   describe 'GET search' do

--- a/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
   include_context 'api v3 brazil flows quants'
 
   before(:each) do
-    Api::V3::Readonly::Dashboards::Company.refresh
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Company.refresh(sync: true, skip_dependencies: true)
   end
 
   describe 'GET search' do

--- a/spec/controllers/api/v3/dashboards/countries_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/countries_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Api::V3::Dashboards::CountriesController, type: :controller do
   include_context 'api v3 brazil flows quants'
 
   before(:each) do
-    Api::V3::Readonly::Dashboards::Country.refresh
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Country.refresh(sync: true, skip_dependencies: true)
   end
 
   describe 'GET search' do

--- a/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Api::V3::Dashboards::DestinationsController, type: :controller do
   include_context 'api v3 brazil flows quants'
 
   before(:each) do
-    Api::V3::Readonly::Dashboards::Destination.refresh
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Destination.refresh(sync: true, skip_dependencies: true)
   end
 
   describe 'GET search' do

--- a/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe Api::V3::Dashboards::SourcesController, type: :controller do
   include_context 'api v3 brazil flows quants'
 
   before(:each) do
-    Api::V3::Readonly::Dashboards::Source.refresh
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Source.refresh(sync: true, skip_dependencies: true)
   end
 
   describe 'GET search' do

--- a/spec/controllers/api/v3/download_controller_spec.rb
+++ b/spec/controllers/api/v3/download_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V3::DownloadController, type: :controller do
 
   describe 'GET index' do
     before(:each) do
-      Api::V3::Readonly::DownloadFlow.refresh
+      Api::V3::Readonly::DownloadFlow.refresh(sync: true)
       Api::V3::DownloadVersion.current_version_symbol(api_v3_context) ||
         FactoryBot.create(
           :api_v3_download_version,

--- a/spec/models/api/v3/download_attribute_spec.rb
+++ b/spec/models/api/v3/download_attribute_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::DownloadAttribute, type: :model do
-  before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil download attributes'
 
   describe :validate do

--- a/spec/models/api/v3/map_attribute_group_spec.rb
+++ b/spec/models/api/v3/map_attribute_group_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::MapAttributeGroup, type: :model do
-  before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil map attribute groups'
 
   describe :validate do

--- a/spec/models/api/v3/map_attribute_spec.rb
+++ b/spec/models/api/v3/map_attribute_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::MapAttribute, type: :model do
-  before do
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil map attributes'
 
   describe :validate do

--- a/spec/models/api/v3/recolor_by_attribute_spec.rb
+++ b/spec/models/api/v3/recolor_by_attribute_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::RecolorByAttribute, type: :model do
-  before do
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil recolor by attributes'
 
   describe :validate do

--- a/spec/models/api/v3/resize_by_attribute_spec.rb
+++ b/spec/models/api/v3/resize_by_attribute_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::ResizeByAttribute, type: :model do
-  before do
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil resize by attributes'
 
   describe :validate do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,36 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
+
+    # disable after commit refresh callbacks
+    Api::V3::DashboardsAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::DashboardsAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::IndProperty.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::NodeProperty.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::Profile.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::QualProperty.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::QuantProperty.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
+    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
+  end
+
+  config.after(:suite) do
+    # enable after commit refresh callbacks
+    Api::V3::DashboardsAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::DashboardsAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::IndProperty.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::NodeProperty.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::Profile.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::QualProperty.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::QuantProperty.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
+    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
   end
 
   config.before(:each) do

--- a/spec/responses/api/v3/contexts_spec.rb
+++ b/spec/responses/api/v3/contexts_spec.rb
@@ -1,29 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Get contexts', type: :request do
-  before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil soy nodes'
   include_context 'api v3 brazil download attributes'
   include_context 'api v3 brazil resize by attributes'
   include_context 'api v3 brazil recolor by attributes'
 
-  describe 'GET /api/v3/contexts' do
-    before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::DownloadAttribute.refresh
-      Api::V3::Readonly::ResizeByAttribute.refresh
-      Api::V3::Readonly::RecolorByAttribute.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::DownloadAttribute.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/contexts' do
     it 'has the correct response structure' do
       get '/api/v3/contexts'
 

--- a/spec/responses/api/v3/dashboards/attributes_spec.rb
+++ b/spec/responses/api/v3/dashboards/attributes_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe 'Attributes', type: :request do
 
   describe 'GET /api/v3/dashboards/attributes' do
     before(:each) do
-      Api::V3::Readonly::DashboardsAttribute.refresh
+      Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::DashboardsAttribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::Dashboards::FlowAttribute.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::Dashboards::NodeAttribute.refresh(sync: true, skip_dependencies: true)
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/dashboards/commodities_spec.rb
+++ b/spec/responses/api/v3/dashboards/commodities_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Commodities', type: :request do
   include_context 'api v3 brazil flows quants'
 
-  describe 'GET /api/v3/dashboards/commodities' do
-    before(:each) do
-      Api::V3::Readonly::Dashboards::Commodity.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Commodity.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/dashboards/commodities' do
     it 'has the correct response structure' do
       get '/api/v3/dashboards/commodities'
 

--- a/spec/responses/api/v3/dashboards/companies_spec.rb
+++ b/spec/responses/api/v3/dashboards/companies_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Companies', type: :request do
   include_context 'api v3 brazil flows quants'
 
-  describe 'GET /api/v3/dashboards/companies' do
-    before(:each) do
-      Api::V3::Readonly::Dashboards::Company.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Company.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/dashboards/companies' do
     it 'has the correct response structure' do
       get '/api/v3/dashboards/companies'
 

--- a/spec/responses/api/v3/dashboards/countries_spec.rb
+++ b/spec/responses/api/v3/dashboards/countries_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe 'Countries', type: :request do
   include_context 'api v3 brazil flows quants'
 
-  describe 'GET /api/v3/dashboards/countries' do
-    before(:each) do
-      Api::V3::Readonly::Dashboards::Country.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Country.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/dashboards/countries' do
     it 'has the correct response structure' do
       get '/api/v3/dashboards/countries'
 

--- a/spec/responses/api/v3/dashboards/destinations_spec.rb
+++ b/spec/responses/api/v3/dashboards/destinations_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe 'destinations', type: :request do
   include_context 'api v3 brazil flows quants'
 
-  describe 'GET /api/v3/dashboards/destinations' do
-    before(:each) do
-      Api::V3::Readonly::Dashboards::Destination.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Destination.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/dashboards/destinations' do
     it 'has the correct response structure' do
       get '/api/v3/dashboards/destinations'
 

--- a/spec/responses/api/v3/dashboards/sources_spec.rb
+++ b/spec/responses/api/v3/dashboards/sources_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe 'sources', type: :request do
   include_context 'api v3 brazil flows quants'
 
-  describe 'GET /api/v3/dashboards/sources' do
-    before(:each) do
-      Api::V3::Readonly::Dashboards::Source.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Dashboards::Source.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/dashboards/sources' do
     it 'requires countries_ids' do
       get '/api/v3/dashboards/sources'
 

--- a/spec/responses/api/v3/dashboards/templates_spec.rb
+++ b/spec/responses/api/v3/dashboards/templates_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe 'Templates', type: :request do
 
   describe 'GET /api/v3/dashboards/templates' do
     before(:each) do
-      Api::V3::Readonly::Dashboards::Commodity.refresh(concurrently: false)
-      Api::V3::Readonly::Dashboards::Country.refresh(concurrently: false)
-      Api::V3::Readonly::Dashboards::Source.refresh(concurrently: false)
-      Api::V3::Readonly::Dashboards::Company.refresh(concurrently: false)
-      Api::V3::Readonly::Dashboards::Destination.refresh(concurrently: false)
+      Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::Dashboards::Commodity.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::Dashboards::Country.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::Dashboards::Source.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::Dashboards::Company.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::Dashboards::Destination.refresh(sync: true, skip_dependencies: true)
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/download_attributes_spec.rb
+++ b/spec/responses/api/v3/download_attributes_spec.rb
@@ -1,22 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Download Attributes', type: :request do
-  before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil download attributes'
   include_context 'api v3 brazil municipality qual values'
   include_context 'api v3 brazil municipality quant values'
 
-  describe 'GET /api/v3/contexts/:context_id/download_attributes' do
-    before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::DownloadAttribute.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::DownloadAttribute.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/contexts/:context_id/download_attributes' do
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/download_attributes"
 

--- a/spec/responses/api/v3/map_layers_spec.rb
+++ b/spec/responses/api/v3/map_layers_spec.rb
@@ -1,23 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'Map layers', type: :request do
-  before do
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
   include_context 'api v3 brazil contextual layers'
   include_context 'api v3 brazil map attributes'
 
-  describe 'GET /api/v3/contexts/:context_id/map_layers' do
-    before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::MapAttribute.refresh
-    end
+  before(:each) do
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::MapAttribute.refresh(sync: true, skip_dependencies: true)
+  end
 
+  describe 'GET /api/v3/contexts/:context_id/map_layers' do
     it 'requires start_year' do
       get "/api/v3/contexts/#{api_v3_context.id}/map_layers"
 

--- a/spec/responses/api/v3/nodes_attributes_spec.rb
+++ b/spec/responses/api/v3/nodes_attributes_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe 'Nodes attributes', type: :request do
   include_context 'api v3 brazil municipality quant values'
   include_context 'api v3 brazil municipality ind values'
 
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::MapAttribute.refresh(sync: true, skip_dependencies: true)
+  end
+
   describe 'GET /api/v3/contexts/:context_id/nodes/attributes' do
     it 'requires a start_year' do
       get "/api/v3/contexts/#{api_v3_context.id}/nodes/attributes"

--- a/spec/responses/api/v3/nodes_search_spec.rb
+++ b/spec/responses/api/v3/nodes_search_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Search', type: :request do
 
   describe 'GET /api/v3/nodes/search' do
     before(:each) do
-      Api::V3::Readonly::Node.refresh
+      Api::V3::Readonly::Node.refresh(sync: true)
     end
 
     it 'has the correct response structure' do

--- a/spec/services/api/v3/database_validation/checks/active_record_check_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/active_record_check_spec.rb
@@ -3,13 +3,6 @@ require 'services/api/v3/database_validation/checks/shared_check_examples'
 
 RSpec.describe Api::V3::DatabaseValidation::Checks::ActiveRecordCheck do
   context 'when checking recolor_by attributes' do
-    before do
-      Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    end
-    after do
-      Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
-    end
-
     let(:context) { FactoryBot.create(:api_v3_context) }
     let(:ind) { FactoryBot.create(:api_v3_ind) }
     let(:recolor_by_attribute) {

--- a/spec/services/api/v3/database_validation/checks/declared_years_match_data_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/declared_years_match_data_spec.rb
@@ -3,13 +3,6 @@ require 'services/api/v3/database_validation/checks/shared_check_examples'
 
 RSpec.describe Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchData do
   context 'when checking resize_by_attributes' do
-    before do
-      Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    end
-    after do
-      Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
-    end
-
     let(:context) { FactoryBot.create(:api_v3_context) }
     let(:quant) { FactoryBot.create(:api_v3_quant) }
     let(:resize_by_attribute) {

--- a/spec/services/api/v3/database_validation/checks/has_at_least_one_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/has_at_least_one_spec.rb
@@ -10,13 +10,6 @@ RSpec.describe Api::V3::DatabaseValidation::Checks::HasAtLeastOne do
   }
 
   context 'when checking context resize_by_attributes' do
-    before do
-      Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    end
-    after do
-      Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
-    end
-
     let(:check) {
       Api::V3::DatabaseValidation::Checks::HasAtLeastOne.new(
         context,

--- a/spec/services/api/v3/database_validation/checks/has_exactly_one_of_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/has_exactly_one_of_spec.rb
@@ -3,15 +3,6 @@ require 'services/api/v3/database_validation/checks/shared_check_examples'
 
 RSpec.describe Api::V3::DatabaseValidation::Checks::HasExactlyOneOf do
   context 'when checking map attributes' do
-    before do
-      Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-      Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    end
-    after do
-      Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-      Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
-    end
-
     let(:map_attribute) {
       FactoryBot.create(:api_v3_map_attribute)
     }

--- a/spec/services/api/v3/database_validation/report_spec.rb
+++ b/spec/services/api/v3/database_validation/report_spec.rb
@@ -1,19 +1,4 @@
 RSpec.describe Api::V3::DatabaseValidation::Report do
-  before do
-    Api::V3::DownloadAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttributeGroup.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::RecolorByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-    Api::V3::ResizeByAttribute.skip_callback(:commit, :after, :refresh_dependents)
-  end
-  after do
-    Api::V3::DownloadAttribute.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttributeGroup.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::MapAttribute.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::RecolorByAttribute.set_callback(:commit, :after, :refresh_dependents)
-    Api::V3::ResizeByAttribute.set_callback(:commit, :after, :refresh_dependents)
-  end
-
   let(:report) {
     Api::V3::DatabaseValidation::Report.new
   }

--- a/spec/services/api/v3/download/flow_download_query_builder_spec.rb
+++ b/spec/services/api/v3/download/flow_download_query_builder_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::Download::FlowDownloadQueryBuilder, type: :model do
-  before(:all) { Api::V3::Flow.delete_all } # TODO: one day db cleaning will work
   include_context 'api v3 brazil two flows'
   describe :query do
     before(:each) do
-      Api::V3::Readonly::DownloadFlow.refresh
+      Api::V3::Readonly::DownloadFlow.refresh(sync: true)
     end
 
     let(:flow1_potential_deforestation_row) {

--- a/spec/services/api/v3/is_mview_populated_spec.rb
+++ b/spec/services/api/v3/is_mview_populated_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V3::IsMviewPopulated do
 
     it 'should return true when populated' do
       FactoryBot.create(:api_v3_node)
-      Api::V3::Readonly::Node.refresh
+      Api::V3::Readonly::Node.refresh(sync: true)
       expect(subject.call).to be true
     end
   end

--- a/spec/services/api/v3/map_layers/map_attribute_filter_spec.rb
+++ b/spec/services/api/v3/map_layers/map_attribute_filter_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::MapLayers::MapAttributeFilter do
   include_context 'api v3 brazil map attributes'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::MapAttribute.refresh(sync: true, skip_dependencies: true)
+  end
+
   context 'when single year' do
     it 'returns dual layer buckets as is' do
       filter = Api::V3::MapLayers::MapAttributeFilter.new(

--- a/spec/services/api/v3/node_attributes/filter_spec.rb
+++ b/spec/services/api/v3/node_attributes/filter_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe Api::V3::NodeAttributes::Filter do
   include_context 'api v3 brazil map attributes'
   include_context 'api v3 brazil municipality quant values'
 
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::MapAttribute.refresh(sync: true, skip_dependencies: true)
+  end
+
   let(:node_attributes) {
     filter.result
   }
@@ -38,6 +43,7 @@ RSpec.describe Api::V3::NodeAttributes::Filter do
   context 'when multi year' do
     let!(:api_v3_land_conflicts_map_attribute_multi_year) {
       api_v3_land_conflicts_map_attribute.update_attribute(:years, [2014, 2015])
+      Api::V3::Readonly::MapAttribute.refresh(sync: true, skip_dependencies: true)
       api_v3_land_conflicts_map_attribute
     }
     let!(:api_v3_land_conflicts_value_2014) {

--- a/spec/services/api/v3/nodes_search/filter_spec.rb
+++ b/spec/services/api/v3/nodes_search/filter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::V3::NodesSearch::Filter do
 
   describe :call do
     before(:each) do
-      Api::V3::Readonly::Node.refresh
+      Api::V3::Readonly::Node.refresh(sync: true)
     end
     let(:filter) { Api::V3::NodesSearch::Filter.new }
 


### PR DESCRIPTION
- removes indexes from `dashboards_flow_attributes_mv` and `dashboards_node_attributes_mv`; the indexes we had there did not help when querying and they did affect the refresh time
- simplifies the definitions of those views for easier joins
- disables the refreshing callbacks in specs; this slowed down the specs. What needs to be done for specs which operate on mviews is an explicit call to refresh once all test objects instantiated
- some style fixes