### PR TITLE
Validate paths length matches context node types and is minimum 4 nodes

### DIFF
--- a/app/services/api/v3/database_validation/chain_builders/context_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/context_chain_builder.rb
@@ -36,6 +36,7 @@ module Api
           checks :has_at_least_one,
                  association: :contextual_layers,
                  link: :index
+          checks :path_matches_context_node_types
           checks :active_record_check, on: :context_property, link: :edit
 
           CHAIN_BUILDERS = [

--- a/app/services/api/v3/database_validation/checks/path_matches_context_node_types.rb
+++ b/app/services/api/v3/database_validation/checks/path_matches_context_node_types.rb
@@ -1,0 +1,36 @@
+# Check if the length of paths matches number of context node types
+module Api
+  module V3
+    module DatabaseValidation
+      module Checks
+        class PathMatchesContextNodeTypes < AbstractCheck
+          # Checks the flows table
+          # @return (see AbstractCheck#passing?)
+          def passing?
+            expected_length = @object.context_node_types.count
+            @violating_flows_cnt = @object.flows.
+              where('ICOUNT(path) <> ?', expected_length).count
+            @violating_flows_cnt.zero?
+          end
+
+          def self.human_readable(_options)
+            'path length matches context node types'
+          end
+
+          private
+
+          def error
+            message = [
+              'Path length should match context node types (',
+              @violating_flows_cnt,
+              'violating flows)'
+            ].join(' ')
+            super.merge(
+              message: message
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20190110094614_add_length_restriction_to_flow_path.rb
+++ b/db/migrate/20190110094614_add_length_restriction_to_flow_path.rb
@@ -1,0 +1,19 @@
+class AddLengthRestrictionToFlowPath < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL
+          ALTER TABLE flows
+            ADD CONSTRAINT flows_path_length_check
+              CHECK (ICOUNT(path) > 3)
+        SQL
+      end
+      dir.down do
+        execute <<~SQL
+          ALTER TABLE flows
+            DROP CONSTRAINT IF EXISTS flows_path_length_check
+        SQL
+      end
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1592,7 +1592,8 @@ CREATE TABLE public.flows (
     context_id integer NOT NULL,
     year smallint NOT NULL,
     path integer[] DEFAULT '{}'::integer[],
-    created_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone NOT NULL,
+    CONSTRAINT flows_path_length_check CHECK ((public.icount(path) > 3))
 );
 
 
@@ -6236,7 +6237,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181119105022'),
 ('20181207143449'),
 ('20181210215622'),
+('20190110094614'),
 ('20190110140539'),
 ('20190111121850');
+
 
 

--- a/spec/factories/api/v3/api_v3_flows.rb
+++ b/spec/factories/api/v3/api_v3_flows.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :api_v3_flow, class: 'Api::V3::Flow' do
+    year { 2019 }
   end
 end

--- a/spec/services/api/v3/database_validation/checks/path_matches_context_node_types_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/path_matches_context_node_types_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+require 'services/api/v3/database_validation/checks/shared_check_examples'
+
+RSpec.describe Api::V3::DatabaseValidation::Checks::PathMatchesContextNodeTypes do
+  include_context 'api v3 node types'
+  let(:context) { FactoryBot.create(:api_v3_context) }
+
+  let!(:context_node_type_1) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_biome_node_type,
+      column_position: 0
+    )
+  }
+  let!(:context_node_type_2) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_state_node_type,
+      column_position: 1
+    )
+  }
+  let!(:context_node_type_3) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_municipality_node_type,
+      column_position: 2
+    )
+  }
+  let!(:context_node_type_4) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_exporter_node_type,
+      column_position: 3
+    )
+  }
+  let!(:context_node_type_5) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_country_node_type,
+      column_position: 4
+    )
+  }
+  let(:node_1) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_1.node_type)
+  }
+  let(:node_2) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_2.node_type)
+  }
+  let(:node_3) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_3.node_type)
+  }
+  let(:node_4) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_4.node_type)
+  }
+  let(:node_5) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_5.node_type)
+  }
+  let(:check) {
+    Api::V3::DatabaseValidation::Checks::PathMatchesContextNodeTypes.new(
+      context
+    )
+  }
+  let(:report_status) {
+    Api::V3::DatabaseValidation::ErrorsList.new
+  }
+
+  context 'path length matches context node types' do
+    let!(:flow) {
+      FactoryBot.create(
+        :api_v3_flow,
+        context: context,
+        path: [node_1, node_2, node_3, node_4, node_5].map(&:id)
+      )
+    }
+    include_examples 'passing checks'
+  end
+
+  context 'path length too short' do
+    let!(:flow) {
+      FactoryBot.create(
+        :api_v3_flow,
+        context: context,
+        path: [node_1, node_2, node_3, node_4].map(&:id)
+      )
+    }
+    include_examples 'failing checks'
+  end
+
+  context 'path length too long' do
+    let(:node_6) { FactoryBot.create(:api_v3_node) }
+    let!(:flow) {
+      FactoryBot.create(
+        :api_v3_flow,
+        context: context,
+        path: [node_1, node_2, node_3, node_4, node_5, node_6].map(&:id)
+      )
+    }
+    include_examples 'failing checks'
+  end
+end

--- a/spec/support/contexts/api/v3/minimum_complete_configuration.rb
+++ b/spec/support/contexts/api/v3/minimum_complete_configuration.rb
@@ -41,40 +41,69 @@ shared_context 'minimum complete configuration' do
       is_temporal_on_place_profile: true
     )
   }
-  let(:exporter_node_type) {
-    FactoryBot.create(:api_v3_node_type, name: NodeTypeName::EXPORTER)
+  let(:biome_node_type) {
+    FactoryBot.create(:api_v3_node_type, name: NodeTypeName::BIOME)
   }
   let(:municipality_node_type) {
     FactoryBot.create(:api_v3_node_type, name: NodeTypeName::MUNICIPALITY)
   }
+  let(:exporter_node_type) {
+    FactoryBot.create(:api_v3_node_type, name: NodeTypeName::EXPORTER)
+  }
   let(:country_node_type) {
     FactoryBot.create(:api_v3_node_type, name: NodeTypeName::COUNTRY)
   }
-  let(:exporter_context_node_type) {
+
+  let(:biome_node) {
+    FactoryBot.create(:api_v3_node, node_type: biome_node_type)
+  }
+  let(:municipality_node) {
+    FactoryBot.create(:api_v3_node, node_type: municipality_node_type)
+  }
+  let(:exporter_node) {
+    FactoryBot.create(:api_v3_node, node_type: exporter_node_type)
+  }
+  let(:country_node) {
+    FactoryBot.create(:api_v3_node, node_type: country_node_type)
+  }
+
+  let(:biome_context_node_type) {
     FactoryBot.create(
       :api_v3_context_node_type,
       context: context,
-      node_type: exporter_node_type
+      node_type: biome_node_type,
+      column_position: 0
     )
   }
   let(:municipality_context_node_type) {
     FactoryBot.create(
       :api_v3_context_node_type,
       context: context,
-      node_type: municipality_node_type
+      node_type: municipality_node_type,
+      column_position: 1
+    )
+  }
+  let(:exporter_context_node_type) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: exporter_node_type,
+      column_position: 2
     )
   }
   let(:country_context_node_type) {
     FactoryBot.create(
       :api_v3_context_node_type,
       context: context,
-      node_type: country_node_type
+      node_type: country_node_type,
+      column_position: 3
     )
   }
-  let!(:exporter_context_node_type_property) {
+
+  let!(:biome_context_node_type_property) {
     FactoryBot.create(
       :api_v3_context_node_type_property,
-      context_node_type: exporter_context_node_type
+      context_node_type: biome_context_node_type
     )
   }
   let!(:municipality_context_node_type_property) {
@@ -83,12 +112,19 @@ shared_context 'minimum complete configuration' do
       context_node_type: municipality_context_node_type
     )
   }
+  let!(:exporter_context_node_type_property) {
+    FactoryBot.create(
+      :api_v3_context_node_type_property,
+      context_node_type: exporter_context_node_type
+    )
+  }
   let!(:country_context_node_type_property) {
     FactoryBot.create(
       :api_v3_context_node_type_property,
       context_node_type: country_context_node_type
     )
   }
+
   let!(:actor_profile) {
     FactoryBot.create(
       :api_v3_profile,
@@ -175,7 +211,17 @@ shared_context 'minimum complete configuration' do
     FactoryBot.create(:api_v3_node_ind, ind: ind, year: 2014)
   }
   let(:flow_2014) {
-    FactoryBot.create(:api_v3_flow, context: context, year: 2014)
+    FactoryBot.create(
+      :api_v3_flow,
+      context: context,
+      path: [
+        biome_node.id,
+        municipality_node.id,
+        exporter_node.id,
+        country_node.id
+      ],
+      year: 2014
+    )
   }
   let!(:flow_quant_2014) {
     FactoryBot.create(:api_v3_flow_quant, flow: flow_2014, quant: quant)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/162124214

https://github.com/Vizzuality/trase/issues/551

This adds a new validation to help with issues resulting from incorrect structure of flow paths. The `flows` table describes the path through which a particular commodity travelled. It is a denormalized table, where the `path` column is an array of node ids. The length of that array depends on the context and should match the number of records in `context_node_types`. For practical reason the path should never be shorter than 4 nodes (because otherwise we cannot render the sankey correctly).

This PR adds
* a `CHECK` constraint on the flows path to ensure it is never shorter than 4 nodes. Adding this as a constraint on the database will crash the import process early.
* a validation that compares the number of nodes declared in `context_node_types` with the length of path for this context.