### PR TITLE
Validate declared years for map attributes using node attributes values

### DIFF
--- a/app/models/api/v3/flow.rb
+++ b/app/models/api/v3/flow.rb
@@ -27,6 +27,8 @@ module Api
       has_many :flow_quals
       has_many :flow_quants
 
+      MINIMUM_LENGTH = 4
+
       def self.import_key
         []
       end

--- a/app/services/api/v3/database_validation/chain_builders/download_attribute_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/download_attribute_chain_builder.rb
@@ -8,10 +8,10 @@ module Api
     module DatabaseValidation
       module ChainBuilders
         class DownloadAttributeChainBuilder < AbstractChainBuilder
-          checks :declared_years_match_data,
+          checks :declared_years_match_flow_attributes,
                  association: :download_quant,
                  link: :edit
-          checks :declared_years_match_data,
+          checks :declared_years_match_flow_attributes,
                  association: :download_qual,
                  link: :edit
           checks :has_exactly_one_of,

--- a/app/services/api/v3/database_validation/chain_builders/map_attribute_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/map_attribute_chain_builder.rb
@@ -8,10 +8,10 @@ module Api
     module DatabaseValidation
       module ChainBuilders
         class MapAttributeChainBuilder < AbstractChainBuilder
-          checks :declared_years_match_data,
+          checks :declared_years_match_node_attributes,
                  association: :map_ind,
                  link: :edit
-          checks :declared_years_match_data,
+          checks :declared_years_match_node_attributes,
                  association: :map_quant,
                  link: :edit
           checks :has_exactly_one_of,

--- a/app/services/api/v3/database_validation/chain_builders/recolor_by_attribute_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/recolor_by_attribute_chain_builder.rb
@@ -11,10 +11,10 @@ module Api
     module DatabaseValidation
       module ChainBuilders
         class RecolorByAttributeChainBuilder < AbstractChainBuilder
-          checks :declared_years_match_data,
+          checks :declared_years_match_flow_attributes,
                  association: :recolor_by_ind,
                  link: :edit
-          checks :declared_years_match_data,
+          checks :declared_years_match_flow_attributes,
                  association: :recolor_by_qual,
                  link: :edit
           checks :attribute_present,

--- a/app/services/api/v3/database_validation/chain_builders/resize_by_attribute_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/resize_by_attribute_chain_builder.rb
@@ -9,7 +9,7 @@ module Api
     module DatabaseValidation
       module ChainBuilders
         class ResizeByAttributeChainBuilder < AbstractChainBuilder
-          checks :declared_years_match_data,
+          checks :declared_years_match_flow_attributes,
                  association: :resize_by_quant,
                  link: :edit
           checks :attribute_present,

--- a/app/services/api/v3/database_validation/checks/declared_years_match_flow_attributes.rb
+++ b/app/services/api/v3/database_validation/checks/declared_years_match_flow_attributes.rb
@@ -2,13 +2,12 @@
 # - resize_by_attribute
 # - recolor_by_attribute
 # - download_attribute
-# - map_attribute
-# match the data available.
+# match the data available in flow_inds/quants/quals.
 module Api
   module V3
     module DatabaseValidation
       module Checks
-        class DeclaredYearsMatchData < AbstractCheck
+        class DeclaredYearsMatchFlowAttributes < AbstractCheck
           # @param (see AbstractCheck#initialize)
           # @option options (see AbstractCheck#initialize)
           # @option options [symbol] :association name of +has_one+ association
@@ -50,14 +49,14 @@ module Api
           end
 
           def self.human_readable(options)
-            "declared year range on #{options[:association]} matches data"
+            "declared year range on #{options[:association]} matches flow attributes"
           end
 
           private
 
           def error
             super.merge(
-              message: "#{@association} years declared differ from available"
+              message: "#{@association} years declared differ from available flow attributes"
             )
           end
         end

--- a/app/services/api/v3/database_validation/checks/declared_years_match_node_attributes.rb
+++ b/app/services/api/v3/database_validation/checks/declared_years_match_node_attributes.rb
@@ -1,0 +1,63 @@
+# Check if the years declared in +years+ column of a:
+# - map_attribute
+# match the data available in flow_inds/quants/quals.
+module Api
+  module V3
+    module DatabaseValidation
+      module Checks
+        class DeclaredYearsMatchNodeAttributes < AbstractCheck
+          # @param (see AbstractCheck#initialize)
+          # @option options (see AbstractCheck#initialize)
+          # @option options [symbol] :association name of +has_one+ association
+          #   e.g. +:resize_by_quant+
+          def initialize(object, options)
+            super(object, options)
+            @association = options[:association]
+          end
+
+          # Checks the flows table
+          # joined with relevant flows_inds/quals/quants table
+          # to get the array of years for which values exist
+          # for the attribute in question
+          # @return (see AbstractCheck#passing?)
+          def passing?
+            declared_years = @object.years
+            return true if declared_years.nil?
+
+            # @association is e.g. :resize_by_quant
+            associated_object = @object.send(@association)
+            return true unless associated_object.present?
+            # e.g. quant
+            attribute_name = @association.to_s.split('_').last
+            # e.g. ind_id
+            attribute_id_name = "#{attribute_name}_id"
+
+            # flow attributes table
+            values_class = ('Api::V3::' + "node_#{attribute_name}".camelize).
+              constantize
+
+            actual_years = values_class.
+              select(:year).
+              where(
+                attribute_id_name => associated_object.send(attribute_id_name)
+              ).
+              distinct.all.map(&:year)
+            actual_years.sort == declared_years.sort
+          end
+
+          def self.human_readable(options)
+            "declared year range on #{options[:association]} matches node attributes"
+          end
+
+          private
+
+          def error
+            super.merge(
+              message: "#{@association} years declared differ from available node attributes"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/database_validation/checks/declared_years_match_flow_attributes_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/declared_years_match_flow_attributes_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'services/api/v3/database_validation/checks/shared_check_examples'
 
-RSpec.describe Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchData do
+RSpec.describe Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchFlowAttributes do
   context 'when checking resize_by_attributes' do
     let(:context) { FactoryBot.create(:api_v3_context) }
     let(:quant) { FactoryBot.create(:api_v3_quant) }
@@ -19,15 +19,22 @@ RSpec.describe Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchData do
         quant: quant
       )
     }
+    let(:flow_path) {
+      Array.new(Api::V3::Flow::MINIMUM_LENGTH) do
+        FactoryBot.create(:api_v3_node).id
+      end
+    }
     let(:flow_2014) {
-      FactoryBot.create(:api_v3_flow, context: context, year: 2014)
+      FactoryBot.create(
+        :api_v3_flow, context: context, path: flow_path, year: 2014
+      )
     }
     let!(:flow_quant_2014) {
       FactoryBot.create(:api_v3_flow_quant, flow: flow_2014, quant: quant)
     }
 
     let(:check) {
-      Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchData.new(
+      Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchFlowAttributes.new(
         resize_by_attribute,
         association: :resize_by_quant
       )
@@ -41,7 +48,9 @@ RSpec.describe Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchData do
 
     context 'when years match' do
       let(:flow_2015) {
-        FactoryBot.create(:api_v3_flow, context: context, year: 2015)
+        FactoryBot.create(
+          :api_v3_flow, context: context, path: flow_path, year: 2015
+        )
       }
       let!(:flow_quant_2015) {
         FactoryBot.create(:api_v3_flow_quant, flow: flow_2015, quant: quant)

--- a/spec/services/api/v3/database_validation/checks/declared_years_match_node_attributes_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/declared_years_match_node_attributes_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+require 'services/api/v3/database_validation/checks/shared_check_examples'
+
+RSpec.describe Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchNodeAttributes do
+  context 'when checking resize_by_attributes' do
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    let(:quant) { FactoryBot.create(:api_v3_quant) }
+    let(:map_attribute_group) {
+      FactoryBot.create(
+        :api_v3_map_attribute_group,
+        context: context
+      )
+    }
+    let(:map_attribute) {
+      FactoryBot.create(
+        :api_v3_map_attribute,
+        map_attribute_group: map_attribute_group,
+        years: [2014, 2015]
+      )
+    }
+    let!(:map_quant) {
+      FactoryBot.create(
+        :api_v3_map_quant,
+        map_attribute: map_attribute,
+        quant: quant
+      )
+    }
+    let!(:node_quant_2014) {
+      FactoryBot.create(:api_v3_node_quant, quant: quant, year: 2014)
+    }
+
+    let(:check) {
+      Api::V3::DatabaseValidation::Checks::DeclaredYearsMatchNodeAttributes.new(
+        map_attribute,
+        association: :map_quant
+      )
+    }
+    let(:report_status) {
+      Api::V3::DatabaseValidation::ErrorsList.new
+    }
+    context 'when years dont match' do
+      include_examples 'failing checks'
+    end
+
+    context 'when years match' do
+      let!(:node_quant_2015) {
+        FactoryBot.create(:api_v3_node_quant, quant: quant, year: 2015)
+      }
+
+      include_examples 'passing checks'
+    end
+  end
+end

--- a/spec/support/contexts/api/v3/minimum_complete_configuration.rb
+++ b/spec/support/contexts/api/v3/minimum_complete_configuration.rb
@@ -13,18 +13,32 @@ shared_context 'minimum complete configuration' do
   }
   let(:ind) { FactoryBot.create(:api_v3_ind) }
   let!(:ind_property) {
-    FactoryBot.create(:api_v3_ind_property, ind: ind, tooltip_text: 'ind text')
+    FactoryBot.create(
+      :api_v3_ind_property,
+      ind: ind,
+      tooltip_text: 'ind text',
+      is_temporal_on_actor_profile: true,
+      is_temporal_on_place_profile: true
+    )
   }
   let(:qual) { FactoryBot.create(:api_v3_qual) }
   let!(:qual_property) {
     FactoryBot.create(
-      :api_v3_qual_property, qual: qual, tooltip_text: 'qual text'
+      :api_v3_qual_property,
+      qual: qual,
+      tooltip_text: 'qual text',
+      is_temporal_on_actor_profile: true,
+      is_temporal_on_place_profile: true
     )
   }
   let(:quant) { FactoryBot.create(:api_v3_quant) }
   let!(:quant_property) {
     FactoryBot.create(
-      :api_v3_quant_property, quant: quant, tooltip_text: 'quant text'
+      :api_v3_quant_property,
+      quant: quant,
+      tooltip_text: 'quant text',
+      is_temporal_on_actor_profile: true,
+      is_temporal_on_place_profile: true
     )
   }
   let(:exporter_node_type) {
@@ -153,6 +167,12 @@ shared_context 'minimum complete configuration' do
       map_attribute: map_attribute,
       ind: ind
     )
+  }
+  let!(:node_quant_2014) {
+    FactoryBot.create(:api_v3_node_quant, quant: quant, year: 2014)
+  }
+  let!(:node_ind_2014) {
+    FactoryBot.create(:api_v3_node_ind, ind: ind, year: 2014)
   }
   let(:flow_2014) {
     FactoryBot.create(:api_v3_flow, context: context, year: 2014)


### PR DESCRIPTION
Separate validation logic needed for map attributes, looking for temporal data in node attributes rather than flow attributes.

Some background: This is part of a custom data validation system we built to validate the dataset after importing new data. It's different from regular ActiveRecord validations in that they don't run on record creation; in terms of the core dataset, records are not created one by one but the contents of the entire table is replaced during a data update process. The validation system codifies some data consistency rules to validate the new dataset.
There is a particular validation rule which was applied to a few similarly structured tables. `download_attributes`, `recolor_by_attributes`, `resize_by_attributes` and `map_attributes` all have a `years` column, which is used to declare the years of data available for a particular indicator. There are 3 classes of indicators, each in its own model (they can't be merged in a single table because that's how they come out of the source dataset): `inds`, `quals` and `quants`. Any `xxx_attributes` record will be linked to one indicator of one of these 3 types. To avoid polymorphic associations these tables use the following relations:

`xxx_attributes -|---|- (one of) xxx_inds/quals/quants >---|- inds/quals/quants`

The full schema is [here](https://vizzuality.github.io/trase/all_tables/relationships.html).

The issue: The indicator values data in most cases is found in `flow_inds/quals/quants` tables, which is where the validation logic was looking for it. Except in case of `map_attributes`, data is actually found in `node_inds/quals/quants values`, so this validation was always raising an error for map attributes. 

The fix I went for was adding a separate validation which checks for indicator data in `node_inds/quals/quants values`.

To run the validation, go to /content/admin/data_validation. The process generates a json report.

https://www.pivotaltracker.com/story/show/162124123
https://github.com/Vizzuality/trase/issues/526