### PR TITLE
Feat: hide empty profile widgets

### DIFF
--- a/frontend/scripts/react-components/profile-node/profile-node-widgets/importing-companies-widget.component.jsx
+++ b/frontend/scripts/react-components/profile-node/profile-node-widgets/importing-companies-widget.component.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { defaultMemoize } from 'reselect';
 import Widget from 'react-components/widgets/widget.component';
 import { GET_ACTOR_EXPORTING_COMPANIES, GET_NODE_SUMMARY_URL } from 'utils/getURLFromParams';
 import Scatterplot from 'react-components/profiles/scatterplot/scatterplot.component';
@@ -11,6 +12,10 @@ class ImportingCompaniesWidget extends React.PureComponent {
   state = {
     tooltipConfig: null
   };
+
+  getDimensions = defaultMemoize((dimensionsX, companies) =>
+    dimensionsX.filter((_, index) => companies.some(company => company.x[index] !== null))
+  );
 
   getScatterplots(dimensionsX, title) {
     const { printMode } = this.props;
@@ -71,7 +76,12 @@ class ImportingCompaniesWidget extends React.PureComponent {
           const { dimensionsX, companies } = data[GET_ACTOR_EXPORTING_COMPANIES];
           const { nodeName, columnName } = data[GET_NODE_SUMMARY_URL];
           const verb = columnName === 'EXPORTER' ? 'exporting' : 'importing';
-          const dimensions = dimensionsX.slice(0, 3);
+          const dimensions = this.getDimensions(dimensionsX, companies);
+
+          if (dimensions.length === 0) {
+            return null;
+          }
+
           const title = `Comparing companies ${verb} ${commodityName} from ${countryName} in ${year}`;
           const scatterplots = this.getScatterplots(dimensions, title);
           return (

--- a/frontend/scripts/react-components/profiles/dropdown-tab-switcher/dropdown-tab-switcher.component.jsx
+++ b/frontend/scripts/react-components/profiles/dropdown-tab-switcher/dropdown-tab-switcher.component.jsx
@@ -43,13 +43,15 @@ class DropdownTabSwitcher extends Component {
             </Heading>
             {titleTooltip && <Tooltip text={titleTooltip} />}
           </div>
-          <Tabs
-            tabs={items}
-            testId={testId}
-            onSelectTab={this.onSelectTab}
-            itemTabRenderer={itemTabRenderer}
-            selectedTab={items[selectedIndex]}
-          />
+          {items.length > 2 && (
+            <Tabs
+              tabs={items}
+              testId={testId}
+              onSelectTab={this.onSelectTab}
+              itemTabRenderer={itemTabRenderer}
+              selectedTab={items[selectedIndex]}
+            />
+          )}
         </div>
         <div className="dropdown-switcher show-for-small">
           <Dropdown

--- a/frontend/scripts/react-components/profiles/dropdown-tab-switcher/dropdown-tab-switcher.component.jsx
+++ b/frontend/scripts/react-components/profiles/dropdown-tab-switcher/dropdown-tab-switcher.component.jsx
@@ -43,7 +43,7 @@ class DropdownTabSwitcher extends Component {
             </Heading>
             {titleTooltip && <Tooltip text={titleTooltip} />}
           </div>
-          {items.length > 2 && (
+          {items.length > 1 && (
             <Tabs
               tabs={items}
               testId={testId}

--- a/frontend/scripts/react-components/profiles/scatterplot/scatterplot.component.jsx
+++ b/frontend/scripts/react-components/profiles/scatterplot/scatterplot.component.jsx
@@ -175,12 +175,11 @@ class Scatterplot extends Component {
   _getFormattedData(i) {
     const { data, node } = this.props;
     const currentComesLast = a => (a.isCurrent ? 1 : -1);
-
     return data
       .map(item => ({
         nodeId: item.id,
         name: item.name,
-        isCurrent: item.name.toUpperCase() === (node.name && node.name.toUpperCase()),
+        isCurrent: item.id === node.id,
         y: item.y,
         x: item.x[i]
       }))

--- a/frontend/scripts/react-components/profiles/scatterplot/scatterplot.component.jsx
+++ b/frontend/scripts/react-components/profiles/scatterplot/scatterplot.component.jsx
@@ -179,7 +179,7 @@ class Scatterplot extends Component {
       .map(item => ({
         nodeId: item.id,
         name: item.name,
-        isCurrent: item.id === node.id,
+        isCurrent: item.name.toUpperCase() === (node.name && node.name.toUpperCase()),
         y: item.y,
         x: item.x[i]
       }))

--- a/frontend/scripts/react-components/profiles/top-destinations-chart.component.jsx
+++ b/frontend/scripts/react-components/profiles/top-destinations-chart.component.jsx
@@ -101,10 +101,7 @@ class TopDestinationsChart extends React.PureComponent {
               />
             )}
           </div>
-          <div
-            className="top-destinations-chart-container"
-            style={{ ...heightStyle, width: '100%' }}
-          >
+          <div className="top-destinations-chart-wrapper" style={{ ...heightStyle, width: '100%' }}>
             <TranslatedLine
               onLinkClick={this.handleLinkClick}
               profileType={profileType}

--- a/frontend/styles/layouts/l-profile-actor.scss
+++ b/frontend/styles/layouts/l-profile-actor.scss
@@ -1,6 +1,7 @@
 @import 'styles/settings';
 
-$small-line-chart-width: 840px;
+$medium-line-chart-width: 490px;
+$large-line-chart-width: 840px;
 
 .l-profile-actor {
   position: relative;
@@ -146,14 +147,23 @@ $small-line-chart-width: 840px;
     align-items: flex-start;
   }
 
-  .top-destinations-chart-container {
+  .top-destinations-chart-container,
+  .top-destinations-chart-wrapper {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    height: 100%;
+  }
 
-    @media screen and (min-width: $small-line-chart-width) {
-      padding: 0 0 60px;
+  .top-destinations-chart-container {
+    height: 100%;
+    padding: 0 0 60px;
+
+    @media screen and (min-width: $medium-line-chart-width) and (max-width: $breakpoint-foundation-small) {
+      padding: 0;
+    }
+
+    @media screen and (min-width: $large-line-chart-width) {
+      padding: 0;
     }
   }
 


### PR DESCRIPTION
This PR hides the scatterplot and the tab switcher when there's no data.