### PR TITLE
fix: dropdown tab switcher handler crash

### DIFF
--- a/frontend/scripts/react-components/profiles/dropdown-tab-switcher.component.jsx
+++ b/frontend/scripts/react-components/profiles/dropdown-tab-switcher.component.jsx
@@ -16,9 +16,15 @@ class DropdownTabSwitcher extends Component {
     };
   }
 
-  handleSelect = selectedIndex => {
+  onSelectTab = (value, selectedIndex) => {
     this.setState({ selectedIndex });
+    this.props.onSelectedIndexChange(selectedIndex);
+  };
 
+  onValueSelected = value => {
+    const { items } = this.props;
+    const selectedIndex = items.indexOf(value);
+    this.setState({ selectedIndex });
     this.props.onSelectedIndexChange(selectedIndex);
   };
 
@@ -36,7 +42,7 @@ class DropdownTabSwitcher extends Component {
           <Tabs
             tabs={items}
             testId={testId}
-            onSelectTab={this.handleSelect}
+            onSelectTab={this.onSelectTab}
             itemTabRenderer={itemTabRenderer}
             selectedTab={items[selectedIndex]}
           />
@@ -46,7 +52,7 @@ class DropdownTabSwitcher extends Component {
             label={title}
             value={items[selectedIndex]}
             valueList={items}
-            onValueSelected={s => this.handleSelect(items.indexOf(s))}
+            onValueSelected={this.onValueSelected}
           />
         </div>
       </div>

--- a/frontend/scripts/react-components/profiles/dropdown-tab-switcher.component.jsx
+++ b/frontend/scripts/react-components/profiles/dropdown-tab-switcher.component.jsx
@@ -16,7 +16,7 @@ class DropdownTabSwitcher extends Component {
     };
   }
 
-  handleSelect = (_, selectedIndex) => {
+  handleSelect = selectedIndex => {
     this.setState({ selectedIndex });
 
     this.props.onSelectedIndexChange(selectedIndex);

--- a/frontend/scripts/react-components/profiles/line.component.jsx
+++ b/frontend/scripts/react-components/profiles/line.component.jsx
@@ -39,7 +39,6 @@ class Line extends Component {
 
   getTicksStyle() {
     const { width } = this.props;
-    console.log(width);
     if (this.isSmallChart()) {
       return 'small';
     }


### PR DESCRIPTION
This PR fixes a crash on mobile profile pages due to a broken event handler.