### PR TITLE
Display ZERO_DEFORESTATION as text, rather than convert to boolean

### DIFF
--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -30,7 +30,7 @@
 #  attribute_name           :text
 #  attribute_name_with_unit :text
 #  display_name             :text
-#  bool_and                 :boolean
+#  text_values              :text
 #  sum                      :float
 #  total                    :text
 #

--- a/db/migrate/20190111121850_update_download_flows_mv_to_handle_new_zd_values.rb
+++ b/db/migrate/20190111121850_update_download_flows_mv_to_handle_new_zd_values.rb
@@ -1,0 +1,8 @@
+class UpdateDownloadFlowsMvToHandleNewZdValues < ActiveRecord::Migration[5.2]
+  def change
+    update_view :download_flows_mv,
+      version: 4,
+      revert_to_version: 3,
+      materialized: true
+  end
+end

--- a/db/views/download_flows_mv_v04.sql
+++ b/db/views/download_flows_mv_v04.sql
@@ -1,0 +1,138 @@
+SELECT
+  ARRAY[
+    f_0.context_id,
+    f_0.year,
+    f_0.node_id,
+    f_1.node_id,
+    f_2.node_id,
+    f_3.node_id,
+    f_4.node_id,
+    f_5.node_id,
+    f_6.node_id,
+    f_7.node_id,
+    f_0.flow_id
+  ] AS row_name,
+  f_0.flow_id AS id,
+  f_0.context_id,
+  f_0.year,
+  f_0.name AS name_0,
+  f_1.name AS name_1,
+  f_2.name AS name_2,
+  f_3.name AS name_3,
+  f_4.name AS name_4,
+  f_5.name AS name_5,
+  f_6.name AS name_6,
+  f_7.name AS name_7,
+  f_0.node_id AS node_id_0,
+  f_1.node_id AS node_id_1,
+  f_2.node_id AS node_id_2,
+  f_3.node_id AS node_id_3,
+  f_4.node_id AS node_id_4,
+  f_5.node_id AS node_id_5,
+  f_6.node_id AS node_id_6,
+  f_7.node_id AS node_id_7,
+  CASE
+    WHEN f_5.node_type_name = 'EXPORTER' THEN f_5.node_id -- BRAZIL-SOY
+    WHEN f_2.node_type_name = 'EXPORTER' THEN f_2.node_id -- PARAGUAY-SOY, BRAZIL-BEEF
+    WHEN f_2.node_type_name = 'TRADER' THEN f_2.node_id -- ARGENTINE-SOY, ARGENTINA-BEEF, PARAGUAY-BEEF
+    WHEN f_1.node_type_name = 'EXPORTER' THEN f_1.node_id -- INDONESIA-PALM OIL
+  END AS exporter_node_id,
+  CASE
+    WHEN f_6.node_type_name = 'IMPORTER' THEN f_6.node_id -- BRAZIL-SOY
+    WHEN f_3.node_type_name = 'IMPORTER' THEN f_3.node_id -- BRAZIL-BEEF
+    WHEN f_2.node_type_name = 'IMPORTER' THEN f_2.node_id -- INDONESIA-PALM OIL
+    ELSE NULL -- OTHERS
+  END AS importer_node_id,
+  CASE
+    WHEN f_7.node_type_name = 'COUNTRY' THEN f_7.node_id -- BRAZIL-SOY
+    WHEN f_4.node_type_name = 'COUNTRY' THEN f_4.node_id -- BRAZIL-BEEF
+    WHEN f_3.node_type_name = 'COUNTRY' THEN f_3.node_id -- OTHERS
+  END AS country_node_id,
+  fi.attribute_type,
+  fi.attribute_id,
+  fi.name AS attribute_name,
+  fi.name_with_unit AS attribute_name_with_unit,
+  fi.display_name,
+  STRING_AGG(fi.text_value, ' / ') AS text_values,
+  SUM(fi.numeric_value) AS sum,
+  CASE
+    WHEN fi.attribute_type = 'Qual' THEN STRING_AGG(fi.text_value, ' / ')
+    ELSE SUM(fi.numeric_value)::TEXT
+  END AS total
+FROM flow_paths_mv f_0
+JOIN flow_paths_mv f_1 ON f_1.flow_id = f_0.flow_id AND f_1.column_position = 1
+JOIN flow_paths_mv f_2 ON f_2.flow_id = f_0.flow_id AND f_2.column_position = 2
+JOIN flow_paths_mv f_3 ON f_3.flow_id = f_0.flow_id AND f_3.column_position = 3
+LEFT JOIN flow_paths_mv f_4 ON f_4.flow_id = f_0.flow_id AND f_4.column_position = 4
+LEFT JOIN flow_paths_mv f_5 ON f_5.flow_id = f_0.flow_id AND f_5.column_position = 5
+LEFT JOIN flow_paths_mv f_6 ON f_6.flow_id = f_0.flow_id AND f_6.column_position = 6
+LEFT JOIN flow_paths_mv f_7 ON f_7.flow_id = f_0.flow_id AND f_7.column_position = 7
+JOIN (
+  SELECT
+    f.flow_id, f.qual_id AS attribute_id, 'Qual' AS attribute_type,
+    null AS numeric_value,
+    value AS text_value,
+    q.name,
+    null AS unit,
+    q.name AS name_with_unit,
+    da.display_name,
+    da.context_id
+  FROM flow_quals f
+  JOIN quals q ON f.qual_id = q.id
+  JOIN download_quals dq ON dq.qual_id = q.id
+  JOIN download_attributes da ON dq.download_attribute_id = da.id
+  GROUP BY f.flow_id, f.qual_id, f.value, q.name, da.display_name, da.context_id
+
+  UNION ALL
+
+  SELECT
+    f.flow_id, f.quant_id, 'Quant',
+    f.value,
+    null,
+    q.name,
+    q.unit,
+    CASE
+      WHEN unit IS null THEN q.name
+      ELSE q.name || ' (' || q.unit || ')'
+    END,
+    da.display_name,
+    da.context_id
+  FROM flow_quants f
+  JOIN quants q ON f.quant_id = q.id
+  JOIN download_quants dq ON dq.quant_id = q.id
+  JOIN download_attributes da ON dq.download_attribute_id = da.id
+  GROUP BY f.flow_id, f.quant_id, f.value, q.name, q.unit, da.display_name, da.context_id
+) fi ON f_0.flow_id = fi.flow_id AND f_0.context_id = fi.context_id
+WHERE f_0.column_position = 0
+GROUP BY
+  f_0.flow_id,
+  f_0.context_id,
+  f_0.year,
+  f_0.name,
+  f_0.node_id,
+  f_1.name,
+  f_1.node_id,
+  f_1.node_type_name,
+  f_2.name,
+  f_2.node_id,
+  f_2.node_type_name,
+  f_3.name,
+  f_3.node_id,
+  f_3.node_type_name,
+  f_4.name,
+  f_4.node_id,
+  f_4.node_type_name,
+  f_5.name,
+  f_5.node_id,
+  f_5.node_type_name,
+  f_6.name,
+  f_6.node_id,
+  f_6.node_type_name,
+  f_7.name,
+  f_7.node_id,
+  f_7.node_type_name,
+  fi.attribute_type,
+  fi.attribute_id,
+  fi.name,
+  fi.name_with_unit,
+  fi.display_name;


### PR DESCRIPTION
When this was first built, the values of ZERO_DEFORESTATION were either "yes" or "no", so the conversion to boolean worked great (the reason for the conversion was that values need to be aggregated, and that worked well with booleans). Now that the value can be any text, I needed to remove the conversion and have the textual values displayed as is, with string aggregation in case of conflicting values.