### PR TITLE
Add asset precompilation to capistrano deploy workflow

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -35,6 +35,7 @@ require 'capistrano/rvm'
 # require 'capistrano/chruby'
 require 'capistrano/bundler'
 require 'capistrano/rails/migrations'
+require 'capistrano/rails/assets'
 require 'capistrano/passenger'
 require 'capistrano/npm'
 


### PR DESCRIPTION
This requires changing apache's settings to have it serve the assets folder directly, instead of passing it to passenger for rails to handle