### PR TITLE
Fix/precompute pivot downloads not table

### DIFF
--- a/app/services/api/v3/download/precomputed_download.rb
+++ b/app/services/api/v3/download/precomputed_download.rb
@@ -29,7 +29,7 @@ module Api
         class << self
           def clear
             FileUtils.rm_rf(
-              Api::V3::Download::PrecomputedDownload::ROOT_DIRNAME,
+              Dir.glob("#{Api::V3::Download::PrecomputedDownload::ROOT_DIRNAME}/*"),
               secure: true
             )
             Cache::Cleaner.clear_cache_for_regexp('/api/v3/contexts/.+.csv$')

--- a/app/workers/precomputed_download_refresh_worker.rb
+++ b/app/workers/precomputed_download_refresh_worker.rb
@@ -16,7 +16,7 @@ class PrecomputedDownloadRefreshWorker
   # @option options [Boolean] :skip_dependents skip refreshing
   def perform(context_id, options)
     context = Api::V3::Context.find(context_id)
-    Api::V3::Download::FlowDownload.new(context, options).
+    Api::V3::Download::FlowDownload.new(context, options.symbolize_keys).
       zipped_csv
   end
 end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :deploy_to, '/var/www/trase'
 append :linked_files, '.env', 'frontend/.env', 'frontend/dist/robots.txt'
 
 # Default value for linked_dirs is []
-append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system', 'vendor/bundle'
+append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system', 'public/downloads', 'vendor/bundle'
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }

--- a/spec/services/api/v3/download/parameters_spec.rb
+++ b/spec/services/api/v3/download/parameters_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Download::Parameters do
+  let(:context) { FactoryBot.create(:api_v3_context) }
+
+  describe :precompute? do
+    context 'when filters present' do
+      let(:subject) {
+        Api::V3::Download::Parameters.new(context, years: [2019])
+      }
+      it 'is false' do
+        expect(subject.precompute?).to be(false)
+      end
+    end
+    context 'when no filters present and pivot' do
+      let(:subject) {
+        Api::V3::Download::Parameters.new(context, pivot: true)
+      }
+      it 'is true' do
+        expect(subject.precompute?).to be(true)
+      end
+    end
+    context 'when no filters present and no pivot' do
+      let(:subject) {
+        Api::V3::Download::Parameters.new(context, {})
+      }
+      it 'is true' do
+        expect(subject.precompute?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/workers/precomputed_download_refresh_worker_spec.rb
+++ b/spec/workers/precomputed_download_refresh_worker_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe PrecomputedDownloadRefreshWorker, type: :worker do
+  Sidekiq::Testing.inline!
+
+  describe :call do
+    before(:each) do
+      Api::V3::Readonly::DownloadFlow.refresh(sync: true)
+    end
+
+    let(:context) { FactoryBot.create(:api_v3_context) }
+    it 'symbolizes options keys' do
+      expect(Api::V3::Download::FlowDownload).to receive(:new).
+        with(context, pivot: true).and_call_original
+      PrecomputedDownloadRefreshWorker.perform_async(context.id, pivot: true)
+    end
+  end
+end


### PR DESCRIPTION
This is an important fix for the precomputed downloads feature:
- when it runs in a worker, the precomputed download deserialises the options hash with stringy keys; which means that options hash does not work in the download generation logic, which expects symbolic keys, so options need to be symbolised; otherewise it would precompute "table" downloads, instead of the intended "pivot" downloads;
- previously the downloads directory used to be removed completely when refreshing, which is why it was not kept between releases; on second thoughts I think it's better (less unexpected and more similar to public/system) to clear the contents under that directory when refreshing, and keep the directory itself as a linked dir between releases.