### PR TITLE
Fixed chunked pivot issue

### DIFF
--- a/app/services/api/v3/download/flow_download_flat_query.rb
+++ b/app/services/api/v3/download/flow_download_flat_query.rb
@@ -1,0 +1,75 @@
+module Api
+  module V3
+    module Download
+      class FlowDownloadFlatQuery
+        def initialize(context, base_query)
+          @context = context
+          initialize_path_column_names(@context.id)
+          @base_query = base_query
+          initialize_query
+        end
+
+        def all
+          @query
+        end
+
+        def total
+          @base_query.count
+        end
+
+        def years
+          @base_query.distinct.pluck(:year)
+        end
+
+        def by_year(year)
+          all.where(year: year)
+        end
+
+        private
+
+        def initialize_query
+          @query = @base_query.select(flat_select_columns).
+            order(:row_name, :attribute_type, :attribute_id)
+        end
+
+        def flat_select_columns
+          [
+            'year AS "YEAR"'
+          ] + @path_columns +
+            [
+              "'#{commodity_type}'::TEXT AS \"TYPE\"",
+              'display_name AS "INDICATOR"',
+              'total AS "TOTAL"'
+            ]
+        end
+
+        def commodity_type
+          commodity_name = @context.commodity.try(:name)
+          if commodity_name == 'SOY'
+            'Soy bean equivalents'
+          else
+            "#{commodity_name.try(:humanize)} equivalents" ||
+              'UNKNOWN'
+          end
+        end
+
+        def initialize_path_column_names(context_id)
+          context_node_types = Api::V3::ContextNodeType.
+            select([:column_position, 'node_types.name']).
+            where(context_id: context_id).
+            joins(:node_type).
+            order(:column_position)
+          context_column_positions = context_node_types.pluck(:column_position)
+          path_column_names = context_column_positions.map { |p| "name_#{p}" }
+          @path_column_aliases = context_node_types.
+            pluck('node_types.name').
+            map { |nt| "\"#{nt}\"" }
+          @path_columns = path_column_names.each_with_index.map do |n, idx|
+            "#{n} AS #{@path_column_aliases[idx]}"
+          end
+          @path_crosstab_columns = @path_column_aliases.map { |a| "#{a} text" }
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/download/flow_download_pivot_query.rb
+++ b/app/services/api/v3/download/flow_download_pivot_query.rb
@@ -1,0 +1,89 @@
+module Api
+  module V3
+    module Download
+      class FlowDownloadPivotQuery < FlowDownloadFlatQuery
+        def all
+          pivot(@query)
+        end
+
+        def total
+          pivot(@base_query.select(pivot_select_columns)).except(:select).count
+        end
+
+        def by_year(year)
+          pivot(@query.where(year: year))
+        end
+
+        private
+
+        def initialize_query
+          @query = @base_query.select(pivot_select_columns).
+            order(:row_name)
+        end
+
+        def pivot_select_columns
+          [
+            'row_name',
+            'year AS "YEAR"'
+          ] + @path_columns +
+            [
+              "'#{commodity_type}'::TEXT AS \"TYPE\"",
+              'display_name',
+              'total'
+            ]
+        end
+
+        def initialize_categories_names(query)
+          @categories = query.
+            except(:select).
+            select('display_name').
+            except(:group).
+            group(:display_name).
+            except(:order).
+            order(:display_name)
+          @categories_names_quoted = @categories.map do |c|
+            '"' + c['display_name'] + '"'
+          end
+          @categories_names_with_type = @categories_names_quoted.map do |cn|
+            cn + ' text'
+          end
+        end
+
+        def outer_select_columns
+          [
+            '"YEAR"'
+          ] + @path_column_aliases + [
+            '"TYPE"'
+          ] + @categories_names_quoted
+        end
+
+        def crosstab_columns
+          [
+            'row_name INT[]',
+            '"YEAR" int'
+          ] + @path_crosstab_columns + [
+            '"TYPE" text'
+          ] + @categories_names_with_type
+        end
+
+        def pivot(query)
+          initialize_categories_names(query)
+
+          source_sql = query.to_sql.gsub("'", "''")
+          categories_sql = @categories.to_sql.gsub("'", "''")
+
+          crosstab_sql = <<~SQL
+            public.CROSSTAB(
+              '#{source_sql}',
+              '#{categories_sql}'
+            )
+            AS CT(#{crosstab_columns.join(',')})
+          SQL
+
+          Api::V3::Readonly::DownloadFlow.
+            select(outer_select_columns).from(crosstab_sql)
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/download/flow_download_query_builder.rb
+++ b/app/services/api/v3/download/flow_download_query_builder.rb
@@ -23,7 +23,6 @@ module Api
           @query = Api::V3::Readonly::DownloadFlow.where(
             context_id: @context.id
           )
-          initialize_path_column_names(@context.id)
           if (years = params[:years]).present?
             @query = @query.where(year: years)
           end
@@ -37,105 +36,19 @@ module Api
             @query = @query.where(country_node_id: countries_ids)
           end
           return unless (filters = params[:filters]).present?
+
           apply_attribute_filters(filters)
         end
 
         def flat_query
-          @query.select(flat_select_columns).
-            order(:row_name, :attribute_type, :attribute_id)
+          FlowDownloadFlatQuery.new(@context, @query)
         end
 
         def pivot_query
-          source = @query.select(pivot_select_columns).
-            order(:row_name)
-          source_sql = source.to_sql.gsub("'", "''")
-          categories = @query.
-            select('display_name').
-            group(:display_name).
-            order(:display_name)
-          categories_sql = categories.to_sql.gsub("'", "''")
-          categories_names_quoted = categories.map do |c|
-            '"' + c['display_name'] + '"'
-          end
-          categories_names_with_type = categories_names_quoted.map do |cn|
-            cn + ' text'
-          end
-
-          select_columns = [
-            '"YEAR"'
-          ] + @path_column_aliases + [
-            '"TYPE"'
-          ] + categories_names_quoted
-
-          crosstab_columns = [
-            'row_name INT[]',
-            '"YEAR" int'
-          ] + @path_crosstab_columns + [
-            '"TYPE" text'
-          ] + categories_names_with_type
-
-          crosstab_sql = <<~SQL
-            public.CROSSTAB(
-              '#{source_sql}',
-              '#{categories_sql}'
-            )
-            AS CT(#{crosstab_columns.join(',')})
-          SQL
-
-          Api::V3::Readonly::DownloadFlow.
-            select(select_columns).from(crosstab_sql)
+          FlowDownloadPivotQuery.new(@context, @query)
         end
 
         private
-
-        def flat_select_columns
-          [
-            'year AS "YEAR"'
-          ] + @path_columns +
-            [
-              "'#{commodity_type}'::TEXT AS \"TYPE\"",
-              'display_name AS "INDICATOR"',
-              'total AS "TOTAL"'
-            ]
-        end
-
-        def pivot_select_columns
-          [
-            'row_name',
-            'year AS "YEAR"'
-          ] + @path_columns +
-            [
-              "'#{commodity_type}'::TEXT AS \"TYPE\"",
-              'display_name',
-              'total'
-            ]
-        end
-
-        def commodity_type
-          if @context.commodity.try(:name) == 'SOY'
-            'Soy bean equivalents'
-          else
-            "#{@context.commodity.try(:name).try(:humanize)} equivalents" ||
-              'UNKNOWN'
-          end
-        end
-
-        def initialize_path_column_names(context_id)
-          context_node_types = Api::V3::ContextNodeType.
-            select([:column_position, 'node_types.name']).
-            where(context_id: context_id).
-            joins(:node_type).
-            order(:column_position)
-          context_column_positions = context_node_types.pluck(:column_position)
-          path_column_names = context_column_positions.map { |p| "name_#{p}" }
-          @path_column_aliases = context_node_types.
-            pluck('node_types.name').
-            map { |nt| "\"#{nt}\"" }
-          @path_columns = path_column_names.each_with_index.map do |n, idx|
-            "#{n} AS #{@path_column_aliases[idx]}"
-          end
-          @path_crosstab_columns = @path_column_aliases.map { |a| "#{a} text" }
-        end
 
         def apply_attribute_filters(attributes_list)
           query_parts = []
@@ -158,6 +71,7 @@ module Api
 
         def attribute_by_name(name)
           return nil unless name
+
           Dictionary::Quant.instance.get(name) ||
             Dictionary::Qual.instance.get(name)
         end
@@ -181,12 +95,14 @@ module Api
         def qual_op_part(op_symbol)
           op = QUAL_OPS[op_symbol]
           return nil unless op
+
           "LOWER(total) #{op} LOWER(?)"
         end
 
         def quant_op_part(op_symbol)
           op = QUANT_OPS[op_symbol]
           return nil unless op
+
           "sum #{op} ?"
         end
       end

--- a/app/services/api/v3/download/zipped_download.rb
+++ b/app/services/api/v3/download/zipped_download.rb
@@ -75,19 +75,12 @@ module Api
         MAX_SIZE = 500_000
 
         def with_chunked_query
-          total = @query.except(:select).count
+          total = @query.total
           if total < MAX_SIZE
-            yield(@query, nil)
+            yield(@query.all, nil)
           else
-            years = @query.
-              except(:select).
-              except(:order).
-              select(:year).
-              distinct.
-              order(:year).
-              pluck(:year)
-            years.each do |year|
-              query = @query.where(year: year)
+            @query.years.each do |year|
+              query = @query.by_year(year)
               yield(query, year)
             end
           end

--- a/spec/services/api/v3/download/flow_download_flat_query_spec.rb
+++ b/spec/services/api/v3/download/flow_download_flat_query_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Download::FlowDownloadFlatQuery do
+  include_context 'api v3 brazil two flows'
+
+  before(:each) do
+    Api::V3::Readonly::DownloadFlow.refresh(sync: true)
+  end
+
+  let(:query) {
+    Api::V3::Readonly::DownloadFlow.where(context_id: api_v3_context.id)
+  }
+
+  let(:flat_query) {
+    Api::V3::Download::FlowDownloadFlatQuery.new(api_v3_context, query)
+  }
+
+  describe :all do
+    it 'returns DEFORESTATION as value of INDICATOR column' do
+      results = flat_query.all
+      deforestation = results.find { |r| r['INDICATOR'] == 'DEFORESTATION' }
+      expect(deforestation['TOTAL']).to eq('10')
+    end
+  end
+
+  describe :total do
+    it 'returns count of flows per year' do
+      expect(flat_query.total).to eq(4)
+    end
+  end
+end

--- a/spec/services/api/v3/download/flow_download_pivot_query_spec.rb
+++ b/spec/services/api/v3/download/flow_download_pivot_query_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Download::FlowDownloadPivotQuery do
+  include_context 'api v3 brazil two flows'
+
+  before(:each) do
+    Api::V3::Readonly::DownloadFlow.refresh(sync: true)
+  end
+
+  let(:query) {
+    Api::V3::Readonly::DownloadFlow.where(context_id: api_v3_context.id)
+  }
+
+  let(:pivot_query) {
+    Api::V3::Download::FlowDownloadPivotQuery.new(api_v3_context, query)
+  }
+
+  describe :all do
+    it 'returns DEFORESTATION as a column header' do
+      results = pivot_query.all
+      expect(results[0]['DEFORESTATION']).to eq('10')
+    end
+  end
+
+  describe :total do
+    it 'returns count of flows' do
+      expect(pivot_query.total).to eq(2)
+    end
+  end
+end

--- a/spec/services/api/v3/download/flow_download_query_builder_spec.rb
+++ b/spec/services/api/v3/download/flow_download_query_builder_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe Api::V3::Download::FlowDownloadQueryBuilder, type: :model do
   end
 
   def query_to_row(query)
-    query.map do |f|
+    query.all.map do |f|
       [
         f['YEAR'],
         f['MUNICIPALITY'],

--- a/spec/services/api/v3/download/flow_download_spec.rb
+++ b/spec/services/api/v3/download/flow_download_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Download::FlowDownload do
+  include_context 'api v3 brazil two flows'
+
+  before(:each) do
+    Api::V3::Readonly::DownloadFlow.refresh(sync: true)
+  end
+
+  let(:flow_download_flat) {
+    Api::V3::Download::FlowDownload.new(api_v3_context, {separator: :semicolon})
+  }
+
+  let(:flow_download_pivot) {
+    Api::V3::Download::FlowDownload.new(api_v3_context, {pivot: :true})
+  }
+
+  describe :zipped_csv do
+    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for flat csv' do
+      expect_any_instance_of(Api::V3::Download::ZippedCsvDownload).to receive(:create)
+      flow_download_flat.zipped_csv
+    end
+
+    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for pivot csv' do
+      expect_any_instance_of(Api::V3::Download::ZippedCsvDownload).to receive(:create)
+      flow_download_pivot.zipped_csv
+    end
+  end
+
+  describe :zipped_json do
+    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for flat json' do
+      expect_any_instance_of(Api::V3::Download::ZippedJsonDownload).to receive(:create)
+      flow_download_flat.zipped_json
+    end
+
+    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for pivot json' do
+      expect_any_instance_of(Api::V3::Download::ZippedJsonDownload).to receive(:create)
+      flow_download_pivot.zipped_json
+    end
+  end
+end

--- a/spec/services/api/v3/download/zipped_csv_download_spec.rb
+++ b/spec/services/api/v3/download/zipped_csv_download_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Download::ZippedCsvDownload do
+  include_context 'api v3 brazil two flows'
+  include ZipHelpers
+
+  before(:each) do
+    Api::V3::Readonly::DownloadFlow.refresh(sync: true)
+  end
+
+  let(:query) {
+    Api::V3::Readonly::DownloadFlow.where(context_id: api_v3_context.id)
+  }
+
+  let(:flat_query) {
+    Api::V3::Download::FlowDownloadFlatQuery.new(api_v3_context, query)
+  }
+
+  let(:pivot_query) {
+    Api::V3::Download::FlowDownloadPivotQuery.new(api_v3_context, query)
+  }
+
+  let(:flat_download) {
+    Api::V3::Download::ZippedCsvDownload.new(flat_query, 'test', ',')
+  }
+
+  let(:pivot_download) {
+    Api::V3::Download::ZippedCsvDownload.new(pivot_query, 'test', ',')
+  }
+
+  describe :create do
+    context 'when max rows not exceeded' do
+      it 'doesn\'t chunk flat data files' do
+        filenames = unzip(flat_download.create).keys
+        csv_files = filenames.select { |f| f.match(/\.csv$/) }
+        expect(csv_files.first).to eq('test.csv')
+      end
+
+      it 'doesn\'t chunk pivot data files' do
+        filenames = unzip(pivot_download.create).keys
+        csv_files = filenames.select { |f| f.match(/\.csv$/) }
+        expect(csv_files.first).to eq('test.csv')
+      end
+    end
+
+    context 'when max rows exceeded' do
+      before(:each) do
+        stub_const('Api::V3::Download::ZippedDownload::MAX_SIZE', 1)
+      end
+
+      it 'chunks flat data files' do
+        filenames = unzip(flat_download.create).keys
+        csv_files = filenames.select { |f| f.match(/\.csv$/) }
+        expect(csv_files.first).to eq('test.2015.csv')
+      end
+
+      it 'chunks pivot data files' do
+        filenames = unzip(pivot_download.create).keys
+        csv_files = filenames.select { |f| f.match(/\.csv$/) }
+        expect(csv_files.first).to eq('test.2015.csv')
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/download/zipped_json_download_spec.rb
+++ b/spec/services/api/v3/download/zipped_json_download_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Download::ZippedJsonDownload do
+  include_context 'api v3 brazil two flows'
+  include ZipHelpers
+
+  before(:each) do
+    Api::V3::Readonly::DownloadFlow.refresh(sync: true)
+  end
+
+  let(:query) {
+    Api::V3::Readonly::DownloadFlow.where(context_id: api_v3_context.id)
+  }
+
+  let(:flat_query) {
+    Api::V3::Download::FlowDownloadFlatQuery.new(api_v3_context, query)
+  }
+
+  let(:pivot_query) {
+    Api::V3::Download::FlowDownloadPivotQuery.new(api_v3_context, query)
+  }
+
+  let(:flat_download) {
+    Api::V3::Download::ZippedJsonDownload.new(flat_query, 'test')
+  }
+
+  let(:pivot_download) {
+    Api::V3::Download::ZippedJsonDownload.new(pivot_query, 'test')
+  }
+
+  describe :create do
+    context 'when max rows not exceeded' do
+      it 'doesn\'t chunk flat data files' do
+        filenames = unzip(flat_download.create).keys
+        json_files = filenames.select { |f| f.match(/\.json$/) }
+        expect(json_files.first).to eq('test.json')
+      end
+
+      it 'doesn\'t chunk pivot data files' do
+        filenames = unzip(pivot_download.create).keys
+        json_files = filenames.select { |f| f.match(/\.json$/) }
+        expect(json_files.first).to eq('test.json')
+      end
+    end
+
+    context 'when max rows exceeded' do
+      before(:each) do
+        stub_const('Api::V3::Download::ZippedDownload::MAX_SIZE', 1)
+      end
+
+      it 'chunks flat data files' do
+        filenames = unzip(flat_download.create).keys
+        json_files = filenames.select { |f| f.match(/\.json$/) }
+        expect(json_files.first).to eq('test.2015.json')
+      end
+
+      it 'chunks pivot data files' do
+        filenames = unzip(pivot_download.create).keys
+        json_files = filenames.select { |f| f.match(/\.json$/) }
+        expect(json_files.first).to eq('test.2015.json')
+      end
+    end
+  end
+end

--- a/spec/support/helpers/zip_helpers.rb
+++ b/spec/support/helpers/zip_helpers.rb
@@ -1,0 +1,15 @@
+module ZipHelpers
+  def unzip(data)
+    fin = StringIO.new(data)
+
+    entries = {}
+
+    ::Zip::InputStream.open(fin) do |fzip|
+      while entry = fzip.get_next_entry
+        entries[entry.name] = fzip.read
+      end
+    end
+
+    entries
+  end
+end


### PR DESCRIPTION
The problem occurred when a pivot download became too long to fit in one file and needed to be chunked; the year condition was applied to the outer crosstab query where it resulted in a syntax error, a situation that we have no tests for. To fix this I encapsulated the flat query and the pivot query in their own objects, making it easier to control how the query is constructed when the year condition is applied, and added specs to cover those scenarios.