### PR TITLE
Sorting out a few things in the data uploader

### DIFF
--- a/app/models/api/v3/chart_ind.rb
+++ b/app/models/api/v3/chart_ind.rb
@@ -28,7 +28,7 @@ module Api
 
       def self.yellow_foreign_keys
         [
-          {name: :chart_attribute_id, table_class: Api::V3::Chart}
+          {name: :chart_attribute_id, table_class: Api::V3::ChartAttribute}
         ]
       end
 

--- a/app/models/api/v3/chart_qual.rb
+++ b/app/models/api/v3/chart_qual.rb
@@ -28,7 +28,7 @@ module Api
 
       def self.yellow_foreign_keys
         [
-          {name: :chart_attribute_id, table_class: Api::V3::Chart}
+          {name: :chart_attribute_id, table_class: Api::V3::ChartAttribute}
         ]
       end
 

--- a/app/models/api/v3/chart_quant.rb
+++ b/app/models/api/v3/chart_quant.rb
@@ -28,7 +28,7 @@ module Api
 
       def self.yellow_foreign_keys
         [
-          {name: :chart_attribute_id, table_class: Api::V3::Chart}
+          {name: :chart_attribute_id, table_class: Api::V3::ChartAttribute}
         ]
       end
 

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -60,8 +60,10 @@ module Api
             refresh_by_name('flow_paths_mv', concurrently: false) # no unique index
           end
 
-          def after_refresh(_options = {})
-            Api::V3::Download::PrecomputedDownload.refresh
+          def after_refresh(options = {})
+            Api::V3::Download::PrecomputedDownload.clear
+            return if options[:skip_precompute]
+            Api::V3::Download::PrecomputedDownload.refresh_later
           end
         end
       end

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -18,11 +18,12 @@ module Api
           Api::V3::BaseModel.transaction do
             backup
             import
-            @database_update.finished_with_success(@stats.to_h)
           end
+          yield if block_given?
           refresh
           Cache::Cleaner.clear_all
           Cache::Warmer::UrlsFile.generate
+          @database_update.finished_with_success(@stats.to_h)
         rescue => e
           @database_update.finished_with_error(e, @stats.to_h)
           raise # re-raise same error

--- a/app/services/api/v3/import/mirror_import.rb
+++ b/app/services/api/v3/import/mirror_import.rb
@@ -11,12 +11,11 @@ module Api
           timer_stats['import'] = Timer.with_timer do
             Api::V3::Import::Importer.new(
               database_update, ENV['TRASE_LOCAL_MIRROR_SCHEMA']
-            ).call
+            ).call { schema_importer.cleanup }
           end
           stats = database_update.reload.stats
           stats['elapsed_seconds'] = timer_stats
           database_update.update_stats(stats)
-          schema_importer.cleanup
         end
       end
     end


### PR DESCRIPTION
A few things:
- delete the temporary schema used for importing data as soon as possible to reduce spike in disk usage
- while materialized views should be refreshed synchronously as part of the process, precomputed downloads can be generated asynchronously after the upload is finished
- finally, there was a stupid mistake because of which chart attributes would get lost after update