### PR TITLE
fix: showing incorrect results + clearing wrong tab data

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
@@ -124,17 +124,14 @@ export function* getMoreDashboardPanelData(dashboardElement, optionsType, active
 export function* fetchDashboardPanelSearchResults(dashboardElement, query) {
   if (!query) return;
   let optionsType = dashboardElement.activePanelId;
-  if (
-    optionsType === 'sources' &&
-    dashboardElement.sourcesPanel.activeItem === null &&
-    dashboardElement.sourcesPanel.activeTab === null
-  ) {
+  if (optionsType === 'sources' && dashboardElement.countriesPanel.activeItem === null) {
     optionsType = 'countries';
   }
-  const filters = {
-    ...getDashboardPanelParams(dashboardElement, optionsType),
-    node_types_ids: undefined
-  };
+  // eslint-ignore-next-line
+  const { node_types_ids: excluded, ...filters } = getDashboardPanelParams(
+    dashboardElement,
+    optionsType
+  );
   const params = {
     ...filters,
     q: query

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -166,13 +166,16 @@ const dashboardElementReducer = {
   [DASHBOARD_ELEMENT__SET_ACTIVE_TAB](state, action) {
     const { panel, activeTab } = action.payload;
     const panelName = `${panel}Panel`;
+    const prevTab = state[panelName].activeTab;
+    const clearedActiveTabData = prevTab ? { [prevTab.id]: null } : {};
+
     return {
       ...state,
       data: {
         ...state.data,
         [panel]: {
           ...state.data[panel],
-          [activeTab.id]: null
+          ...clearedActiveTabData
         }
       },
       activeIndicatorsList: [],
@@ -186,21 +189,26 @@ const dashboardElementReducer = {
   [DASHBOARD_ELEMENT__SET_ACTIVE_ITEM_WITH_SEARCH](state, action) {
     const { panel, activeItem } = action.payload;
     const panelName = `${panel}Panel`;
-    const activeTab = state.tabs[panel].find(tab => tab.id === activeItem.nodeTypeId);
+    const prevTab = state[panelName].activeTab;
+    const clearedActiveTabData = prevTab ? { [prevTab.id]: null } : {};
+    const activeTab =
+      state.tabs[panel] && state.tabs[panel].find(tab => tab.id === activeItem.nodeTypeId);
+
     return {
       ...state,
       data: {
         ...state.data,
         [panel]: {
           ...state.data[panel],
-          [activeTab.id]: null
+          ...clearedActiveTabData
         }
       },
       activeIndicatorsList: [],
       [panelName]: {
         ...state[panelName],
         activeItem,
-        activeTab
+        activeTab,
+        page: initialState[panelName].page
       }
     };
   },

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -28,6 +28,10 @@ class DashboardPanel extends Component {
     }
   }
 
+  static sourcesNodeTypeRenderer(node) {
+    return node.nodeType || 'Country of Production';
+  }
+
   static countryNameNodeTypeRenderer(node) {
     return `${node.countryName + addApostrophe(node.countryName)} ${node.nodeType}`;
   }
@@ -77,27 +81,28 @@ class DashboardPanel extends Component {
           />
           {activePanelId === 'sources' && (
             <SourcesPanel
+              tabs={tabs}
+              loading={loading}
+              countries={countries}
               page={sourcesPanel.page}
               getMoreItems={getMoreItems}
-              setSearchResult={item => setSearchResult(item, activePanelId)}
-              getSearchResults={getSearchResults}
-              loadingMoreItems={sourcesPanel.loadingItems}
-              loading={loading}
-              clearItems={() => clearActiveItem(activePanelId)}
-              activeCountryItem={countriesPanel.activeItem}
-              activeSourceTab={sourcesPanel.activeTab}
-              activeSourceItem={sourcesPanel.activeItem}
               searchSources={
                 !countriesPanel.activeItem
                   ? countriesPanel.searchResults
                   : sourcesPanel.searchResults
               }
-              tabs={tabs}
-              sources={sources[sourcesPanel.activeTab && sourcesPanel.activeTab.id] || []}
-              countries={countries}
+              getSearchResults={getSearchResults}
+              loadingMoreItems={sourcesPanel.loadingItems}
+              clearItems={() => clearActiveItem(activePanelId)}
+              activeCountryItem={countriesPanel.activeItem}
+              activeSourceTab={sourcesPanel.activeTab}
+              activeSourceItem={sourcesPanel.activeItem}
               onSelectCountry={item => setActiveItem(item, 'countries')}
               onSelectSourceTab={item => setActiveTab(item, activePanelId)}
+              setSearchResult={item => setSearchResult(item, activePanelId)}
               onSelectSourceValue={item => setActiveItem(item, activePanelId)}
+              nodeTypeRenderer={DashboardPanel.sourcesNodeTypeRenderer}
+              sources={sources[sourcesPanel.activeTab && sourcesPanel.activeTab.id] || []}
             />
           )}
           {activePanelId === 'destinations' && (
@@ -158,31 +163,31 @@ class DashboardPanel extends Component {
 }
 
 DashboardPanel.propTypes = {
+  tabs: PropTypes.array,
+  sources: PropTypes.object,
   countries: PropTypes.array,
   companies: PropTypes.object,
   getMoreItems: PropTypes.func,
   commodities: PropTypes.array,
   dirtyBlocks: PropTypes.object,
   activePanelId: PropTypes.string,
-  sources: PropTypes.object,
-  tabs: PropTypes.array,
-  editMode: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   commoditiesPanel: PropTypes.object,
   panels: PropTypes.array.isRequired,
-  destinations: PropTypes.array.isRequired,
-  onContinue: PropTypes.func.isRequired,
-  setSearchResult: PropTypes.func.isRequired,
-  getSearchResults: PropTypes.func.isRequired,
+  editMode: PropTypes.bool.isRequired,
   dynamicSentenceParts: PropTypes.array,
+  onContinue: PropTypes.func.isRequired,
   setActiveTab: PropTypes.func.isRequired,
   setActiveItem: PropTypes.func.isRequired,
-  clearActiveItem: PropTypes.func.isRequired,
+  destinations: PropTypes.array.isRequired,
   setActivePanel: PropTypes.func.isRequired,
   sourcesPanel: PropTypes.object.isRequired,
-  destinationsPanel: PropTypes.object.isRequired,
+  clearActiveItem: PropTypes.func.isRequired,
+  setSearchResult: PropTypes.func.isRequired,
+  getSearchResults: PropTypes.func.isRequired,
   companiesPanel: PropTypes.object.isRequired,
-  countriesPanel: PropTypes.object.isRequired
+  countriesPanel: PropTypes.object.isRequired,
+  destinationsPanel: PropTypes.object.isRequired
 };
 
 export default DashboardPanel;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.container.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.container.jsx
@@ -88,6 +88,11 @@ class DashboardPanelContainer extends React.PureComponent {
     }
   ];
 
+  static propTypes = {
+    companiesPanel: PropTypes.object,
+    countryNames: PropTypes.object
+  };
+
   static addCountryNameToSearchResults(panel, countryNames) {
     const searchResults = panel.searchResults.map(item => ({
       ...item,
@@ -105,11 +110,6 @@ class DashboardPanelContainer extends React.PureComponent {
     return <DashboardPanel {...this.props} panels={this.panels} companiesPanel={companiesPanel} />;
   }
 }
-
-DashboardPanelContainer.propTypes = {
-  companiesPanel: PropTypes.array,
-  countryNames: PropTypes.array
-};
 
 export default connect(
   mapStateToProps,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/sources-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/sources-panel.component.jsx
@@ -102,24 +102,24 @@ function SourcesPanel(props) {
 }
 
 SourcesPanel.propTypes = {
-  loadingMoreItems: PropTypes.bool,
   loading: PropTypes.bool,
-  page: PropTypes.number.isRequired,
-  searchSources: PropTypes.array.isRequired,
   sources: PropTypes.array,
   countries: PropTypes.array,
-  getMoreItems: PropTypes.func.isRequired,
-  activeCountryItem: PropTypes.object,
+  tabs: PropTypes.array.isRequired,
+  nodeTypeRenderer: PropTypes.func,
+  loadingMoreItems: PropTypes.bool,
+  page: PropTypes.number.isRequired,
   activeSourceTab: PropTypes.object,
   activeSourceItem: PropTypes.object,
-  tabs: PropTypes.array.isRequired,
-  onSelectCountry: PropTypes.func.isRequired,
+  activeCountryItem: PropTypes.object,
   clearItems: PropTypes.func.isRequired,
+  getMoreItems: PropTypes.func.isRequired,
+  searchSources: PropTypes.array.isRequired,
+  onSelectCountry: PropTypes.func.isRequired,
   setSearchResult: PropTypes.func.isRequired,
   getSearchResults: PropTypes.func.isRequired,
-  onSelectSourceValue: PropTypes.func.isRequired,
   onSelectSourceTab: PropTypes.func.isRequired,
-  nodeTypeRenderer: PropTypes.func.isRequired
+  onSelectSourceValue: PropTypes.func.isRequired
 };
 
 SourcesPanel.defaultProps = {

--- a/frontend/scripts/react-components/shared/tags-group/tags-group.component.jsx
+++ b/frontend/scripts/react-components/shared/tags-group/tags-group.component.jsx
@@ -21,10 +21,7 @@ function TagsGroup(props) {
           >
             {part.value}
             {clearItem && (
-              <button
-                onClick={() => console.log('click', part) || clearItem(part)}
-                className="tags-group-item-remove-cross"
-              >
+              <button onClick={() => clearItem(part)} className="tags-group-item-remove-cross">
                 <svg className="icon icon-close">
                   <use xlinkHref="#icon-close" />
                 </svg>

--- a/frontend/scripts/tests/dashboard-element/reducer.test.js
+++ b/frontend/scripts/tests/dashboard-element/reducer.test.js
@@ -337,10 +337,12 @@ test(DASHBOARD_ELEMENT__SET_ACTIVE_TAB, () => {
     }
   };
   const newState = reducer(state, action);
-  const clearedPreviousTab = { sources: { '3': null } };
   expect(newState).toEqual({
     ...state,
-    data: { ...state.data, ...clearedPreviousTab },
+    data: {
+      ...state.data,
+      sources: { 1: null }
+    },
     activeIndicatorsList: [],
     sourcesPanel: {
       ...state.sourcesPanel,
@@ -598,19 +600,23 @@ test(DASHBOARD_ELEMENT__SET_ACTIVE_ITEM_WITH_SEARCH, () => {
     activeIndicatorsList: [1, 2, 3],
     companiesPanel: {
       ...initialState.companiesPanel,
-      activeTab: { id: 7, name: 'IMPORTER' }
+      activeTab: { id: 7, name: 'IMPORTER' },
+      page: 4
     }
   };
   const newState = reducer(state, action);
-  const clearedPreviousTab = { companies: { '6': null } };
   expect(newState).toEqual({
     ...state,
-    data: { ...state.data, ...clearedPreviousTab },
+    data: {
+      ...state.data,
+      companies: { 7: null }
+    },
     activeIndicatorsList: [],
     companiesPanel: {
       ...state.companiesPanel,
       activeItem: someItem,
-      activeTab: tabs.companies[0]
+      activeTab: tabs.companies[0],
+      page: initialState.companiesPanel.page
     }
   });
 });


### PR DESCRIPTION
This PR address a couple of issues I found on the sources panel:
- Search in sources should show only countries when no country is selected. If you selected a country, then deselect it and search again, the results were not showing countries but jurisdictions.
- When changing tab using the search, the page number wasn't being reset.
- When changing tabs the data being reset was that of the new tab, instead of the previous.
