### PR TITLE
Feature/renaming profile indicators again

### DIFF
--- a/app/services/api/v3/actors/exporting_companies_plot.rb
+++ b/app/services/api/v3/actors/exporting_companies_plot.rb
@@ -100,23 +100,6 @@ module Api
               name: 'Soy deforestation',
               unit: 'ha',
               attribute_type: 'quant',
-            },
-            {
-              name: 'Soy related deforestation',
-              unit: 'ha',
-              attribute_type: 'quant',
-              attribute_name: 'AGROSATELITE_SOY_DEFOR_'
-            },
-            {
-              name: 'Loss of biodiversity',
-              attribute_type: 'quant',
-              attribute_name: 'BIODIVERSITY'
-            },
-            {
-              name: 'Land-based emissions',
-              unit: 't',
-              attribute_type: 'quant',
-              attribute_name: 'GHG_'
               attribute_name: 'SOY_DEFORESTATION_5_YEAR_ANNUAL'
             }
           ]

--- a/app/services/api/v3/actors/exporting_companies_plot.rb
+++ b/app/services/api/v3/actors/exporting_companies_plot.rb
@@ -100,7 +100,6 @@ module Api
               name: 'Soy deforestation',
               unit: 'ha',
               attribute_type: 'quant',
-              attribute_name: 'SOY_DEFORESTATION_1_YEAR'
             },
             {
               name: 'Soy related deforestation',
@@ -118,6 +117,7 @@ module Api
               unit: 't',
               attribute_type: 'quant',
               attribute_name: 'GHG_'
+              attribute_name: 'SOY_DEFORESTATION_5_YEAR_ANNUAL'
             }
           ]
         end

--- a/app/services/api/v3/actors/sustainability_table.rb
+++ b/app/services/api/v3/actors/sustainability_table.rb
@@ -137,7 +137,7 @@ module Api
             {
               name: 'Soy deforestation',
               attribute_type: 'quant',
-              attribute_name: 'SOY_DEFORESTATION_1_YEAR'
+              attribute_name: 'SOY_DEFORESTATION_5_YEAR_ANNUAL'
             }
           ]
         end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/162306205

2 changes to indicators on actor profiles:
the deforestation risk table on the actor profile SOY_DEFORESTATION_1_YEAR -> SOY_DEFORESTATION_5_YEAR_ANNUAL
the company comparison scatterplot on the actor profile SOY_DEFORESTATION_1_YEAR -> SOY_DEFORESTATION_5_YEAR_ANNUAL

additionally, removed 2 indicators which were never really displayed on the company comparison scatterplot and not sure why they've been there in the code (for a long time probably)