### PR TITLE
Validate that column positions in flow paths match context_node_types

### DIFF
--- a/app/services/api/v3/database_validation/chain_builders/context_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/context_chain_builder.rb
@@ -37,6 +37,7 @@ module Api
                  association: :contextual_layers,
                  link: :index
           checks :path_matches_context_node_types
+          checks :path_positions_match_context_node_types
           checks :active_record_check, on: :context_property, link: :edit
 
           CHAIN_BUILDERS = [

--- a/app/services/api/v3/database_validation/chain_builders/context_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/context_chain_builder.rb
@@ -36,7 +36,7 @@ module Api
           checks :has_at_least_one,
                  association: :contextual_layers,
                  link: :index
-          checks :path_matches_context_node_types
+          checks :path_length_matches_context_node_types
           checks :path_positions_match_context_node_types
           checks :active_record_check, on: :context_property, link: :edit
 

--- a/app/services/api/v3/database_validation/checks/path_length_matches_context_node_types.rb
+++ b/app/services/api/v3/database_validation/checks/path_length_matches_context_node_types.rb
@@ -4,6 +4,8 @@ module Api
     module DatabaseValidation
       module Checks
         class PathLengthMatchesContextNodeTypes < AbstractCheck
+          include ErrorMessageWithViolatingFlows
+
           # Checks the flows table
           # @return (see AbstractCheck#passing?)
           def passing?
@@ -21,23 +23,10 @@ module Api
           private
 
           def error
-            violating_ids, n_more =
-              if @violating_flows.size > 10
-                [@violating_flows[0..9], @violating_flows.size - 10]
-              else
-                [@violating_flows, nil]
-              end
-            violating_ids_message = violating_ids.join(', ')
-            violating_ids_message += " and #{n_more} more" if n_more
-
-            message = [
-              'Path length should match context node types ',
-              '(violating flows ids: ',
-              violating_ids_message,
-              ')'
-            ].join('')
             super.merge(
-              message: message
+              message: error_message(
+                'Path length should match context node types'
+              )
             )
           end
         end

--- a/app/services/api/v3/database_validation/checks/path_length_matches_context_node_types.rb
+++ b/app/services/api/v3/database_validation/checks/path_length_matches_context_node_types.rb
@@ -3,7 +3,7 @@ module Api
   module V3
     module DatabaseValidation
       module Checks
-        class PathMatchesContextNodeTypes < AbstractCheck
+        class PathLengthMatchesContextNodeTypes < AbstractCheck
           # Checks the flows table
           # @return (see AbstractCheck#passing?)
           def passing?

--- a/app/services/api/v3/database_validation/checks/path_positions_match_context_node_types.rb
+++ b/app/services/api/v3/database_validation/checks/path_positions_match_context_node_types.rb
@@ -5,6 +5,8 @@ module Api
     module DatabaseValidation
       module Checks
         class PathPositionsMatchContextNodeTypes < AbstractCheck
+          include ErrorMessageWithViolatingFlows
+
           # Checks the flows table, expanding paths in a subjquery
           # to get node types for each node and compares
           # node_type_id + position from path versus that declared
@@ -53,23 +55,10 @@ module Api
           end
 
           def error
-            violating_ids, n_more =
-              if @violating_flows.size > 10
-                [@violating_flows[0..9], @violating_flows.size - 10]
-              else
-                [@violating_flows, nil]
-              end
-            violating_ids_message = violating_ids.join(', ')
-            violating_ids_message += " and #{n_more} more" if n_more
-
-            message = [
-              'Path node types should match context node types ',
-              '(violating flows ids: ',
-              violating_ids_message,
-              ')'
-            ].join('')
             super.merge(
-              message: message
+              message: error_message(
+                'Path positions should match context node types'
+              )
             )
           end
         end

--- a/app/services/api/v3/database_validation/checks/path_positions_match_context_node_types.rb
+++ b/app/services/api/v3/database_validation/checks/path_positions_match_context_node_types.rb
@@ -1,0 +1,79 @@
+# Check if positions of nodes in flow paths match declared positions
+# in context_node_types.
+module Api
+  module V3
+    module DatabaseValidation
+      module Checks
+        class PathPositionsMatchContextNodeTypes < AbstractCheck
+          # Checks the flows table, expanding paths in a subjquery
+          # to get node types for each node and compares
+          # node_type_id + position from path versus that declared
+          # in context_node_types.
+          # @return (see AbstractCheck#passing?)
+          def passing?
+            @violating_flows = Api::V3::Flow.
+              select('a.id').
+              from(
+                <<~SQL
+                  (
+                    #{actual_column_positions_subquery.to_sql}
+                  ) a
+                  LEFT JOIN (
+                    #{expected_column_positions_subquery.to_sql}
+                  ) e ON a.position = (e.column_position + 1)
+                    AND a.node_type_id = e.node_type_id
+                SQL
+              ).where('e.node_type_id' => nil).
+              group('a.id').
+              pluck('a.id')
+            @violating_flows.none?
+          end
+
+          def self.human_readable(_options)
+            'declared column positions match data'
+          end
+
+          private
+
+          def actual_column_positions_subquery
+            Api::V3::Flow.
+              select('flows.id', 'a."position"', 'nodes.node_type_id').
+              from(
+                'flows, LATERAL unnest(flows.path) WITH ORDINALITY a(node_id, "position")'
+              ).
+              joins('JOIN nodes ON nodes.id = a.node_id').
+              where(context_id: @object.id).
+              group('flows.id', 'a."position"', 'nodes.node_type_id')
+          end
+
+          def expected_column_positions_subquery
+            Api::V3::ContextNodeType.select(
+              :context_id, :node_type_id, :column_position
+            ).where(context_id: @object.id)
+          end
+
+          def error
+            violating_ids, n_more =
+              if @violating_flows.size > 10
+                [@violating_flows[0..9], @violating_flows.size - 10]
+              else
+                [@violating_flows, nil]
+              end
+            violating_ids_message = violating_ids.join(', ')
+            violating_ids_message += " and #{n_more} more" if n_more
+
+            message = [
+              'Path node types should match context node types ',
+              '(violating flows ids: ',
+              violating_ids_message,
+              ')'
+            ].join('')
+            super.merge(
+              message: message
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/concerns/api/v3/database_validation/checks/error_message_with_violating_flows.rb
+++ b/app/services/concerns/api/v3/database_validation/checks/error_message_with_violating_flows.rb
@@ -1,0 +1,34 @@
+require 'active_support/concern'
+
+module Api
+  module V3
+    module DatabaseValidation
+      module Checks
+        module ErrorMessageWithViolatingFlows
+          extend ActiveSupport::Concern
+
+          N = 10
+
+          def error_message(prefix)
+            violating_flows_cnt = @violating_flows.size
+            violating_ids, n_more =
+              if violating_flows_cnt > N
+                [@violating_flows[0..(N - 1)], violating_flows_cnt - N]
+              else
+                [@violating_flows, nil]
+              end
+            violating_ids_message = violating_ids.join(', ')
+            violating_ids_message += " and #{n_more} more" if n_more
+
+            [
+              prefix,
+              ' (violating flows ids: ',
+              violating_ids_message,
+              ')'
+            ].join('')
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/concerns/api/v3/database_validation/checks/error_message_with_violating_flows.rb
+++ b/app/services/concerns/api/v3/database_validation/checks/error_message_with_violating_flows.rb
@@ -7,13 +7,16 @@ module Api
         module ErrorMessageWithViolatingFlows
           extend ActiveSupport::Concern
 
-          N = 10
+          MAX_IDS_TO_SHOW = 10
 
           def error_message(prefix)
             violating_flows_cnt = @violating_flows.size
             violating_ids, n_more =
-              if violating_flows_cnt > N
-                [@violating_flows[0..(N - 1)], violating_flows_cnt - N]
+              if violating_flows_cnt > MAX_IDS_TO_SHOW
+                [
+                  @violating_flows[0..(MAX_IDS_TO_SHOW - 1)],
+                  violating_flows_cnt - MAX_IDS_TO_SHOW
+                ]
               else
                 [@violating_flows, nil]
               end

--- a/spec/services/api/v3/database_validation/checks/path_length_matches_context_node_types_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/path_length_matches_context_node_types_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'services/api/v3/database_validation/checks/shared_check_examples'
 
-RSpec.describe Api::V3::DatabaseValidation::Checks::PathMatchesContextNodeTypes do
+RSpec.describe Api::V3::DatabaseValidation::Checks::PathLengthMatchesContextNodeTypes do
   include_context 'api v3 node types'
   let(:context) { FactoryBot.create(:api_v3_context) }
 
@@ -61,7 +61,7 @@ RSpec.describe Api::V3::DatabaseValidation::Checks::PathMatchesContextNodeTypes 
     FactoryBot.create(:api_v3_node, node_type: context_node_type_5.node_type)
   }
   let(:check) {
-    Api::V3::DatabaseValidation::Checks::PathMatchesContextNodeTypes.new(
+    Api::V3::DatabaseValidation::Checks::PathLengthMatchesContextNodeTypes.new(
       context
     )
   }

--- a/spec/services/api/v3/database_validation/checks/path_positions_match_context_node_types_spec.rb
+++ b/spec/services/api/v3/database_validation/checks/path_positions_match_context_node_types_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+require 'services/api/v3/database_validation/checks/shared_check_examples'
+
+RSpec.describe Api::V3::DatabaseValidation::Checks::PathPositionsMatchContextNodeTypes do
+  include_context 'api v3 node types'
+
+  let(:context) { FactoryBot.create(:api_v3_context) }
+  let!(:context_node_type_1) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_biome_node_type,
+      column_position: 0
+    )
+  }
+  let!(:context_node_type_2) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_state_node_type,
+      column_position: 1
+    )
+  }
+  let!(:context_node_type_3) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_municipality_node_type,
+      column_position: 2
+    )
+  }
+  let!(:context_node_type_4) {
+    FactoryBot.create(
+      :api_v3_context_node_type,
+      context: context,
+      node_type: api_v3_exporter_node_type,
+      column_position: 3
+    )
+  }
+  let(:node_1) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_1.node_type)
+  }
+  let(:node_2) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_2.node_type)
+  }
+  let(:node_3) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_3.node_type)
+  }
+  let(:node_4) {
+    FactoryBot.create(:api_v3_node, node_type: context_node_type_4.node_type)
+  }
+
+  let(:check) {
+    Api::V3::DatabaseValidation::Checks::PathPositionsMatchContextNodeTypes.new(context)
+  }
+  let(:report_status) {
+    Api::V3::DatabaseValidation::ErrorsList.new
+  }
+  context 'when node types don\'t match positions' do
+    let!(:flow) {
+      FactoryBot.create(
+        :api_v3_flow,
+        context: context,
+        path: [node_4, node_1, node_2, node_3].map(&:id)
+      )
+    }
+    include_examples 'failing checks'
+  end
+
+  context 'when node types match positions' do
+    let!(:flow) {
+      FactoryBot.create(
+        :api_v3_flow,
+        context: context,
+        path: [node_1, node_2, node_3, node_4].map(&:id)
+      )
+    }
+    include_examples 'passing checks'
+  end
+end


### PR DESCRIPTION
https://github.com/Vizzuality/trase/issues/540

This adds a new validation, which again has to do with flow paths. This one checks that the node ids on respective path positions correspond to records in the `context_node_types` table. For example, for Brazil-soy context the node in first position should be a BIOME. To check for offenders it runs a query which normalizes flows (by `UNNEST`ing the paths with `ORDINALITY` to get the actual positions), gets the actual node types and positions and cross checks that with expected node types on these positions from `context_node_types`, looking for mismatched flows.