### PR TITLE
Fix: minor ui fixes

### DIFF
--- a/frontend/html/tool.ejs
+++ b/frontend/html/tool.ejs
@@ -139,8 +139,8 @@
         </div>
 
         <div class="c-titlebar">
-          <div class="c-nodes-titles js-nodes-titles">
-            <div class="nodes-titles-container js-nodes-titles-container"></div>
+          <div class="c-node-title-group js-nodes-titles">
+            <div class="js-nodes-titles-container"></div>
             <div class="c-nodes-clear js-nodes-titles-clear is-hidden">
               <div class="button icon-button">
                 <svg class="icon"><use xlink:href="#icon-close"></use></svg>

--- a/frontend/scripts/react-components/shared/dropdown.component.jsx
+++ b/frontend/scripts/react-components/shared/dropdown.component.jsx
@@ -6,8 +6,11 @@ import PropTypes from 'prop-types';
 
 export default class Dropdown extends Component {
   state = {
-    isOpen: false
+    isOpen: false,
+    listHeight: null
   };
+
+  listItemRef = React.createRef();
 
   componentDidMount() {
     window.addEventListener('keyup', this.handleKeyUpOutside);
@@ -19,6 +22,20 @@ export default class Dropdown extends Component {
     document.removeEventListener('keyup', this.handleKeyUpOutside);
     document.removeEventListener('mouseup', this.handleClickOutside);
     document.removeEventListener('touchend', this.handleClickOutside);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if (this.listItemRef.current && prevState.listHeight === null) {
+      this.setListHeight();
+    }
+  }
+
+  setListHeight() {
+    const { height } = this.listItemRef.current.getBoundingClientRect();
+    if (height > 0) {
+      const listHeight = height * 6 - height / 2;
+      this.setState({ listHeight });
+    }
   }
 
   onDropdownValueClicked = (e, value) => {
@@ -72,12 +89,14 @@ export default class Dropdown extends Component {
           {valueRenderer ? valueRenderer(value) : value}
         </span>
         <ul
+          style={this.state.listHeight ? { maxHeight: this.state.listHeight } : undefined}
           className={cx('dropdown-list', {
             'is-hidden': !this.state.isOpen
           })}
         >
           {valueList.map((elem, index) => (
             <li
+              ref={index === 0 ? this.listItemRef : undefined}
               className={cx('dropdown-item', getItemClassName(elem))}
               key={index}
               onClick={e => this.onDropdownValueClicked(e, elem)}

--- a/frontend/scripts/react-components/shared/dropdown.component.jsx
+++ b/frontend/scripts/react-components/shared/dropdown.component.jsx
@@ -10,6 +10,8 @@ export default class Dropdown extends Component {
     listHeight: null
   };
 
+  static DEFAULT_MAX_LIST_HEIGHT = 265;
+
   listItemRef = React.createRef();
 
   componentDidMount() {
@@ -32,7 +34,7 @@ export default class Dropdown extends Component {
 
   setListHeight() {
     const { height } = this.listItemRef.current.getBoundingClientRect();
-    if (height > 0) {
+    if (height > 0 && height * this.props.valueList.length > Dropdown.DEFAULT_MAX_LIST_HEIGHT) {
       const listHeight = height * 6 - height / 2;
       this.setState({ listHeight });
     }

--- a/frontend/scripts/react-components/shared/sentence-selector/sentence-selector.container.js
+++ b/frontend/scripts/react-components/shared/sentence-selector/sentence-selector.container.js
@@ -13,7 +13,7 @@ function mapStateToProps(state) {
   const contexts = getSortedContexts(state);
   const selectedCountryPairs = getSelectedCountryPairs(state);
   const selectedCommodityPairs = getSelectedCommodityPairs(state);
-  console.log(selectedCountryPairs);
+
   return {
     contexts,
     selectedCountryPairs,

--- a/frontend/scripts/react-components/shared/sentence-selector/sentence-selector.scss
+++ b/frontend/scripts/react-components/shared/sentence-selector/sentence-selector.scss
@@ -72,8 +72,6 @@
       min-width: 120px;
       right: 0;
       left: auto;
-      overflow-y: scroll;
-      overflow-x: hidden;
 
       > .dropdown-item {
         color: $charcoal-grey;

--- a/frontend/styles/_settings.scss
+++ b/frontend/styles/_settings.scss
@@ -1,6 +1,6 @@
 // layout
 $nav-height: 64px;
-$titlebar-height: 56px;
+$titlebar-height: 62px;
 $map-width: 320px;
 $layer-map-width: 376px;
 $feedback-button-closed-width: 45px;

--- a/frontend/styles/components/shared/dropdown.scss
+++ b/frontend/styles/components/shared/dropdown.scss
@@ -121,6 +121,7 @@
   }
 
   .dropdown-list > .dropdown-item {
+    color: $charcoal-grey;
     padding: 10px 25px;
     font-family: $font-family-2;
     font-size: $font-size-xx-regular;

--- a/frontend/styles/layouts/l-tool.scss
+++ b/frontend/styles/layouts/l-tool.scss
@@ -115,11 +115,13 @@ body {
     }
 
     > .c-titlebar {
+      display: flex;
+      align-items: center;
       position: absolute;
       left: $layer-map-width;
       top: calc(100% - #{$titlebar-height});
       width: calc(100% - #{$layer-map-width + $feedback-button-closed-width + 8});
-      height: $titlebar-height + 5px; /* some extra space for scrollbar */
+      height: $titlebar-height;
       padding-left: 8px;
       overflow-x: auto;
       overflow-y: hidden;


### PR DESCRIPTION
This PR addresses the following two issues:
- User can't really tell that there's mote options available in a dropdown. Now we purposely show only the half of last item.

- Clear nodes button in `/flows` page footer bar was broken. Fixes regression.