### PR TITLE
fix: dependencies for deploying within capistrano

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,9 @@ group :development do
   gem 'capistrano-passenger'
   gem 'capistrano-npm'
   gem 'rubocop', require: false
+  gem 'rbnacl', '>= 3.2', '< 5.0'
+  gem 'rbnacl-libsodium'
+  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
+    bcrypt_pbkdf (1.0.0)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     buftok (0.2.0)
@@ -257,7 +258,7 @@ GEM
     naught (1.1.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (5.0.2)
+    net-ssh (4.2.0)
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
@@ -326,6 +327,10 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    rbnacl (4.0.2)
+      ffi
+    rbnacl-libsodium (1.0.16)
+      rbnacl (>= 3.0.1)
     redis (4.0.2)
     require_all (1.5.0)
     responders (2.4.0)
@@ -456,6 +461,7 @@ DEPENDENCIES
   annotate
   appsignal
   aws-sdk-s3 (~> 1)
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   bootsnap
   byebug
   capistrano (= 3.7.1)
@@ -488,6 +494,8 @@ DEPENDENCIES
   rails (~> 5.2.1)
   rails-controller-testing
   ransack
+  rbnacl (>= 3.2, < 5.0)
+  rbnacl-libsodium
   rspec-collection_matchers
   rspec-rails (~> 3.5)
   rubocop


### PR DESCRIPTION
This adds the necessary dependencies and rollbacks the `Gemfile.lock` to use a working version of `net-ssh `.