### PR TITLE
Fix: refactor dashboard panel reducer

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
@@ -107,12 +107,12 @@ export const setDashboardActivePanel = activePanelId => ({
   payload: { activePanelId }
 });
 
-export const setDashboardPanelActiveItem = ({ activeItem, panel }) => ({
+export const setDashboardPanelActiveItem = (activeItem, panel) => ({
   type: DASHBOARD_ELEMENT__SET_ACTIVE_ITEM,
   payload: { panel, activeItem }
 });
 
-export const setDashboardPanelActiveTab = ({ activeTab, panel }) => ({
+export const setDashboardPanelActiveTab = (activeTab, panel) => ({
   type: DASHBOARD_ELEMENT__SET_ACTIVE_TAB,
   payload: { panel, activeTab }
 });

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
@@ -9,7 +9,8 @@ import {
 export const DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA = 'DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA';
 export const DASHBOARD_ELEMENT__SET_PANEL_DATA = 'DASHBOARD_ELEMENT__SET_PANEL_DATA';
 export const DASHBOARD_ELEMENT__SET_ACTIVE_PANEL = 'DASHBOARD_ELEMENT__SET_ACTIVE_PANEL';
-export const DASHBOARD_ELEMENT__SET_ACTIVE_ID = 'DASHBOARD_ELEMENT__SET_ACTIVE_ID';
+export const DASHBOARD_ELEMENT__SET_ACTIVE_ITEM = 'DASHBOARD_ELEMENT__SET_ACTIVE_ITEM';
+export const DASHBOARD_ELEMENT__SET_ACTIVE_TAB = 'DASHBOARD_ELEMENT__SET_ACTIVE_TAB';
 export const DASHBOARD_ELEMENT__CLEAR_PANEL = 'DASHBOARD_ELEMENT__CLEAR_PANEL';
 export const DASHBOARD_ELEMENT__ADD_ACTIVE_INDICATOR = 'DASHBOARD_ELEMENT__ADD_ACTIVE_INDICATOR';
 export const DASHBOARD_ELEMENT__REMOVE_ACTIVE_INDICATOR =
@@ -100,14 +101,14 @@ export const setDashboardActivePanel = activePanelId => ({
   payload: { activePanelId }
 });
 
-export const setDashboardPanelActiveId = ({ type, active, panel, section }) => ({
-  type: DASHBOARD_ELEMENT__SET_ACTIVE_ID,
-  payload: {
-    type,
-    panel,
-    active,
-    section
-  }
+export const setDashboardPanelActiveItem = ({ activeItem, panel }) => ({
+  type: DASHBOARD_ELEMENT__SET_ACTIVE_ITEM,
+  payload: { panel, activeItem }
+});
+
+export const setDashboardPanelActiveTab = ({ activeTab, panel }) => ({
+  type: DASHBOARD_ELEMENT__SET_ACTIVE_TAB,
+  payload: { panel, activeTab }
 });
 
 export const clearDashboardPanel = panel => ({
@@ -176,7 +177,10 @@ export const getDashboardPanelSearchResults = query => (dispatch, getState) => {
   ) {
     optionsType = 'countries';
   }
-  const filters = getDashboardPanelParams(dashboardElement, optionsType);
+  const filters = {
+    ...getDashboardPanelParams(dashboardElement, optionsType),
+    node_types_ids: undefined
+  };
   const params = { ...filters, q: query };
   const url = getURLFromParams(GET_DASHBOARD_SEARCH_RESULTS_URL, params);
 

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
@@ -21,33 +21,39 @@ export const DASHBOARD_ELEMENT__SET_LOADING_ITEMS = 'DASHBOARD_ELEMENT__SET_LOAD
 export const DASHBOARD_ELEMENT__SET_SEARCH_RESULTS = 'DASHBOARD_ELEMENT__SET_SEARCH_RESULTS';
 
 const getDashboardPanelParams = (state, options_type, options = {}) => {
-  const { sourcesPanel, companiesPanel, destinationsPanel, commoditiesPanel } = state;
+  const {
+    countriesPanel,
+    sourcesPanel,
+    companiesPanel,
+    destinationsPanel,
+    commoditiesPanel
+  } = state;
   const { page, refetchPanel } = options;
   const node_types_ids = {
-    sources: sourcesPanel.activeSourceTabId,
-    companies: companiesPanel.activeNodeTypeTabId
+    sources: sourcesPanel.activeTab,
+    companies: companiesPanel.activeTab
   }[options_type];
   const params = {
     page,
     options_type,
     node_types_ids,
-    countries_ids: sourcesPanel.activeCountryItemId
+    countries_ids: countriesPanel.activeItem
   };
 
   if (options_type !== 'sources' || refetchPanel) {
-    params.sources_ids = sourcesPanel.activeSourceItemId;
+    params.sources_ids = sourcesPanel.activeItem;
   }
 
   if (options_type !== 'commodities' || refetchPanel) {
-    params.commodities_ids = commoditiesPanel.activeCommodityItemId;
+    params.commodities_ids = commoditiesPanel.activeItem;
   }
 
   if (options_type !== 'destinations' || refetchPanel) {
-    params.destinations_ids = destinationsPanel.activeDestinationItemId;
+    params.destinations_ids = destinationsPanel.activeItem;
   }
 
   if (options_type !== 'companies' || refetchPanel) {
-    params.companies_ids = companiesPanel.activeCompanyItemId;
+    params.companies_ids = companiesPanel.activeItem;
   }
   return params;
 };
@@ -172,8 +178,8 @@ export const getDashboardPanelSearchResults = query => (dispatch, getState) => {
   let optionsType = dashboardElement.activePanelId;
   if (
     optionsType === 'sources' &&
-    dashboardElement.sourcesPanel.activeCountryItemId === null &&
-    dashboardElement.sourcesPanel.activeSourceTabId === null
+    dashboardElement.sourcesPanel.activeItem === null &&
+    dashboardElement.sourcesPanel.activeTab === null
   ) {
     optionsType = 'countries';
   }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -196,7 +196,11 @@ const dashboardElementReducer = {
   },
   [DASHBOARD_ELEMENT__SET_SEARCH_RESULTS](state, action) {
     const { data } = action.payload;
-    const panelName = `${state.activePanelId}Panel`;
+    let panel = state.activePanelId;
+    if (state.activePanelId === 'sources' && state.countriesPanel.activeItem === null) {
+      panel = 'countries';
+    }
+    const panelName = `${panel}Panel`;
     return {
       ...state,
       [panelName]: {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -29,33 +29,33 @@ const initialState = {
   activePanelId: null,
   activeIndicatorsList: [],
   countriesPanel: {
-    page: 0,
+    page: 1,
     searchResults: [],
     loadingItems: false,
     activeItem: null
   },
   sourcesPanel: {
-    page: 0,
+    page: 1,
     searchResults: [],
     loadingItems: false,
     activeItem: null,
     activeTab: null
   },
   destinationsPanel: {
-    page: 0,
+    page: 1,
     searchResults: [],
     loadingItems: false,
     activeItem: null
   },
   companiesPanel: {
-    page: 0,
+    page: 1,
     searchResults: [],
     loadingItems: false,
     activeItem: null,
     activeTab: null
   },
   commoditiesPanel: {
-    page: 0,
+    page: 1,
     searchResults: [],
     loadingItems: false,
     activeItem: null
@@ -70,10 +70,12 @@ const dashboardElementReducer = {
     return {
       ...state,
       activePanelId,
-      [prevPanelName]: {
-        ...state[prevPanelName],
-        page: 0
-      }
+      [prevPanelName]: prevActivePanelId
+        ? {
+            ...state[prevPanelName],
+            page: initialState[prevPanelName].page
+          }
+        : undefined
     };
   },
   [DASHBOARD_ELEMENT__SET_PANEL_PAGE](state, action) {
@@ -84,7 +86,6 @@ const dashboardElementReducer = {
   },
   [DASHBOARD_ELEMENT__SET_PANEL_DATA](state, action) {
     const { key, data, meta, tab, loading } = action.payload;
-    const metaFallback = meta && meta.contextNodeTypes ? meta.contextNodeTypes : meta; // FIXME
     const initialData = initialState.data[key];
     let newData;
     if (Array.isArray(initialData)) {
@@ -96,7 +97,7 @@ const dashboardElementReducer = {
       ...state,
       loading,
       data: { ...state.data, [key]: newData },
-      meta: { ...state.meta, [key]: metaFallback }
+      meta: { ...state.meta, [key]: meta }
     };
   },
   [DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA](state, action) {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -1,5 +1,4 @@
 import createReducer from 'utils/createReducer';
-import { getActiveTab } from 'react-components/dashboard-element/dashboard-element.selectors';
 import {
   DASHBOARD_ELEMENT__SET_PANEL_DATA,
   DASHBOARD_ELEMENT__SET_ACTIVE_TAB,
@@ -131,15 +130,22 @@ const dashboardElementReducer = {
     const { data } = action.payload;
     const getSection = n => n.section && n.section.toLowerCase();
     const tabs = data.reduce((acc, next) => ({ ...acc, [getSection(next)]: next.tabs }), {});
+    const panelName = `${state.activePanelId}Panel`;
+    const activeTab =
+      tabs[state.activePanelId] && tabs[state.activePanelId][0] && tabs[state.activePanelId][0].id;
     return {
       ...state,
-      tabs
+      tabs,
+      [panelName]: {
+        ...state[panelName],
+        activeTab
+      }
     };
   },
   [DASHBOARD_ELEMENT__SET_ACTIVE_ITEM](state, action) {
     const { panel, activeItem } = action.payload;
     const panelName = `${panel}Panel`;
-    const page = panel === 'country' ? 0 : state[panelName].page;
+    const page = panel === 'countries' ? 0 : state[panelName].page;
     return {
       ...state,
       activeIndicatorsList: [],
@@ -165,11 +171,13 @@ const dashboardElementReducer = {
   [DASHBOARD_ELEMENT__CLEAR_PANEL](state, action) {
     const { panel } = action.payload;
     const panelName = `${panel}Panel`;
-    const { activeTab, activeTabName } = getActiveTab(state);
+    const { activeTab } = state[panelName];
+    const countriesState = panel === 'sources' ? initialState.countriesPanel : state.countriesPanel;
 
     return {
       ...state,
-      [panelName]: { ...initialState[panelName], [activeTabName]: activeTab }
+      [panelName]: { ...initialState[panelName], activeTab },
+      countriesPanel: countriesState
     };
   },
   [DASHBOARD_ELEMENT__ADD_ACTIVE_INDICATOR](state, action) {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -207,45 +207,33 @@ const dashboardElementReducer = {
   }
 };
 
-const dashboardElementReducerTypes = PropTypes => ({
-  meta: PropTypes.object.isRequired,
-  tabs: PropTypes.object.isRequired,
-  activePanelId: PropTypes.string,
-  activeIndicatorsList: PropTypes.array.isRequired,
-  data: PropTypes.shape({
-    indicators: PropTypes.array.isRequired,
-    countries: PropTypes.array.isRequired,
-    companies: PropTypes.object.isRequired,
-    sources: PropTypes.object.isRequired,
-    destinations: PropTypes.array.isRequired
-  }).isRequired,
-  sourcesPanel: PropTypes.shape({
+const dashboardElementReducerTypes = PropTypes => {
+  const PanelTypes = {
     page: PropTypes.number,
     searchResults: PropTypes.array,
     loadingItems: PropTypes.bool,
-    activeCountryItemId: PropTypes.number,
-    activeSourceItemId: PropTypes.number,
-    activeSourceTabId: PropTypes.number
-  }).isRequired,
-  destinationsPanel: PropTypes.shape({
-    page: PropTypes.number,
-    searchResults: PropTypes.array,
-    loadingItems: PropTypes.bool,
-    activeDestinationItemId: PropTypes.number
-  }).isRequired,
-  companiesPanel: PropTypes.shape({
-    page: PropTypes.number,
-    searchResults: PropTypes.array,
-    loadingItems: PropTypes.bool,
-    activeCompanyItemId: PropTypes.number,
-    activeNodeTypeTabId: PropTypes.number
-  }).isRequired,
-  commoditiesPanel: PropTypes.shape({
-    page: PropTypes.number,
-    searchResults: PropTypes.array,
-    loadingItems: PropTypes.bool,
-    activeCommodityItemId: PropTypes.number
-  }).isRequired
-});
+    activeItem: PropTypes.number,
+    activeTab: PropTypes.number
+  };
+
+  return {
+    meta: PropTypes.object.isRequired,
+    tabs: PropTypes.object.isRequired,
+    activePanelId: PropTypes.string,
+    activeIndicatorsList: PropTypes.array.isRequired,
+    data: PropTypes.shape({
+      indicators: PropTypes.array.isRequired,
+      countries: PropTypes.array.isRequired,
+      companies: PropTypes.object.isRequired,
+      sources: PropTypes.object.isRequired,
+      destinations: PropTypes.array.isRequired
+    }).isRequired,
+    countriesPanel: PropTypes.shape(PanelTypes).isRequired,
+    sourcesPanel: PropTypes.shape(PanelTypes).isRequired,
+    destinationsPanel: PropTypes.shape(PanelTypes).isRequired,
+    companiesPanel: PropTypes.shape(PanelTypes).isRequired,
+    commoditiesPanel: PropTypes.shape(PanelTypes).isRequired
+  };
+};
 
 export default createReducer(initialState, dashboardElementReducer, dashboardElementReducerTypes);

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -1,9 +1,9 @@
-import camelCase from 'lodash/camelCase';
 import createReducer from 'utils/createReducer';
 import { getActiveTab } from 'react-components/dashboard-element/dashboard-element.selectors';
 import {
   DASHBOARD_ELEMENT__SET_PANEL_DATA,
-  DASHBOARD_ELEMENT__SET_ACTIVE_ID,
+  DASHBOARD_ELEMENT__SET_ACTIVE_TAB,
+  DASHBOARD_ELEMENT__SET_ACTIVE_ITEM,
   DASHBOARD_ELEMENT__CLEAR_PANEL,
   DASHBOARD_ELEMENT__ADD_ACTIVE_INDICATOR,
   DASHBOARD_ELEMENT__REMOVE_ACTIVE_INDICATOR,
@@ -29,32 +29,37 @@ const initialState = {
   tabs: {},
   activePanelId: null,
   activeIndicatorsList: [],
+  countriesPanel: {
+    page: 0,
+    searchResults: [],
+    loadingItems: false,
+    activeItem: null
+  },
   sourcesPanel: {
     page: 0,
     searchResults: [],
     loadingItems: false,
-    activeCountryItemId: null,
-    activeSourceItemId: null,
-    activeSourceTabId: null
+    activeItem: null,
+    activeTab: null
   },
   destinationsPanel: {
     page: 0,
     searchResults: [],
     loadingItems: false,
-    activeDestinationItemId: null
+    activeItem: null
   },
   companiesPanel: {
     page: 0,
     searchResults: [],
     loadingItems: false,
-    activeCompanyItemId: null,
-    activeNodeTypeTabId: null
+    activeItem: null,
+    activeTab: null
   },
   commoditiesPanel: {
     page: 0,
     searchResults: [],
     loadingItems: false,
-    activeCommodityItemId: null
+    activeItem: null
   }
 };
 
@@ -131,17 +136,29 @@ const dashboardElementReducer = {
       tabs
     };
   },
-  [DASHBOARD_ELEMENT__SET_ACTIVE_ID](state, action) {
-    const { panel, section, active, type } = action.payload;
+  [DASHBOARD_ELEMENT__SET_ACTIVE_ITEM](state, action) {
+    const { panel, activeItem } = action.payload;
     const panelName = `${panel}Panel`;
-    const page = type === 'tab' || section === 'country' ? 0 : state[panelName].page;
+    const page = panel === 'country' ? 0 : state[panelName].page;
     return {
       ...state,
       activeIndicatorsList: [],
       [panelName]: {
         ...state[panelName],
         page,
-        [camelCase(`active_${section}_${type}_id`)]: active
+        activeItem
+      }
+    };
+  },
+  [DASHBOARD_ELEMENT__SET_ACTIVE_TAB](state, action) {
+    const { panel, activeTab } = action.payload;
+    const panelName = `${panel}Panel`;
+    return {
+      ...state,
+      activeIndicatorsList: [],
+      [panelName]: {
+        ...state[panelName],
+        activeTab
       }
     };
   },

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -2,17 +2,15 @@ import { select, put, all, fork, takeLatest } from 'redux-saga/effects';
 import {
   DASHBOARD_ELEMENT__CLEAR_PANEL,
   DASHBOARD_ELEMENT__SET_ACTIVE_PANEL,
-  DASHBOARD_ELEMENT__SET_ACTIVE_ID,
+  DASHBOARD_ELEMENT__SET_ACTIVE_TAB,
+  DASHBOARD_ELEMENT__SET_ACTIVE_ITEM,
   getDashboardPanelData,
   getMoreDashboardPanelData,
   getDashboardPanelSectionTabs,
   DASHBOARD_ELEMENT__SET_PANEL_TABS,
   DASHBOARD_ELEMENT__SET_PANEL_PAGE
 } from 'react-components/dashboard-element/dashboard-element.actions';
-import {
-  getActiveTab,
-  getDirtyBlocks
-} from 'react-components/dashboard-element/dashboard-element.selectors';
+import { getDirtyBlocks } from 'react-components/dashboard-element/dashboard-element.selectors';
 
 function* fetchDataOnPanelChange() {
   function* fetchDashboardPanelInitialData(action) {
@@ -20,49 +18,66 @@ function* fetchDataOnPanelChange() {
     const initialData = activePanelId === 'sources' ? 'countries' : activePanelId;
     const state = yield select();
     const { dashboardElement } = state;
-    const { activeTab } = getActiveTab(dashboardElement);
+    const panelName = `${dashboardElement.activePanelId}Panel`;
+    const { activeTab } = dashboardElement[panelName];
     const refetchPanel = getDirtyBlocks(state)[activePanelId];
 
     if (dashboardElement.activePanelId === 'companies') {
       yield put(getDashboardPanelSectionTabs(dashboardElement.activePanelId));
     }
-
     yield put(getDashboardPanelData(initialData, activeTab, { refetchPanel }));
   }
 
   yield takeLatest(DASHBOARD_ELEMENT__SET_ACTIVE_PANEL, fetchDashboardPanelInitialData);
 }
 
-function* fetchDataOnFilterChange() {
-  function* onFilterChange(action) {
-    const { type, section, active } = action.payload;
+function* fetchDataOnTabChange() {
+  function* onTabChange(action) {
+    const { activeTab, panel } = action.payload;
     const { dashboardElement } = yield select();
-    const { activeTab } = getActiveTab(dashboardElement);
+    const activePanelId = panel || dashboardElement.activePanelId;
+    const activeTabId = activeTab || dashboardElement[`${activePanelId}Panel`].activeTab;
+    yield put(getDashboardPanelData(activePanelId, activeTabId));
+  }
+
+  yield takeLatest(
+    [DASHBOARD_ELEMENT__SET_ACTIVE_TAB, DASHBOARD_ELEMENT__SET_PANEL_TABS],
+    onTabChange
+  );
+}
+
+function* fetchDataOnItemChange() {
+  function* onItemChange(action) {
+    const { activeItem, panel } = action.payload;
+    const { dashboardElement } = yield select();
+    const panelName = `${dashboardElement.activePanelId}Panel`;
+    const { activeTab } = dashboardElement[panelName];
     const data = dashboardElement.data[dashboardElement.activePanelId];
     const items = typeof activeTab !== 'undefined' ? data[activeTab] : data;
-    const activeItemExists = !!items && items.find(i => i.id === active);
+    const activeItemExists = !!items && items.find(i => i.id === activeItem);
 
     // for now, we just need to recalculate the tabs when selecting a new country
-    if (type === 'item' && section === 'country') {
-      yield put(getDashboardPanelSectionTabs(dashboardElement.activePanelId));
+    if (panel === 'countries') {
+      yield put(getDashboardPanelSectionTabs(panel));
     }
 
-    if (type === 'tab' || (items && !activeItemExists)) {
+    if (items && !activeItemExists) {
       yield put(
-        getDashboardPanelData(dashboardElement.activePanelId, activeTab, {
-          refetchPanel: !activeItemExists
+        getDashboardPanelData(panel, activeTab, {
+          refetchPanel: true
         })
       );
     }
   }
 
-  yield takeLatest(DASHBOARD_ELEMENT__SET_ACTIVE_ID, onFilterChange);
+  yield takeLatest(DASHBOARD_ELEMENT__SET_ACTIVE_ITEM, onItemChange);
 }
 
 function* fetchDataOnFilterClear() {
   function* onFilterClear() {
     const { dashboardElement } = yield select();
-    const { activeTab } = getActiveTab(dashboardElement);
+    const panelName = `${dashboardElement.activePanelId}Panel`;
+    const { activeTab } = dashboardElement[panelName];
     yield put(getDashboardPanelData(dashboardElement.activePanelId, activeTab));
 
     if (dashboardElement.activePanelId) {
@@ -78,7 +93,8 @@ function* fetchDataOnPageChange() {
   function* onPageChange(action) {
     const { direction } = action.payload;
     const { dashboardElement } = yield select();
-    const { activeTab } = getActiveTab(dashboardElement);
+    const panelName = `${dashboardElement.activePanelId}Panel`;
+    const { activeTab } = dashboardElement[panelName];
 
     yield put(getMoreDashboardPanelData(dashboardElement.activePanelId, activeTab, direction));
   }
@@ -86,40 +102,11 @@ function* fetchDataOnPageChange() {
   yield takeLatest(DASHBOARD_ELEMENT__SET_PANEL_PAGE, onPageChange);
 }
 
-function* setActiveTabOnDataFetch() {
-  function* setFirstTab(action) {
-    const { data } = action.payload;
-    const { dashboardElement } = yield select();
-    const getTabId = d => {
-      const current = d.find(t => t.section.toLowerCase() === dashboardElement.activePanelId);
-      return current && current.tabs.length > 0 ? current.tabs[0].id : null;
-    };
-    const active = data && getTabId(data);
-    const section = {
-      sources: 'source',
-      companies: 'nodeType'
-    }[dashboardElement.activePanelId];
-    if (active && section) {
-      yield put({
-        type: DASHBOARD_ELEMENT__SET_ACTIVE_ID,
-        payload: {
-          active,
-          section,
-          type: 'tab',
-          panel: dashboardElement.activePanelId
-        }
-      });
-    }
-  }
-
-  yield takeLatest(DASHBOARD_ELEMENT__SET_PANEL_TABS, setFirstTab);
-}
-
 export default function* dashboardElementSaga() {
   const sagas = [
     fetchDataOnPanelChange,
-    setActiveTabOnDataFetch,
-    fetchDataOnFilterChange,
+    fetchDataOnTabChange,
+    fetchDataOnItemChange,
     fetchDataOnFilterClear,
     fetchDataOnPageChange
   ];

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -24,8 +24,10 @@ function* fetchDataOnPanelChange() {
 
     if (dashboardElement.activePanelId === 'companies') {
       yield put(getDashboardPanelSectionTabs(dashboardElement.activePanelId));
+    } else {
+      // avoid dispatching getDashboardPanelData through getDashboardPanelSectionTabs
+      yield put(getDashboardPanelData(initialData, activeTab, { refetchPanel }));
     }
-    yield put(getDashboardPanelData(initialData, activeTab, { refetchPanel }));
   }
 
   yield takeLatest(DASHBOARD_ELEMENT__SET_ACTIVE_PANEL, fetchDashboardPanelInitialData);
@@ -50,9 +52,9 @@ function* fetchDataOnItemChange() {
   function* onItemChange(action) {
     const { activeItem, panel } = action.payload;
     const { dashboardElement } = yield select();
-    const panelName = `${dashboardElement.activePanelId}Panel`;
+    const panelName = `${panel}Panel`;
     const { activeTab } = dashboardElement[panelName];
-    const data = dashboardElement.data[dashboardElement.activePanelId];
+    const data = dashboardElement.data[panel];
     const items = typeof activeTab !== 'undefined' ? data[activeTab] : data;
     const activeItemExists = !!items && items.find(i => i.id === activeItem);
 
@@ -61,7 +63,7 @@ function* fetchDataOnItemChange() {
       yield put(getDashboardPanelSectionTabs(panel));
     }
 
-    if (items && !activeItemExists) {
+    if (items && !activeItemExists && panel !== 'countries') {
       yield put(
         getDashboardPanelData(panel, activeTab, {
           refetchPanel: true
@@ -78,12 +80,12 @@ function* fetchDataOnFilterClear() {
     const { dashboardElement } = yield select();
     const panelName = `${dashboardElement.activePanelId}Panel`;
     const { activeTab } = dashboardElement[panelName];
-    yield put(getDashboardPanelData(dashboardElement.activePanelId, activeTab));
 
-    if (dashboardElement.activePanelId) {
+    if (dashboardElement.activePanelId !== 'sources') {
+      yield put(getDashboardPanelData(dashboardElement.activePanelId, activeTab));
+    } else {
       yield put(getDashboardPanelData('countries'));
     }
-    yield put(getDashboardPanelSectionTabs(dashboardElement.activePanelId));
   }
 
   yield takeLatest(DASHBOARD_ELEMENT__CLEAR_PANEL, onFilterClear);
@@ -95,7 +97,6 @@ function* fetchDataOnPageChange() {
     const { dashboardElement } = yield select();
     const panelName = `${dashboardElement.activePanelId}Panel`;
     const { activeTab } = dashboardElement[panelName];
-
     yield put(getMoreDashboardPanelData(dashboardElement.activePanelId, activeTab, direction));
   }
 

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -76,7 +76,11 @@ class DashboardPanel extends Component {
               activeCountryItemId={countriesPanel.activeItem}
               activeSourceTabId={sourcesPanel.activeTab}
               activeSourceItemId={sourcesPanel.activeItem}
-              searchSources={sourcesPanel.searchResults}
+              searchSources={
+                !countriesPanel.activeItem
+                  ? countriesPanel.searchResults
+                  : sourcesPanel.searchResults
+              }
               tabs={tabs}
               sources={sources[sourcesPanel.activeTab]}
               countries={countries}

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -34,11 +34,12 @@ class DashboardPanel extends Component {
       dirtyBlocks,
       activePanelId,
       setActivePanel,
+      countriesPanel,
       sourcesPanel,
       getSearchResults,
       destinationsPanel,
       companiesPanel,
-      clearActiveId,
+      clearActiveItem,
       setActiveTab,
       setActiveItem,
       sources,
@@ -71,32 +72,17 @@ class DashboardPanel extends Component {
               getSearchResults={getSearchResults}
               loadingMoreItems={sourcesPanel.loadingItems}
               loading={loading}
-              clearItems={() => clearActiveId(activePanelId)}
-              activeCountryItemId={sourcesPanel.activeCountryItemId}
-              activeSourceTabId={sourcesPanel.activeSourceTabId}
-              activeSourceItemId={sourcesPanel.activeSourceItemId}
+              clearItems={() => clearActiveItem(activePanelId)}
+              activeCountryItemId={countriesPanel.activeItem}
+              activeSourceTabId={sourcesPanel.activeTab}
+              activeSourceItemId={sourcesPanel.activeItem}
               searchSources={sourcesPanel.searchResults}
               tabs={tabs}
-              sources={sources[sourcesPanel.activeSourceTabId]}
+              sources={sources[sourcesPanel.activeTab]}
               countries={countries}
-              onSelectCountry={item =>
-                setActiveItem({
-                  active: item && item.id,
-                  panel: 'countries'
-                })
-              }
-              onSelectSourceTab={item =>
-                setActiveTab({
-                  active: item && item.id,
-                  panel: activePanelId
-                })
-              }
-              onSelectSourceValue={item =>
-                setActiveItem({
-                  active: item && item.id,
-                  panel: activePanelId
-                })
-              }
+              onSelectCountry={item => setActiveItem(item && item.id, 'countries')}
+              onSelectSourceTab={item => setActiveTab(item && item.id, activePanelId)}
+              onSelectSourceValue={item => setActiveItem(item && item.id, activePanelId)}
             />
           )}
           {activePanelId === 'destinations' && (
@@ -106,15 +92,10 @@ class DashboardPanel extends Component {
               getSearchResults={getSearchResults}
               searchDestinations={destinationsPanel.searchResults}
               destinations={destinations}
-              onSelectDestinationValue={item =>
-                setActiveItem({
-                  active: item && item.id,
-                  panel: activePanelId
-                })
-              }
+              onSelectDestinationValue={item => setActiveItem(item && item.id, activePanelId)}
               loadingMoreItems={destinationsPanel.loadingItems}
               loading={loading}
-              activeDestinationId={destinationsPanel.activeDestinationItemId}
+              activeDestinationId={destinationsPanel.activeItem}
             />
           )}
           {activePanelId === 'companies' && (
@@ -126,21 +107,11 @@ class DashboardPanel extends Component {
               getSearchResults={getSearchResults}
               loadingMoreItems={companiesPanel.loadingItems}
               loading={loading}
-              companies={companies[companiesPanel.activeNodeTypeTabId]}
-              onSelectNodeTypeTab={item =>
-                setActiveTab({
-                  active: item && item.id,
-                  panel: activePanelId
-                })
-              }
-              onSelectCompany={item =>
-                setActiveItem({
-                  active: item && item.id,
-                  panel: activePanelId
-                })
-              }
-              activeNodeTypeTabId={companiesPanel.activeNodeTypeTabId}
-              activeCompanyId={companiesPanel.activeCompanyItemId}
+              companies={companies[companiesPanel.activeTab]}
+              onSelectNodeTypeTab={item => setActiveTab(item && item.id, activePanelId)}
+              onSelectCompany={item => setActiveItem(item && item.id, activePanelId)}
+              activeNodeTypeTabId={companiesPanel.activeTab}
+              activeCompanyId={companiesPanel.activeItem}
             />
           )}
           {activePanelId === 'commodities' && (
@@ -152,13 +123,8 @@ class DashboardPanel extends Component {
               loadingMoreItems={commoditiesPanel.loadingItems}
               loading={loading}
               commodities={commodities}
-              onSelectCommodity={item =>
-                setActiveItem({
-                  active: item && item.id,
-                  panel: activePanelId
-                })
-              }
-              activeCommodityId={commoditiesPanel.activeCommodityItemId}
+              onSelectCommodity={item => setActiveItem(item && item.id, activePanelId)}
+              activeCommodityId={commoditiesPanel.activeItem}
             />
           )}
         </div>
@@ -167,7 +133,7 @@ class DashboardPanel extends Component {
             editMode={editMode}
             isPanelFooter
             onContinue={onContinue}
-            clearItem={clearActiveId}
+            clearItem={clearActiveItem}
             dynamicSentenceParts={dynamicSentenceParts}
           />
         )}
@@ -195,11 +161,12 @@ DashboardPanel.propTypes = {
   dynamicSentenceParts: PropTypes.array,
   setActiveTab: PropTypes.func.isRequired,
   setActiveItem: PropTypes.func.isRequired,
-  clearActiveId: PropTypes.func.isRequired,
+  clearActiveItem: PropTypes.func.isRequired,
   setActivePanel: PropTypes.func.isRequired,
   sourcesPanel: PropTypes.object.isRequired,
   destinationsPanel: PropTypes.object.isRequired,
-  companiesPanel: PropTypes.object.isRequired
+  companiesPanel: PropTypes.object.isRequired,
+  countriesPanel: PropTypes.object.isRequired
 };
 
 export default DashboardPanel;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -39,7 +39,8 @@ class DashboardPanel extends Component {
       destinationsPanel,
       companiesPanel,
       clearActiveId,
-      setActiveId,
+      setActiveTab,
+      setActiveItem,
       sources,
       destinations,
       countries,
@@ -79,26 +80,20 @@ class DashboardPanel extends Component {
               sources={sources[sourcesPanel.activeSourceTabId]}
               countries={countries}
               onSelectCountry={item =>
-                setActiveId({
-                  type: 'item',
+                setActiveItem({
                   active: item && item.id,
-                  section: 'country',
-                  panel: activePanelId
+                  panel: 'countries'
                 })
               }
               onSelectSourceTab={item =>
-                setActiveId({
-                  type: 'tab',
-                  active: item.id,
-                  section: 'source',
+                setActiveTab({
+                  active: item && item.id,
                   panel: activePanelId
                 })
               }
               onSelectSourceValue={item =>
-                setActiveId({
-                  type: 'item',
+                setActiveItem({
                   active: item && item.id,
-                  section: 'source',
                   panel: activePanelId
                 })
               }
@@ -112,10 +107,8 @@ class DashboardPanel extends Component {
               searchDestinations={destinationsPanel.searchResults}
               destinations={destinations}
               onSelectDestinationValue={item =>
-                setActiveId({
+                setActiveItem({
                   active: item && item.id,
-                  type: 'item',
-                  section: 'destination',
                   panel: activePanelId
                 })
               }
@@ -135,18 +128,14 @@ class DashboardPanel extends Component {
               loading={loading}
               companies={companies[companiesPanel.activeNodeTypeTabId]}
               onSelectNodeTypeTab={item =>
-                setActiveId({
-                  type: 'tab',
+                setActiveTab({
                   active: item && item.id,
-                  section: 'nodeType',
                   panel: activePanelId
                 })
               }
               onSelectCompany={item =>
-                setActiveId({
-                  type: 'item',
+                setActiveItem({
                   active: item && item.id,
-                  section: 'company',
                   panel: activePanelId
                 })
               }
@@ -164,10 +153,8 @@ class DashboardPanel extends Component {
               loading={loading}
               commodities={commodities}
               onSelectCommodity={item =>
-                setActiveId({
-                  type: 'item',
+                setActiveItem({
                   active: item && item.id,
-                  section: 'commodity',
                   panel: activePanelId
                 })
               }
@@ -206,7 +193,8 @@ DashboardPanel.propTypes = {
   onContinue: PropTypes.func.isRequired,
   getSearchResults: PropTypes.func.isRequired,
   dynamicSentenceParts: PropTypes.array,
-  setActiveId: PropTypes.func.isRequired,
+  setActiveTab: PropTypes.func.isRequired,
+  setActiveItem: PropTypes.func.isRequired,
   clearActiveId: PropTypes.func.isRequired,
   setActivePanel: PropTypes.func.isRequired,
   sourcesPanel: PropTypes.object.isRequired,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.container.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.container.jsx
@@ -17,13 +17,14 @@ import {
 
 const mapStateToProps = state => {
   const {
+    loading,
     activePanelId,
     sourcesPanel,
     destinationsPanel,
     companiesPanel,
     commoditiesPanel,
-    data: { sources, countries, commodities, companies, destinations },
-    loading
+    countriesPanel,
+    data: { sources, countries, commodities, companies, destinations }
   } = state.dashboardElement;
 
   return {
@@ -35,6 +36,7 @@ const mapStateToProps = state => {
     destinations,
     activePanelId,
     sourcesPanel,
+    countriesPanel,
     destinationsPanel,
     companiesPanel,
     commoditiesPanel,
@@ -46,7 +48,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = {
   getMoreItems: setDashboardPanelPage,
-  clearActiveId: clearDashboardPanel,
+  clearActiveItem: clearDashboardPanel,
   setActivePanel: setDashboardActivePanel,
   setActiveTab: setDashboardPanelActiveTab,
   setActiveItem: setDashboardPanelActiveItem,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.container.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.container.jsx
@@ -4,7 +4,8 @@ import {
   clearDashboardPanel,
   setDashboardPanelPage,
   setDashboardActivePanel,
-  setDashboardPanelActiveId,
+  setDashboardPanelActiveTab,
+  setDashboardPanelActiveItem,
   getDashboardPanelSearchResults
 } from 'react-components/dashboard-element/dashboard-element.actions';
 import DashboardPanel from 'react-components/dashboard-element/dashboard-panel/dashboard-panel.component';
@@ -46,8 +47,9 @@ const mapStateToProps = state => {
 const mapDispatchToProps = {
   getMoreItems: setDashboardPanelPage,
   clearActiveId: clearDashboardPanel,
-  setActiveId: setDashboardPanelActiveId,
   setActivePanel: setDashboardActivePanel,
+  setActiveTab: setDashboardPanelActiveTab,
+  setActiveItem: setDashboardPanelActiveItem,
   getSearchResults: getDashboardPanelSearchResults
 };
 

--- a/frontend/scripts/react-components/shared/grid-list.component.jsx
+++ b/frontend/scripts/react-components/shared/grid-list.component.jsx
@@ -23,7 +23,7 @@ class GridList extends React.Component {
 
   static defaultProps = {
     getMoreItems: () => {},
-    page: 0
+    page: 1
   };
 
   listRef = React.createRef();


### PR DESCRIPTION
This PR refactors the `dashboard-panel.reducer`. I removed the adhoc variable names in favor of calling every item prop as `activeItem` and every tab prop as `activeTab`. Also extracted countries into a new panel, this is actually an abstract panel because there's no UI for it, but makes way more sense data wise.

I refactored some of the actions and components to fit to this new structure and removed a saga that set the first tab as active. Now instead of using a saga, we do this a reducer level. This solution seems more solid.

Finally the big WHY behind this refactor? I'm paving the road for my next PR that will search nodes across all tabs of the same panel and if a node is selected and doesn't belong to that tab, the tab will be changed.

Have fun 🌮 