### PR TITLE
Feature/dashboard testing

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
@@ -83,7 +83,7 @@ export function* getDashboardPanelSectionTabs(dashboardElement, optionsType) {
   }
 }
 
-function* removeLoadingSpinner() {
+export function* removeLoadingSpinner() {
   yield delay(1000);
   yield put(setDashboardPanelLoadingItems(false));
 }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -168,7 +168,8 @@ const dashboardElementReducer = {
     const { panel, activeTab } = action.payload;
     const panelName = `${panel}Panel`;
     const prevTab = state[panelName].activeTab;
-    const clearedActiveTabData = prevTab ? { [prevTab.id]: null } : {};
+    const clearedActiveTabData =
+      prevTab && prevTab.id !== activeTab.id ? { [prevTab.id]: null } : {};
 
     return {
       ...state,
@@ -191,7 +192,8 @@ const dashboardElementReducer = {
     const { panel, activeItem } = action.payload;
     const panelName = `${panel}Panel`;
     const prevTab = state[panelName].activeTab;
-    const clearedActiveTabData = prevTab ? { [prevTab.id]: null } : {};
+    const clearedActiveTabData =
+      prevTab && prevTab.id !== activeItem.nodeTypeId ? { [prevTab.id]: null } : {};
     const activeTab =
       state.tabs[panel] && state.tabs[panel].find(tab => tab.id === activeItem.nodeTypeId);
 

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -127,12 +127,12 @@ function* fetchDataOnPageChange() {
   yield takeLatest(DASHBOARD_ELEMENT__SET_PANEL_PAGE, onPageChange);
 }
 
-function* fetchDataOnStepChange() {
-  function* onStepChange() {
-    const { dashboardElement } = yield select();
-    yield fork(getDashboardPanelData, dashboardElement, 'indicators');
-  }
+export function* onStepChange() {
+  const { dashboardElement } = yield select();
+  yield fork(getDashboardPanelData, dashboardElement, 'indicators');
+}
 
+function* fetchDataOnStepChange() {
   yield takeLatest(DASHBOARD_ELEMENT__OPEN_INDICATORS_STEP, onStepChange);
 }
 

--- a/frontend/scripts/tests/dashboard-element/fetch.saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/fetch.saga.test.js
@@ -1,0 +1,236 @@
+import { put, cancelled, call } from 'redux-saga/effects';
+import { fetchWithCancel } from 'react-components/dashboard-element/fetch-with-cancel';
+
+import {
+  getDashboardPanelData,
+  getDashboardPanelSectionTabs,
+  fetchDashboardPanelSearchResults,
+  getMoreDashboardPanelData,
+  removeLoadingSpinner
+} from 'react-components/dashboard-element/dashboard-element.fetch.saga';
+import {
+  DASHBOARD_ELEMENT__SET_PANEL_DATA,
+  DASHBOARD_ELEMENT__SET_PANEL_TABS,
+  DASHBOARD_ELEMENT__SET_SEARCH_RESULTS,
+  DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
+  DASHBOARD_ELEMENT__SET_LOADING_ITEMS
+} from 'react-components/dashboard-element/dashboard-element.actions';
+import { getURLFromParams } from 'utils/getURLFromParams';
+
+jest.mock('react-components/dashboard-element/fetch-with-cancel', () => ({
+  fetchWithCancel: jest.fn()
+}));
+
+jest.mock('utils/getURLFromParams', () => ({
+  getURLFromParams: jest.fn()
+}));
+
+const dashboardElement = {
+  data: {
+    indicators: [],
+    countries: [
+      {
+        id: 23,
+        name: 'BOLIVIA'
+      }
+    ]
+  },
+  meta: {},
+  tabs: {
+    sources: [{ id: 1, name: 'BIOME' }]
+  },
+  activePanelId: 'sources',
+  activeIndicatorsList: [],
+  sourcesPanel: {
+    page: 1,
+    searchResults: [],
+    loadingItems: false,
+    activeItem: null,
+    activeTab: {
+      id: 1,
+      name: 'BIOME'
+    }
+  },
+  companiesPanel: {},
+  countriesPanel: {},
+  destinationsPanel: {},
+  commoditiesPanel: {}
+};
+
+const someUrl = 'http://trase.earth';
+const sourceMock = { cancel: jest.fn() };
+getURLFromParams.mockImplementation(() => someUrl);
+fetchWithCancel.mockImplementation(() => ({ source: sourceMock, fetchPromise: () => {} }));
+
+describe('getDashboardPanelData', () => {
+  const data = {
+    data: { hello: 1 },
+    meta: {}
+  };
+  const optionsType = 'companies';
+  const options = undefined; // Do we use this page param?
+  jest.mock('utils/getURLFromParams', () => ({
+    getURLFromParams: jest.fn()
+  }));
+
+  it('Calls DASHBOARD_ELEMENT__SET_PANEL_DATA action to clear data', () => {
+    const generator = getDashboardPanelData(dashboardElement, optionsType, options);
+    expect(generator.next().value).toEqual(
+      put({
+        type: DASHBOARD_ELEMENT__SET_PANEL_DATA,
+        payload: {
+          key: optionsType,
+          tab: 1,
+          data: null,
+          meta: null,
+          loading: true
+        }
+      })
+    );
+    generator.next();
+    expect(generator.next({ data }).value).toEqual(
+      put({
+        type: DASHBOARD_ELEMENT__SET_PANEL_DATA,
+        payload: {
+          key: optionsType,
+          tab: 1,
+          data: data.data,
+          meta: data.meta,
+          loading: false
+        }
+      })
+    );
+  });
+
+  it('Calls DASHBOARD_ELEMENT__SET_PANEL_DATA action to clear data and Cancels if the fetch is cancelled', () => {
+    const generator = getDashboardPanelData(dashboardElement, optionsType, options);
+    expect(generator.next().value).toEqual(
+      put({
+        type: DASHBOARD_ELEMENT__SET_PANEL_DATA,
+        payload: {
+          key: optionsType,
+          tab: 1,
+          data: null,
+          meta: null,
+          loading: true
+        }
+      })
+    );
+    generator.next();
+    expect(generator.return().value).toEqual(cancelled());
+    generator.next(true);
+    expect(sourceMock.cancel).toBeCalled();
+  });
+});
+
+describe('getDashboardPanelSectionTabs', () => {
+  const data = {
+    data: { hello: 1 },
+    meta: {}
+  };
+  const optionsType = 'companies';
+
+  it('Calls DASHBOARD_ELEMENT__SET_PANEL_TABS with the fetch data', () => {
+    const generator = getDashboardPanelSectionTabs(dashboardElement, optionsType);
+    generator.next();
+    expect(generator.next({ data }).value).toEqual(
+      put({
+        type: DASHBOARD_ELEMENT__SET_PANEL_TABS,
+        payload: {
+          data: data.data
+        }
+      })
+    );
+  });
+
+  it('Cancels if the fetch is cancelled', () => {
+    const generator = getDashboardPanelSectionTabs(dashboardElement, optionsType);
+    generator.next();
+    expect(generator.return().value).toEqual(cancelled());
+    generator.next(true);
+    expect(sourceMock.cancel).toBeCalled();
+  });
+});
+
+describe('getMoreDashboardPanelData', () => {
+  const data = {
+    data: { hello: 1 },
+    meta: {}
+  };
+
+  it('Calls DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA action', () => {
+    const optionsType = 'companies';
+    const activeTab = { id: 4, name: 'BIOME' };
+    const direction = 'FORWARD';
+    const loadingAction = loading => ({
+      payload: { loadingItems: loading },
+      type: DASHBOARD_ELEMENT__SET_LOADING_ITEMS
+    });
+    const generator = getMoreDashboardPanelData(
+      dashboardElement,
+      optionsType,
+      activeTab,
+      direction
+    );
+    expect(generator.next().value).toEqual(put(loadingAction(true)));
+    generator.next();
+    expect(generator.next({ data }).value).toEqual(
+      put({
+        type: DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
+        payload: {
+          key: optionsType,
+          tab: 4,
+          data: data.data,
+          direction
+        }
+      })
+    );
+    expect(generator.next().value).toEqual(call(removeLoadingSpinner));
+  });
+
+  it('Calls DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA action to clear data', () => {
+    const query = 'Bra';
+    const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
+    generator.next();
+    expect(generator.return().value).toEqual(cancelled());
+    generator.next(true);
+    expect(sourceMock.cancel).toBeCalled();
+  });
+});
+
+describe('fetchDashboardPanelSearchResults', () => {
+  const data = {
+    data: { hello: 1 },
+    meta: {}
+  };
+
+  it('returns if there is no query ', () => {
+    const query = null;
+    const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
+    generator.next();
+    expect(generator.next().value).toEqual(undefined);
+  });
+
+  it('Calls DASHBOARD_ELEMENT__SET_SEARCH_RESULTS action to clear data', () => {
+    const query = 'Bra';
+    const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
+    generator.next();
+    expect(generator.next({ data }).value).toEqual(
+      put({
+        type: DASHBOARD_ELEMENT__SET_SEARCH_RESULTS,
+        payload: {
+          data: data.data
+        }
+      })
+    );
+  });
+
+  it('Calls DASHBOARD_ELEMENT__SET_SEARCH_RESULTS action to clear data', () => {
+    const query = 'Bra';
+    const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
+    generator.next();
+    expect(generator.return().value).toEqual(cancelled());
+    generator.next(true);
+    expect(sourceMock.cancel).toBeCalled();
+  });
+});

--- a/frontend/scripts/tests/dashboard-element/fetch.saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/fetch.saga.test.js
@@ -1,20 +1,11 @@
-import { put, cancelled, call } from 'redux-saga/effects';
+import { cancelled } from 'redux-saga/effects';
 import { fetchWithCancel } from 'react-components/dashboard-element/fetch-with-cancel';
 
 import {
   getDashboardPanelData,
   getDashboardPanelSectionTabs,
-  fetchDashboardPanelSearchResults,
-  getMoreDashboardPanelData,
-  removeLoadingSpinner
+  fetchDashboardPanelSearchResults
 } from 'react-components/dashboard-element/dashboard-element.fetch.saga';
-import {
-  DASHBOARD_ELEMENT__SET_PANEL_DATA,
-  DASHBOARD_ELEMENT__SET_PANEL_TABS,
-  DASHBOARD_ELEMENT__SET_SEARCH_RESULTS,
-  DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
-  DASHBOARD_ELEMENT__SET_LOADING_ITEMS
-} from 'react-components/dashboard-element/dashboard-element.actions';
 import { getURLFromParams } from 'utils/getURLFromParams';
 
 jest.mock('react-components/dashboard-element/fetch-with-cancel', () => ({
@@ -62,60 +53,16 @@ const sourceMock = { cancel: jest.fn() };
 getURLFromParams.mockImplementation(() => someUrl);
 fetchWithCancel.mockImplementation(() => ({ source: sourceMock, fetchPromise: () => {} }));
 
+const optionsType = 'companies';
+const query = 'Bra';
 describe('getDashboardPanelData', () => {
-  const data = {
-    data: { hello: 1 },
-    meta: {}
-  };
-  const optionsType = 'companies';
-  const options = undefined; // Do we use this page param?
   jest.mock('utils/getURLFromParams', () => ({
     getURLFromParams: jest.fn()
   }));
 
-  it('Calls DASHBOARD_ELEMENT__SET_PANEL_DATA action to clear data', () => {
-    const generator = getDashboardPanelData(dashboardElement, optionsType, options);
-    expect(generator.next().value).toEqual(
-      put({
-        type: DASHBOARD_ELEMENT__SET_PANEL_DATA,
-        payload: {
-          key: optionsType,
-          tab: 1,
-          data: null,
-          meta: null,
-          loading: true
-        }
-      })
-    );
+  it('Cancels if the fetch is cancelled', () => {
+    const generator = getDashboardPanelData(dashboardElement, optionsType);
     generator.next();
-    expect(generator.next({ data }).value).toEqual(
-      put({
-        type: DASHBOARD_ELEMENT__SET_PANEL_DATA,
-        payload: {
-          key: optionsType,
-          tab: 1,
-          data: data.data,
-          meta: data.meta,
-          loading: false
-        }
-      })
-    );
-  });
-
-  it('Calls DASHBOARD_ELEMENT__SET_PANEL_DATA action to clear data and Cancels if the fetch is cancelled', () => {
-    const generator = getDashboardPanelData(dashboardElement, optionsType, options);
-    expect(generator.next().value).toEqual(
-      put({
-        type: DASHBOARD_ELEMENT__SET_PANEL_DATA,
-        payload: {
-          key: optionsType,
-          tab: 1,
-          data: null,
-          meta: null,
-          loading: true
-        }
-      })
-    );
     generator.next();
     expect(generator.return().value).toEqual(cancelled());
     generator.next(true);
@@ -124,25 +71,6 @@ describe('getDashboardPanelData', () => {
 });
 
 describe('getDashboardPanelSectionTabs', () => {
-  const data = {
-    data: { hello: 1 },
-    meta: {}
-  };
-  const optionsType = 'companies';
-
-  it('Calls DASHBOARD_ELEMENT__SET_PANEL_TABS with the fetch data', () => {
-    const generator = getDashboardPanelSectionTabs(dashboardElement, optionsType);
-    generator.next();
-    expect(generator.next({ data }).value).toEqual(
-      put({
-        type: DASHBOARD_ELEMENT__SET_PANEL_TABS,
-        payload: {
-          data: data.data
-        }
-      })
-    );
-  });
-
   it('Cancels if the fetch is cancelled', () => {
     const generator = getDashboardPanelSectionTabs(dashboardElement, optionsType);
     generator.next();
@@ -153,43 +81,7 @@ describe('getDashboardPanelSectionTabs', () => {
 });
 
 describe('getMoreDashboardPanelData', () => {
-  const data = {
-    data: { hello: 1 },
-    meta: {}
-  };
-
-  it('Calls DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA action', () => {
-    const optionsType = 'companies';
-    const activeTab = { id: 4, name: 'BIOME' };
-    const direction = 'FORWARD';
-    const loadingAction = loading => ({
-      payload: { loadingItems: loading },
-      type: DASHBOARD_ELEMENT__SET_LOADING_ITEMS
-    });
-    const generator = getMoreDashboardPanelData(
-      dashboardElement,
-      optionsType,
-      activeTab,
-      direction
-    );
-    expect(generator.next().value).toEqual(put(loadingAction(true)));
-    generator.next();
-    expect(generator.next({ data }).value).toEqual(
-      put({
-        type: DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
-        payload: {
-          key: optionsType,
-          tab: 4,
-          data: data.data,
-          direction
-        }
-      })
-    );
-    expect(generator.next().value).toEqual(call(removeLoadingSpinner));
-  });
-
-  it('Calls DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA action to clear data', () => {
-    const query = 'Bra';
+  it('Cancels if the fetch is cancelled', () => {
     const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
     generator.next();
     expect(generator.return().value).toEqual(cancelled());
@@ -199,34 +91,7 @@ describe('getMoreDashboardPanelData', () => {
 });
 
 describe('fetchDashboardPanelSearchResults', () => {
-  const data = {
-    data: { hello: 1 },
-    meta: {}
-  };
-
-  it('returns if there is no query ', () => {
-    const query = null;
-    const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
-    generator.next();
-    expect(generator.next().value).toEqual(undefined);
-  });
-
-  it('Calls DASHBOARD_ELEMENT__SET_SEARCH_RESULTS action to clear data', () => {
-    const query = 'Bra';
-    const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
-    generator.next();
-    expect(generator.next({ data }).value).toEqual(
-      put({
-        type: DASHBOARD_ELEMENT__SET_SEARCH_RESULTS,
-        payload: {
-          data: data.data
-        }
-      })
-    );
-  });
-
-  it('Calls DASHBOARD_ELEMENT__SET_SEARCH_RESULTS action to clear data', () => {
-    const query = 'Bra';
+  it('Cancels if the fetch is cancelled', () => {
     const generator = fetchDashboardPanelSearchResults(dashboardElement, query);
     generator.next();
     expect(generator.return().value).toEqual(cancelled());

--- a/frontend/scripts/tests/dashboard-element/saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/saga.test.js
@@ -1,0 +1,319 @@
+import { fork, select } from 'redux-saga/effects';
+import {
+  getDashboardPanelSectionTabs,
+  getDashboardPanelData,
+  fetchDashboardPanelSearchResults,
+  getMoreDashboardPanelData
+} from 'react-components/dashboard-element/dashboard-element.fetch.saga';
+import {
+  fetchDashboardPanelInitialData,
+  getSearchResults,
+  onTabChange,
+  onItemChange,
+  onFilterClear,
+  onPageChange
+} from 'react-components/dashboard-element/dashboard-element.saga';
+
+describe('fetchDashboardPanelInitialData', () => {
+  const setActiveAction = tab => ({
+    type: 'DASHBOARD_ELEMENT__SET_ACTIVE_PANEL',
+    payload: { activePanelId: tab }
+  });
+
+  const stateCountries = {
+    dashboardElement: {
+      activePanelId: 'countries',
+      countriesPanel: {
+        activeItem: 'Brazil'
+      }
+    }
+  };
+
+  const stateCompanies = {
+    dashboardElement: {
+      activePanelId: 'companies'
+    }
+  };
+
+  it('Calls getDashboardPanelSectionTabs tabs if the current active panel is companies', () => {
+    const generator = fetchDashboardPanelInitialData(setActiveAction('any'));
+
+    expect(generator.next().value).toEqual(select());
+    expect(generator.next(stateCompanies).value).toEqual(
+      fork(getDashboardPanelSectionTabs, stateCompanies.dashboardElement, 'any')
+    );
+  });
+
+  it('Calls getDashboardPanelData and getDashboardPanelData for regions if selected panel is sources', () => {
+    const sourcesGenerator = fetchDashboardPanelInitialData(setActiveAction('sources'));
+
+    expect(sourcesGenerator.next().value).toEqual(select());
+    expect(sourcesGenerator.next(stateCountries).value).toEqual(
+      fork(getDashboardPanelData, stateCountries.dashboardElement, 'countries')
+    );
+    expect(sourcesGenerator.next(stateCountries).value).toEqual(
+      fork(getDashboardPanelData, stateCountries.dashboardElement, 'sources')
+    );
+  });
+
+  it('Calls getDashboardPanelData if selected panel is not companies nor sources', () => {
+    const countriesGenerator = fetchDashboardPanelInitialData(setActiveAction('countries'));
+
+    expect(countriesGenerator.next().value).toEqual(select());
+    expect(countriesGenerator.next(stateCountries).value).toEqual(
+      fork(getDashboardPanelData, stateCountries.dashboardElement, 'countries')
+    );
+  });
+});
+
+describe('getSearchResults', () => {
+  const state = {
+    dashboardElement: {
+      activePanelId: 'countries',
+      countriesPanel: {
+        activeItem: 'Brazil'
+      }
+    }
+  };
+  const searchAction = {
+    type: 'DASHBOARD_ELEMENT__GET_SEARCH_RESULTS',
+    payload: { query: 'a' }
+  };
+
+  it('Calls fetchDashboardPanelSearchResults for the result of the search', () => {
+    const generator = getSearchResults(searchAction);
+
+    expect(generator.next().value).toEqual(select());
+    expect(generator.next(state).value).toEqual(
+      fork(fetchDashboardPanelSearchResults, state.dashboardElement, searchAction.payload.query)
+    );
+  });
+});
+
+describe('onTabChange', () => {
+  const sameTabChangeState = {
+    dashboardElement: {
+      data: {
+        sources: {
+          3: {
+            someData: 'data'
+          }
+        }
+      },
+      countriesPanel: {
+        activeTab: {
+          id: 3
+        }
+      },
+      activePanelId: 'countries'
+    }
+  };
+  const differentTabChangeState = {
+    dashboardElement: {
+      data: {
+        sources: {
+          4: {
+            someData: 'data'
+          }
+        }
+      },
+      countriesPanel: {
+        activeTab: {
+          id: 3
+        }
+      },
+      activeTab: {
+        id: 3
+      },
+      activePanelId: 'countries'
+    }
+  };
+  const searchAction = {
+    type: 'DASHBOARD_ELEMENT__SET_ACTIVE_ITEM_WITH_SEARCH',
+    payload: { panel: 'countries' }
+  };
+
+  it('Calls getDashboardPanelData if tab action is triggered', () => {
+    const generator = onTabChange(searchAction);
+
+    expect(generator.next().value).toEqual(select());
+    expect(generator.next(differentTabChangeState).value).toEqual(
+      fork(
+        getDashboardPanelData,
+        differentTabChangeState.dashboardElement,
+        searchAction.payload.panel
+      )
+    );
+  });
+  const otherGenerator = onTabChange(searchAction);
+
+  it('Does not call getDashboardPanelData if we already are in the target tab (we have data for it)', () => {
+    expect(otherGenerator.next().value).toEqual(select());
+    expect(otherGenerator.next(sameTabChangeState).value).not.toEqual(
+      fork(getDashboardPanelData, sameTabChangeState.dashboardElement, searchAction.payload.panel)
+    );
+  });
+});
+
+describe('onItemChange', () => {
+  const state = {
+    dashboardElement: {
+      data: {
+        countries: {
+          2: [{ id: 3, name: 'Brazil' }]
+        },
+        sources: {
+          6: [{ name: 'data', id: 9 }]
+        }
+      },
+      activePanelId: 'countries',
+      countriesPanel: {
+        activeTab: {
+          id: 2
+        }
+      },
+      sourcesPanel: {
+        activeTab: {
+          id: 6
+        }
+      }
+    }
+  };
+  const otherState = {
+    dashboardElement: {
+      data: {
+        sources: {
+          6: [{ name: 'data', id: 6 }]
+        }
+      },
+      sourcesPanel: {
+        activeTab: {
+          id: 6
+        }
+      }
+    }
+  };
+  const changeToCountriesAction = {
+    type: 'DASHBOARD_ELEMENT__SET_ACTIVE_ITEM',
+    payload: { activeItem: { id: 5 }, panel: 'countries' }
+  };
+  const changeToSourcesAction = {
+    type: 'DASHBOARD_ELEMENT__SET_ACTIVE_ITEM',
+    payload: { activeItem: { id: 6 }, panel: 'sources' }
+  };
+
+  it('Recalculates getDashboardPanelSectionTabs if we select countries', () => {
+    const countriesGenerator = onItemChange(changeToCountriesAction);
+
+    expect(countriesGenerator.next().value).toEqual(select());
+    expect(countriesGenerator.next(state).value).toEqual(
+      fork(
+        getDashboardPanelSectionTabs,
+        state.dashboardElement,
+        changeToCountriesAction.payload.panel
+      )
+    );
+  });
+
+  it('Recalculates getDashboardPanelData if the active item is missing', () => {
+    const sourcesGenerator = onItemChange(changeToSourcesAction);
+
+    expect(sourcesGenerator.next().value).toEqual(select());
+    expect(sourcesGenerator.next(state).value).toEqual(
+      fork(getDashboardPanelData, state.dashboardElement, changeToSourcesAction.payload.panel)
+    );
+  });
+
+  it('Does not call getDashboardPanelData if we have the active item', () => {
+    const otherSourcesGenerator = onItemChange(changeToSourcesAction);
+
+    expect(otherSourcesGenerator.next().value).toEqual(select());
+    expect(otherSourcesGenerator.next(otherState).value).not.toEqual(
+      fork(getDashboardPanelData, otherState.dashboardElement, changeToSourcesAction.payload.panel)
+    );
+  });
+});
+
+describe('onFilterClear', () => {
+  const state = {
+    dashboardElement: {
+      activePanelId: 'sources'
+    }
+  };
+  const sourcesStateWithActiveItem = {
+    dashboardElement: {
+      activePanelId: 'sources',
+      countriesPanel: {
+        activeItem: { id: 5 }
+      }
+    }
+  };
+  const countriesState = {
+    dashboardElement: {
+      activePanelId: 'countries',
+      countriesPanel: {
+        activeItem: { id: 5 }
+      }
+    }
+  };
+  const clear = {
+    type: 'DASHBOARD_ELEMENT__CLEAR_PANEL'
+  };
+
+  it('Calls getDashboardPanelData for countries if the active panel is sources', () => {
+    const generator = onFilterClear(clear);
+    expect(generator.next().value).toEqual(select());
+    expect(generator.next(state).value).toEqual(
+      fork(getDashboardPanelData, state.dashboardElement, 'countries')
+    );
+  });
+
+  it('Calls getDashboardPanelData for countries and sources if the activeItem exists', () => {
+    const generator = onFilterClear(clear);
+    expect(generator.next().value).toEqual(select());
+    expect(generator.next(sourcesStateWithActiveItem).value).toEqual(
+      fork(getDashboardPanelData, sourcesStateWithActiveItem.dashboardElement, 'countries')
+    );
+    expect(generator.next(sourcesStateWithActiveItem).value).toEqual(
+      fork(getDashboardPanelData, sourcesStateWithActiveItem.dashboardElement, 'sources')
+    );
+  });
+
+  it('Calls getDashboardPanelData for countries with the active panel if is not sources', () => {
+    const otherGenerator = onFilterClear(clear);
+    expect(otherGenerator.next().value).toEqual(select());
+    expect(otherGenerator.next(countriesState).value).toEqual(
+      fork(getDashboardPanelData, countriesState.dashboardElement, 'countries')
+    );
+  });
+});
+
+describe('onPageChange', () => {
+  const state = {
+    dashboardElement: {
+      activePanelId: 'countries',
+      countriesPanel: {
+        activeTab: 'BIOME'
+      }
+    }
+  };
+  const searchAction = {
+    type: 'DASHBOARD_ELEMENT__SET_PANEL_PAGE',
+    payload: { direction: 'LETS_GO' }
+  };
+
+  it('Calls getMoreDashboardPanelData to retrieve the next page of data when scrolling', () => {
+    const generator = onPageChange(searchAction);
+
+    expect(generator.next().value).toEqual(select());
+    expect(generator.next(state).value).toEqual(
+      fork(
+        getMoreDashboardPanelData,
+        state.dashboardElement,
+        state.dashboardElement.activePanelId,
+        state.dashboardElement.countriesPanel.activeTab,
+        searchAction.payload.direction
+      )
+    );
+  });
+});

--- a/frontend/scripts/tests/dashboard-element/saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/saga.test.js
@@ -5,9 +5,11 @@ import {
   onTabChange,
   onItemChange,
   onFilterClear,
-  onPageChange
+  onPageChange,
+  onStepChange
 } from 'react-components/dashboard-element/dashboard-element.saga';
 import {
+  openIndicatorsStep,
   clearDashboardPanel,
   setDashboardPanelPage,
   setDashboardActivePanel,
@@ -487,6 +489,23 @@ describe('onPageChange', () => {
         direction: 'forward'
       },
       type: DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA
+    });
+  });
+});
+
+describe('onStepChange', () => {
+  const stepChangeAction = openIndicatorsStep();
+  it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_DATA} to retrieve indicators data on step change`, async () => {
+    const dispatched = await recordSaga(onStepChange, stepChangeAction, baseState);
+    expect(dispatched).toContainEqual({
+      payload: {
+        key: 'indicators',
+        data,
+        meta,
+        tab: null,
+        loading: false
+      },
+      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
     });
   });
 });

--- a/frontend/scripts/tests/utils/record-saga.js
+++ b/frontend/scripts/tests/utils/record-saga.js
@@ -1,0 +1,15 @@
+import { runSaga } from 'redux-saga';
+
+export async function recordSaga(saga, initialAction, state) {
+  const dispatched = [];
+
+  await runSaga(
+    {
+      dispatch: action => dispatched.push(action),
+      getState: () => state
+    },
+    saga,
+    initialAction
+  ).done;
+  return dispatched;
+}


### PR DESCRIPTION
Tests dashboard sagas and dashboards fetch saga files.

We need to export the saga functions and keep them on one level to be able to test them.
Fetching action its not tested itself but cancel is.
We are using this methodology to test only the final actions dispatched by the sagas: https://dev.to/phil/the-best-way-to-test-redux-sagas-4hib

The recordSaga syntax has been updated due to changes in the redux-saga API
It will be interesting to research more in the sagaMonitor object created by runSaga:
See the runSaga definition in https://redux-saga.js.org/docs/api/

In the fetch saga file, only the cancellation is tested but It can surely be improved to prevent a step by step testing. Any ideas are appreciated.