### PR TITLE
Pre-computed downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 !/log/.keep
 !/tmp/.keep
 
+/public/downloads
 /public/system
 /public/urls.txt
 

--- a/app/controllers/api/v3/download_controller.rb
+++ b/app/controllers/api/v3/download_controller.rb
@@ -8,13 +8,13 @@ module Api
           format.csv do
             send_data download.zipped_csv,
                       type: 'application/zip',
-                      filename: "#{download.download_name}.zip",
+                      filename: download.filename,
                       disposition: 'attachment'
           end
           format.json do
             send_data download.zipped_json,
                       type: 'application/zip',
-                      filename: "#{download.download_name}.zip",
+                      filename: download.filename,
                       disposition: 'attachment'
           end
         end

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -10,6 +10,8 @@ module Api
           # Refreshes the views dependencies, the view itself and its dependents
           # @param options
           # @option options [Boolean] :skip_dependencies skip refreshing
+          # @option options [Boolean] :skip_dependents skip refreshing
+          # @option options [Boolean] :sync synchronously
           def refresh(options = {})
             # rubocop:disable Style/DoubleNegation
             sync_processing = !!options[:sync]
@@ -24,6 +26,7 @@ module Api
           def refresh_now(options = {})
             refresh_dependencies(options) unless options[:skip_dependencies]
             refresh_by_name(table_name, options)
+            after_refresh(options)
             refresh_dependents(options) unless options[:skip_dependents]
           end
 
@@ -61,6 +64,9 @@ module Api
               concurrently: safe_concurrently
             )
           end
+
+          # Whatever needs doing after refreshing that is not a cascading refresh
+          def after_refresh(_options = {}); end
         end
       end
     end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -51,12 +51,18 @@ module Api
         self.table_name = 'download_flows_mv'
         self.primary_key = 'id'
 
-        def self.long_running?
-          true
-        end
+        class << self
+          def long_running?
+            true
+          end
 
-        def self.refresh_dependencies(_options = {})
-          refresh_by_name('flow_paths_mv', concurrently: false) # no unique index
+          def refresh_dependencies(_options = {})
+            refresh_by_name('flow_paths_mv', concurrently: false) # no unique index
+          end
+
+          def after_refresh(_options = {})
+            Api::V3::Download::PrecomputedDownload.refresh
+          end
         end
       end
     end

--- a/app/serializers/api/v3/download_attribute_serializer.rb
+++ b/app/serializers/api/v3/download_attribute_serializer.rb
@@ -12,6 +12,7 @@ module Api
 
       def filter_options
         return qual_filter_options if object.original_type == 'Qual'
+
         quant_filter_options
       end
 

--- a/app/services/api/v3/download/flow_download.rb
+++ b/app/services/api/v3/download/flow_download.rb
@@ -2,23 +2,15 @@ module Api
   module V3
     module Download
       class FlowDownload
-        attr_reader :download_name
+        delegate :download_name, to: :@parameters
+        delegate :filename, to: :@parameters
 
         def initialize(context, params)
-          @context = context
-          @pivot = params[:pivot].present?
-          @separator = if params[:separator].present? && params[:separator] == 'semicolon'
-                         ';'
-                       else
-                         ','
-                       end
-          @download_name = [
-            @context.country.name,
-            @context.commodity.name,
-            DownloadVersion.current_version_symbol(@context)
-          ].compact.join('_')
-          query_builder = Api::V3::Download::FlowDownloadQueryBuilder.new(@context, params)
-          @query = if @pivot
+          @parameters = Api::V3::Download::Parameters.new(context, params)
+          query_builder = Api::V3::Download::FlowDownloadQueryBuilder.new(
+            context, @parameters.filters
+          )
+          @query = if @parameters.pivot
                      query_builder.pivot_query
                    else
                      query_builder.flat_query
@@ -26,15 +18,35 @@ module Api
         end
 
         def zipped_csv
-          Api::V3::Download::ZippedCsvDownload.new(
-            @query, @download_name, @separator
-          ).create
+          precompute do
+            Api::V3::Download::ZippedCsvDownload.new(
+              @query, download_name, @separator
+            ).create
+          end
         end
 
         def zipped_json
-          Api::V3::Download::ZippedJsonDownload.new(
-            @query, @download_name
-          ).create
+          precompute do
+            Api::V3::Download::ZippedJsonDownload.new(
+              @query, download_name
+            ).create
+          end
+        end
+
+        def precompute
+          if @parameters.precompute?
+            precomputed_download = Api::V3::Download::PrecomputedDownload.new(
+              @parameters
+            )
+          end
+
+          data = precomputed_download&.retrieve
+          return data if data
+
+          Rails.logger.debug('Generating download')
+          data = yield
+          precomputed_download&.store(data)
+          data
         end
       end
     end

--- a/app/services/api/v3/download/parameters.rb
+++ b/app/services/api/v3/download/parameters.rb
@@ -1,0 +1,63 @@
+module Api
+  module V3
+    module Download
+      class Parameters
+        attr_reader :context, :version, :pivot, :separator, :format, :filters,
+                    :download_name, :filename
+
+        def initialize(context, params)
+          @context = context
+          @version = DownloadVersion.current_version_symbol(@context)
+          @filters = {}
+          [:years, :e_ids, :i_ids, :c_ids, :filters].each do |key|
+            @filters[key] = params[key] if params[key]
+          end
+          @pivot = params[:pivot].present?
+          @separator =
+            if params[:separator].present? && params[:separator] == 'semicolon'
+              ';'
+            else
+              ','
+            end
+          @format =
+            if params[:format] && params[:format] == 'json'
+              'json'
+            else
+              'csv'
+            end
+          @download_name = download_name_parts.compact.join('_')
+          @filename = @download_name + '.zip'
+        end
+
+        def precompute?
+          @filters.none?
+        end
+
+        def separator_name
+          if @separator == ';'
+            'semicolon'
+          else
+            'comma'
+          end
+        end
+
+        def pivot_name
+          if @pivot
+            'pivot'
+          else
+            'table'
+          end
+        end
+
+        def download_name_parts
+          [
+            @context.country.name,
+            @context.commodity.name,
+            @version,
+            pivot_name[0] + separator_name[0]
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/download/precomputed_download.rb
+++ b/app/services/api/v3/download/precomputed_download.rb
@@ -1,0 +1,73 @@
+module Api
+  module V3
+    module Download
+      class PrecomputedDownload
+        include Cache::Cleaner
+        ROOT_DIRNAME = 'public/downloads'.freeze
+
+        # @param parameters [Api::V3::Download::Parameters]
+        def initialize(parameters)
+          @parameters = parameters
+          @format = @parameters.format
+          @dirname = "#{ROOT_DIRNAME}/#{@format}"
+          @filename = @parameters.filename
+          @file_path = "#{@dirname}/#{@filename}"
+        end
+
+        def retrieve
+          return nil unless File.exist?(@file_path)
+
+          Rails.logger.debug "Retrieving file from #{@file_path}"
+          File.read(@file_path)
+        end
+
+        def store(data)
+          ensure_directory_exists
+          Rails.logger.debug "Storing file at #{@file_path}"
+          File.open(@file_path, 'w') { |f| f.write data }
+        end
+
+        class << self
+          def clear
+            FileUtils.rm_rf(
+              Api::V3::Download::PrecomputedDownload::ROOT_DIRNAME,
+              secure: true
+            )
+            clear_cache_for_regexp('/api/v3/contexts/.+.csv$')
+            clear_cache_for_regexp('/api/v3/contexts/.+.json$')
+          end
+
+          def refresh
+            clear_and_refresh_all_contexts do |context|
+              Api::V3::Download::FlowDownload.new(context, pivot: true).
+                zipped_csv
+            end
+          end
+
+          def refresh_later
+            clear_and_refresh_all_contexts do |context|
+              PrecomputedDownloadRefreshWorker.perform_async(
+                context.id, pivot: true
+              )
+            end
+          end
+        end
+
+        private
+
+        def ensure_directory_exists
+          return if File.directory?(@dirname)
+
+          FileUtils.mkdir_p(@dirname)
+        end
+
+        private_class_method def self.clear_and_refresh_all_contexts
+          clear
+          Api::V3::Context.all.each do |context|
+            yield(context)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/download/zipped_download.rb
+++ b/app/services/api/v3/download/zipped_download.rb
@@ -12,7 +12,7 @@ module Api
         def initialize(query, download_name)
           @query = query
           @download_name = download_name
-          @temp_dir = "#{Rails.root}/tmp/#{Time.now.strftime('%Y%m%d%H%M%S')}"
+          @temp_dir = "#{Rails.root}/tmp/#{Time.now.strftime('%Y%m%d%H%M%S,%N')}"
         end
 
         # @return [String] compressed data

--- a/app/workers/precomputed_download_refresh_worker.rb
+++ b/app/workers/precomputed_download_refresh_worker.rb
@@ -1,22 +1,22 @@
-class MaterializedViewRefreshWorker
+class PrecomputedDownloadRefreshWorker
   include Sidekiq::Worker
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true,
                   unique: :until_and_while_executing,
-                  run_lock_expiration: 150, # 2.5 mins
                   log_duplicate_payload: true
 
   def self.unique_args(args)
-    [args[0]]
+    [args[0], args[1]]
   end
 
-  # @param mview_class_name [String] e.g. Api::V3::Readonly::DownloadFlow
+  # @param context_id [Integer]
   # @param options
   # @option options [Boolean] :skip_dependencies skip refreshing
   # @option options [Boolean] :skip_dependents skip refreshing
-  def perform(mview_class_name, options)
-    mview_class = mview_class_name.constantize
-    mview_class.refresh_now(options.symbolize_keys)
+  def perform(context_id, options)
+    context = Api::V3::Context.find(context_id)
+    Api::V3::Download::FlowDownload.new(context, options).
+      zipped_csv
   end
 end

--- a/lib/tasks/downloads.rake
+++ b/lib/tasks/downloads.rake
@@ -1,0 +1,16 @@
+namespace :downloads do
+  desc 'Clear pre-computed bulk downloads'
+  task refresh: :environment do
+    Api::V3::Download::PrecomputedDownload.clear
+  end
+
+  desc 'Refresh pre-computed bulk downloads'
+  task refresh: :environment do
+    Api::V3::Download::PrecomputedDownload.refresh
+  end
+
+  desc 'Refresh pre-computed bulk downloads in a background job'
+  task refresh_later: :environment do
+    Api::V3::Download::PrecomputedDownload.refresh_later
+  end
+end

--- a/lib/zipfile.rb
+++ b/lib/zipfile.rb
@@ -5,6 +5,7 @@ module Zipfile
     Zip::File.open_buffer(zipfile_content) do |zipfile|
       entry = zipfile.glob("*.#{format}").first
       break nil unless entry
+
       break entry.get_input_stream.read
     end
   end

--- a/spec/controllers/api/v3/download_controller_spec.rb
+++ b/spec/controllers/api/v3/download_controller_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Api::V3::DownloadController, type: :controller do
   include_context 'api v3 brazil flows'
   include_context 'api v3 paraguay context'
 
+  before do
+    allow(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:refresh)
+  end
+
   describe 'GET index' do
     before(:each) do
       Api::V3::Readonly::DownloadFlow.refresh(sync: true)
@@ -14,6 +20,12 @@ RSpec.describe Api::V3::DownloadController, type: :controller do
           is_current: true,
           context_id: api_v3_context.id
         )
+      allow_any_instance_of(
+        Api::V3::Download::FlowDownload
+      ).to receive(:zipped_csv).and_return('')
+      allow_any_instance_of(
+        Api::V3::Download::FlowDownload
+      ).to receive(:zipped_json).and_return('')
     end
     it 'returns a zipped csv file' do
       get :index, params: {context_id: api_v3_context.id}, format: :csv
@@ -21,7 +33,7 @@ RSpec.describe Api::V3::DownloadController, type: :controller do
       expect(response.content_type).to eq('application/zip')
       expect(
         response.headers['Content-Disposition']
-      ).to eq('attachment; filename="BRAZIL_SOY_v1.0.zip"')
+      ).to eq('attachment; filename="BRAZIL_SOY_v1.0_tc.zip"')
     end
     it 'returns a zipped json file' do
       get :index, params: {context_id: api_v3_context.id}, format: :json
@@ -29,7 +41,7 @@ RSpec.describe Api::V3::DownloadController, type: :controller do
       expect(response.content_type).to eq('application/zip')
       expect(
         response.headers['Content-Disposition']
-      ).to eq('attachment; filename="BRAZIL_SOY_v1.0.zip"')
+      ).to eq('attachment; filename="BRAZIL_SOY_v1.0_tc.zip"')
     end
     it 'returns no version on file name if none is available' do
       get :index, params: {context_id: api_v3_paraguay_context.id}, format: :json
@@ -37,7 +49,7 @@ RSpec.describe Api::V3::DownloadController, type: :controller do
       expect(response.content_type).to eq('application/zip')
       expect(
         response.headers['Content-Disposition']
-      ).to eq('attachment; filename="PARAGUAY_SOY.zip"')
+      ).to eq('attachment; filename="PARAGUAY_SOY_tc.zip"')
     end
   end
 end

--- a/spec/services/api/v3/download/flow_download_flat_query_spec.rb
+++ b/spec/services/api/v3/download/flow_download_flat_query_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe Api::V3::Download::FlowDownloadFlatQuery do
   include_context 'api v3 brazil two flows'
 
+  before do
+    allow(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:refresh)
+  end
+
   before(:each) do
     Api::V3::Readonly::DownloadFlow.refresh(sync: true)
   end

--- a/spec/services/api/v3/download/flow_download_pivot_query_spec.rb
+++ b/spec/services/api/v3/download/flow_download_pivot_query_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe Api::V3::Download::FlowDownloadPivotQuery do
   include_context 'api v3 brazil two flows'
 
+  before do
+    allow(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:refresh)
+  end
+
   before(:each) do
     Api::V3::Readonly::DownloadFlow.refresh(sync: true)
   end

--- a/spec/services/api/v3/download/flow_download_query_builder_spec.rb
+++ b/spec/services/api/v3/download/flow_download_query_builder_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe Api::V3::Download::FlowDownloadQueryBuilder, type: :model do
   include_context 'api v3 brazil two flows'
   describe :query do
+    before do
+      allow(
+        Api::V3::Download::PrecomputedDownload
+      ).to receive(:refresh)
+    end
+
     before(:each) do
       Api::V3::Readonly::DownloadFlow.refresh(sync: true)
     end

--- a/spec/services/api/v3/download/flow_download_spec.rb
+++ b/spec/services/api/v3/download/flow_download_spec.rb
@@ -3,39 +3,116 @@ require 'rails_helper'
 RSpec.describe Api::V3::Download::FlowDownload do
   include_context 'api v3 brazil two flows'
 
+  before do
+    allow(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:refresh)
+    allow_any_instance_of(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:store)
+  end
+
   before(:each) do
     Api::V3::Readonly::DownloadFlow.refresh(sync: true)
   end
 
   let(:flow_download_flat) {
-    Api::V3::Download::FlowDownload.new(api_v3_context, {separator: :semicolon})
+    Api::V3::Download::FlowDownload.new(api_v3_context, separator: :semicolon)
   }
 
   let(:flow_download_pivot) {
-    Api::V3::Download::FlowDownload.new(api_v3_context, {pivot: :true})
+    Api::V3::Download::FlowDownload.new(api_v3_context, pivot: true)
   }
 
   describe :zipped_csv do
-    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for flat csv' do
-      expect_any_instance_of(Api::V3::Download::ZippedCsvDownload).to receive(:create)
-      flow_download_flat.zipped_csv
+    context 'when no precomputed file' do
+      before(:each) do
+        allow_any_instance_of(
+          Api::V3::Download::PrecomputedDownload
+        ).to receive(:retrieve).and_return(nil)
+      end
+
+      it 'creates a file for flat csv' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedCsvDownload
+        ).to receive(:create)
+        flow_download_flat.zipped_csv
+      end
+
+      it 'creates a file for pivot csv' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedCsvDownload
+        ).to receive(:create)
+        flow_download_pivot.zipped_csv
+      end
     end
 
-    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for pivot csv' do
-      expect_any_instance_of(Api::V3::Download::ZippedCsvDownload).to receive(:create)
-      flow_download_pivot.zipped_csv
+    context 'when precomputed file' do
+      before(:each) do
+        allow_any_instance_of(
+          Api::V3::Download::PrecomputedDownload
+        ).to receive(:retrieve).and_return('')
+      end
+
+      it 'does not create a file for flat csv' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedCsvDownload
+        ).not_to receive(:create)
+        flow_download_flat.zipped_csv
+      end
+
+      it 'does not create a file for pivot csv' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedCsvDownload
+        ).not_to receive(:create)
+        flow_download_pivot.zipped_csv
+      end
     end
   end
 
   describe :zipped_json do
-    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for flat json' do
-      expect_any_instance_of(Api::V3::Download::ZippedJsonDownload).to receive(:create)
-      flow_download_flat.zipped_json
+    context 'when no precomputed file' do
+      before(:each) do
+        allow_any_instance_of(
+          Api::V3::Download::PrecomputedDownload
+        ).to receive(:retrieve).and_return(nil)
+      end
+
+      it 'creates a file for flat json' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedJsonDownload
+        ).to receive(:create)
+        flow_download_flat.zipped_json
+      end
+
+      it 'creates a file for pivot json' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedJsonDownload
+        ).to receive(:create)
+        flow_download_pivot.zipped_json
+      end
     end
 
-    it 'creates an instance of Api::V3::Download::ZippedCsvDownload for pivot json' do
-      expect_any_instance_of(Api::V3::Download::ZippedJsonDownload).to receive(:create)
-      flow_download_pivot.zipped_json
+    context 'when precomputed file' do
+      before(:each) do
+        allow_any_instance_of(
+          Api::V3::Download::PrecomputedDownload
+        ).to receive(:retrieve).and_return('')
+      end
+
+      it 'does not create a file for flat csv' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedJsonDownload
+        ).not_to receive(:create)
+        flow_download_flat.zipped_json
+      end
+
+      it 'does not create a file for pivot csv' do
+        expect_any_instance_of(
+          Api::V3::Download::ZippedJsonDownload
+        ).not_to receive(:create)
+        flow_download_pivot.zipped_json
+      end
     end
   end
 end

--- a/spec/services/api/v3/download/zipped_csv_download_spec.rb
+++ b/spec/services/api/v3/download/zipped_csv_download_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Api::V3::Download::ZippedCsvDownload do
   include_context 'api v3 brazil two flows'
   include ZipHelpers
 
+  before do
+    allow(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:refresh)
+  end
+
   before(:each) do
     Api::V3::Readonly::DownloadFlow.refresh(sync: true)
   end
@@ -29,6 +35,12 @@ RSpec.describe Api::V3::Download::ZippedCsvDownload do
   }
 
   describe :create do
+    before(:each) do
+      allow_any_instance_of(
+        Api::V3::Download::PrecomputedDownload
+      ).to receive(:store).and_return('')
+    end
+
     context 'when max rows not exceeded' do
       it 'doesn\'t chunk flat data files' do
         filenames = unzip(flat_download.create).keys

--- a/spec/services/api/v3/download/zipped_json_download_spec.rb
+++ b/spec/services/api/v3/download/zipped_json_download_spec.rb
@@ -4,6 +4,12 @@ RSpec.describe Api::V3::Download::ZippedJsonDownload do
   include_context 'api v3 brazil two flows'
   include ZipHelpers
 
+  before do
+    allow(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:refresh)
+  end
+
   before(:each) do
     Api::V3::Readonly::DownloadFlow.refresh(sync: true)
   end
@@ -29,6 +35,12 @@ RSpec.describe Api::V3::Download::ZippedJsonDownload do
   }
 
   describe :create do
+    before(:each) do
+      allow_any_instance_of(
+        Api::V3::Download::PrecomputedDownload
+      ).to receive(:store).and_return('')
+    end
+
     context 'when max rows not exceeded' do
       it 'doesn\'t chunk flat data files' do
         filenames = unzip(flat_download.create).keys

--- a/spec/workers/database_update_worker_spec.rb
+++ b/spec/workers/database_update_worker_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe DatabaseUpdateWorker, type: :worker do
     FactoryBot.create(:api_v3_database_update)
   }
 
+  before do
+    allow(
+      Api::V3::Download::PrecomputedDownload
+    ).to receive(:refresh)
+  end
+
   context "When processing a successful database import" do
     before do
       allow_any_instance_of(


### PR DESCRIPTION
Modification of the download service so that in case of full downloads it first checks if a file is already generated and serves that; in case it's not, after generating it it stores it for future use.

After the download flows materialised view refreshes, it precomputes all full pivot csv downloads.

There are capistrano tasks:

`cap [env] downloads:clear`
`cap [env] downloads:refresh` <- this one clears immediately and refreshes in background after `sidekiq:restart`