### PR TITLE
Remove COUNTRY OF PRODUCTION from the source tabs

### DIFF
--- a/app/services/api/v3/dashboards/filter_meta.rb
+++ b/app/services/api/v3/dashboards/filter_meta.rb
@@ -18,6 +18,8 @@ module Api
                 section: 'SOURCES',
                 tabs: @query.where(
                   'context_node_type_properties.column_group' => 0
+                ).where(
+                  'node_types.name <> ?', NodeTypeName::COUNTRY_OF_PRODUCTION
                 ).all
               },
               {


### PR DESCRIPTION
For contexts with national data country of origin comes from the context and this is not needed.

https://www.pivotaltracker.com/n/projects/1637931/stories/161288825