### PR TITLE
fix info window

### DIFF
--- a/frontend/scripts/react-components/shared/grid-list-item.component.jsx
+++ b/frontend/scripts/react-components/shared/grid-list-item.component.jsx
@@ -48,6 +48,7 @@ function GridListItem(props) {
                   trigger="click"
                   show={isInfoActive}
                   position="bottom-start"
+                  insideTooltip
                 >
                   <button type="button" disabled={isDisabled} onClick={() => onInfoClick(item)}>
                     i

--- a/frontend/scripts/react-components/shared/help-tooltip.component.jsx
+++ b/frontend/scripts/react-components/shared/help-tooltip.component.jsx
@@ -26,14 +26,14 @@ export default class TooltipComponent extends Component {
   }
 
   initTooltip() {
-    const { position, text, show } = this.props;
+    const { position, text, show, insideTooltip } = this.props;
 
     this.tooltip = new Tooltip(this.element, {
       trigger: typeof show !== 'undefined' ? '' : 'hover focus',
       title: text,
       placement: position,
       container: 'body',
-      boundariesElement: 'window',
+      boundariesElement: insideTooltip ? 'scrollParent' : 'window',
       offset: '1, 1'
     });
 
@@ -83,11 +83,13 @@ TooltipComponent.propTypes = {
   text: PropTypes.string,
   children: PropTypes.any,
   showIcon: PropTypes.bool,
+  insideTooltip: PropTypes.bool,
   position: PropTypes.string,
   className: PropTypes.string
 };
 
 TooltipComponent.defaultProps = {
   position: 'bottom',
-  showIcon: true
+  showIcon: true,
+  insideTooltip: false
 };


### PR DESCRIPTION
This PR forces info window to render inside the modal when creating a dashboard.
https://www.pivotaltracker.com/story/show/161410221

![kapture 2018-10-25 at 16 43 26](https://user-images.githubusercontent.com/6906348/47508834-2185f300-d875-11e8-954e-79c469c8939c.gif)
