### PR TITLE
Avoid displaying legends with one element

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget-legend.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget-legend.component.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 function DashboardWidgetLegend(props) {
   const { colors } = props;
+  if (colors.length < 2) return null;
   return (
     <div className="c-dashboard-widget-legend">
       <div className="row -equal-height">

--- a/frontend/styles/components/dashboard-element/dashboard-widget-legend.scss
+++ b/frontend/styles/components/dashboard-element/dashboard-widget-legend.scss
@@ -1,4 +1,5 @@
 .c-dashboard-widget-legend {
+  border-bottom: solid 1px rgba($white, 0.13);
   padding: 31px 42px;
 }
 

--- a/frontend/styles/components/dashboard-element/dashboard-widget.scss
+++ b/frontend/styles/components/dashboard-element/dashboard-widget.scss
@@ -71,7 +71,6 @@
     }
 
     .widget-chart {
-      border-top: solid 1px rgba($white, 0.13);
       flex: 1;
       padding: 25px 42px;
     }


### PR DESCRIPTION
This PR avoids displaying the top legend when there's only information about one element on the chart.
https://www.pivotaltracker.com/story/show/161445644

![image](https://user-images.githubusercontent.com/6906348/47493346-5a12d600-d84f-11e8-95c9-0526838f9bec.png)
