### PR TITLE
fix: line chart labels get cut

### DIFF
--- a/frontend/scripts/react-components/profiles/line.component.jsx
+++ b/frontend/scripts/react-components/profiles/line.component.jsx
@@ -96,6 +96,7 @@ class Line extends Component {
       .append('svg')
       .attr('width', width + chartMargin.left + chartMargin.right)
       .attr('height', chartHeight + chartMargin.top + chartMargin.bottom)
+      .style('overflow', 'visible')
       .append('g')
       .attr('transform', `translate(${chartMargin.left},${chartMargin.top})`);
 


### PR DESCRIPTION
This PR addresses an issue where long named nodes got cut on the line charts label.

[On actor profiles, long place names of the top destination and top sourcing tables are being cut off in the legend](https://www.pivotaltracker.com/story/show/162156663)

<img width="743" alt="screen shot 2018-11-23 at 18 09 23" src="https://user-images.githubusercontent.com/12124839/48954692-edbcec80-ef4a-11e8-9111-3a0c9bccddae.png">
