### PR TITLE
fixes styles for table score units

### DIFF
--- a/frontend/styles/components/profiles/area-table.scss
+++ b/frontend/styles/components/profiles/area-table.scss
@@ -111,8 +111,11 @@
           > .unit {
 
             &::after {
+              display: flex;
               position: absolute;
+              right: 0;
               top: 0;
+              transform: translateX(100%);
 
               color: rgba($charcoal-grey, .6);
               content: attr(data-unit);


### PR DESCRIPTION
Fixes text overflowing to a second line on profile-pages tables.

[Profile pages: Scale on water scarcity is incorrect. Should be '/7'](https://www.pivotaltracker.com/story/show/161919472)