### PR TITLE
fix bug when landing on a translated page

### DIFF
--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -8,6 +8,7 @@ import {
 import { TOGGLE_MAP, loadToolDataForCurrentContext } from 'scripts/actions/tool.actions';
 import { getContextById } from 'scripts/reducers/helpers/contextHelper';
 import getPageTitle from 'scripts/router/page-title';
+import { redirect } from 'redux-first-router';
 
 export const LOAD_STATE_FROM_URL = 'LOAD_STATE_FROM_URL';
 export const LOAD_INITIAL_CONTEXT = 'LOAD_INITIAL_CONTEXT';
@@ -24,7 +25,6 @@ export const SET_SEARCH_TERM = 'SET_SEARCH_TERM';
 export const LOAD_SEARCH_RESULTS = 'LOAD_SEARCH_RESULTS';
 export const SET_CONTEXTS = 'SET_CONTEXTS';
 export const SET_CONTEXT_IS_USER_SELECTED = 'SET_CONTEXT_IS_USER_SELECTED';
-export const SET_LANGUAGE = 'SET_LANGUAGE';
 
 export function selectInitialContextById(contextId) {
   return (dispatch, getState) => {
@@ -162,12 +162,12 @@ export function resetSearchResults() {
   };
 }
 
-export function setLanguage(languageCode) {
-  return {
-    type: SET_LANGUAGE,
-    payload: languageCode
-  };
-}
+export const setLanguage = lang => (dispatch, getState) => {
+  const { location } = getState();
+  const query = { ...location.query, lang };
+  const payload = { ...location.payload, query };
+  return dispatch(redirect({ type: location.type, payload }));
+};
 
 export function loadSearchResults(searchTerm) {
   return dispatch => {

--- a/frontend/scripts/react-components/nav/locale-selector/locale-selector.container.js
+++ b/frontend/scripts/react-components/nav/locale-selector/locale-selector.container.js
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 import { setLanguage } from 'scripts/actions/app.actions';
 import LocaleSelector from './locale-selector.component';
 
-const mapStateToProps = state => ({ urlLang: state.app.languageCode });
+const mapStateToProps = state => {
+  const { query: { lang } = {} } = state.location;
+  return { urlLang: lang };
+};
 
 const mapDispatchToProps = dispatch => bindActionCreators({ onTranslate: setLanguage }, dispatch);
 

--- a/frontend/scripts/reducers/app.reducer.js
+++ b/frontend/scripts/reducers/app.reducer.js
@@ -12,8 +12,7 @@ import {
   SET_CONTEXT_IS_USER_SELECTED,
   SET_CONTEXT,
   LOAD_INITIAL_CONTEXT,
-  LOAD_STATE_FROM_URL,
-  SET_LANGUAGE
+  LOAD_STATE_FROM_URL
 } from 'actions/app.actions';
 import createReducer from 'utils/createReducer';
 
@@ -36,8 +35,7 @@ const initialState = {
   },
   selectedContext: null,
   initialSelectedContextIdFromURL: null, // IMPORTANT: this should only be used to load context by id from the URL
-  contexts: [],
-  languageCode: undefined
+  contexts: []
 };
 
 const isSankeyExpanded = state => state.isMapLayerVisible !== true && state.isMapVisible !== true;
@@ -62,9 +60,6 @@ const appReducer = {
   },
   [SET_TOOLTIPS](state, action) {
     return Object.assign({}, state, { tooltips: action.payload });
-  },
-  [SET_LANGUAGE](state, action) {
-    return Object.assign({}, state, { languageCode: action.payload });
   },
   [SHOW_DISCLAIMER](state, action) {
     return Object.assign({}, state, {
@@ -124,7 +119,6 @@ const appReducerTypes = PropTypes => ({
   currentDropdown: PropTypes.string,
   isMapLayerVisible: PropTypes.bool,
   isAppMenuVisible: PropTypes.bool,
-  languageCode: PropTypes.string,
   modal: PropTypes.shape({
     visibility: PropTypes.bool,
     modalParams: PropTypes.object

--- a/frontend/scripts/utils/stateURL.js
+++ b/frontend/scripts/utils/stateURL.js
@@ -134,14 +134,10 @@ export const stringify = params => {
 
 const stateToURLObject = (state, location) => {
   if (location.type === 'tool') {
-    return { state: encodeStateToURL(state), lang: state.app.languageCode };
+    return { state: encodeStateToURL(state) };
   }
 
-  if (location.type === 'profileNode') {
-    return { lang: state.app.languageCode, ...location.query };
-  }
-
-  return { lang: state.app.languageCode };
+  return { ...location.query };
 };
 
 export const rehydrateAppStateFromToolURL = (action, next, state) => {


### PR DESCRIPTION
This PR fixes a bug where if you share an url with `lang=es` or any other locale that's not the default, the page would ignore the url locale and load the default one.