### PR TITLE
[BE] Fix selecting multiple companies

### DIFF
--- a/app/services/api/v3/dashboards/chart_data_from_flow_attributes.rb
+++ b/app/services/api/v3/dashboards/chart_data_from_flow_attributes.rb
@@ -54,7 +54,7 @@ module Api
             q = q.where('contexts.commodity_id' => @commodities_ids)
           end
 
-          q = q.where('flows.path @> ARRAY[?]', @nodes_ids) if @nodes_ids.any?
+          q = q.where(any_nodes_in_common?)
 
           q =
             if @attribute.aggregatable?
@@ -66,6 +66,10 @@ module Api
             end
 
           @query = q
+        end
+
+        def any_nodes_in_common?
+          ['flows.path && ARRAY[?]', @nodes_ids] if @nodes_ids.any?
         end
       end
     end

--- a/app/services/api/v3/dashboards/retrieve_attributes.rb
+++ b/app/services/api/v3/dashboards/retrieve_attributes.rb
@@ -101,7 +101,7 @@ module Api
             cond_vals << @commodities_ids
           end
           if @nodes_ids.any?
-            cond_strs << 'path @> ARRAY[?]'
+            cond_strs << any_elements_in_common?
             cond_vals << @nodes_ids
           end
           Api::V3::Readonly::Attribute.send(
@@ -125,6 +125,10 @@ module Api
 
         def node_attributes_default_for_case
           @nodes_ids.empty?
+        end
+
+        def any_elements_in_common?
+          'path && ARRAY[?]'
         end
       end
     end

--- a/spec/controllers/api/v3/dashboards/chart_data_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/chart_data_controller_spec.rb
@@ -39,10 +39,62 @@ RSpec.describe Api::V3::Dashboards::ChartDataController, type: :controller do
       expect(data.map { |e| e['x'] }).to eq([2015])
     end
 
-    it 'returns values for multiple matched companies' do
+    it 'returns values for a single company - filtering by exporter node' do
+      get :index, params: {
+        attribute_id: api_v3_volume.readonly_attribute.id,
+        companies_ids: [api_v3_exporter1_node.id].join(',')
+      }
+
+      json = JSON.parse(response.body)
+      data = json['data']
+      expect(data.map { |e| e['x'] }).to eq([2015])
+      expect(data.map { |e| e['y1']}).to eq([
+        flow1_volume.value +
+        flow2_volume.value +
+        flow3_volume.value +
+        flow5_volume.value
+      ])
+    end
+
+    it 'returns values for multiple companies - filtering by importer and exporter node' do
       get :index, params: {
         attribute_id: api_v3_volume.readonly_attribute.id,
         companies_ids: [api_v3_exporter1_node.id, api_v3_importer1_node.id].join(',')
+      }
+
+      json = JSON.parse(response.body)
+      data = json['data']
+      expect(data.map { |e| e['x'] }).to eq([2015])
+      expect(data.map { |e| e['y1']}).to eq([
+        flow1_volume.value +
+        flow2_volume.value +
+        flow3_volume.value +
+        flow4_volume.value +
+        flow5_volume.value
+      ])
+    end
+
+    it 'returns values for multiple companies - filtering by 2 exporters' do
+      get :index, params: {
+        attribute_id: api_v3_volume.readonly_attribute.id,
+        companies_ids: [
+          api_v3_exporter1_node.id,
+          api_v3_other_exporter_node.id
+        ].join(',')
+      }
+
+      json = JSON.parse(response.body)
+      data = json['data']
+      expect(data.map { |e| e['x'] }).to eq([2015])
+    end
+
+    it 'returns values for multiple companies - filtering by 2 importers' do
+      get :index, params: {
+        attribute_id: api_v3_volume.readonly_attribute.id,
+        companies_ids: [
+          api_v3_importer1_node.id,
+          api_v3_other_importer_node.id
+        ].join(',')
       }
 
       json = JSON.parse(response.body)

--- a/spec/controllers/api/v3/dashboards/chart_data_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/chart_data_controller_spec.rb
@@ -38,5 +38,16 @@ RSpec.describe Api::V3::Dashboards::ChartDataController, type: :controller do
       data = json['data']
       expect(data.map { |e| e['x'] }).to eq([2015])
     end
+
+    it 'returns values for matched companies' do
+      get :index, params: {
+        attribute_id: api_v3_volume.readonly_attribute.id,
+        companies_ids: [api_v3_exporter1_node.id, api_v3_importer1_node.id].join(',')
+      }
+
+      json = JSON.parse(response.body)
+      data = json['data']
+      expect(data.map { |e| e['x'] }).to eq([2015])
+    end
   end
 end

--- a/spec/controllers/api/v3/dashboards/chart_data_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/chart_data_controller_spec.rb
@@ -39,10 +39,24 @@ RSpec.describe Api::V3::Dashboards::ChartDataController, type: :controller do
       expect(data.map { |e| e['x'] }).to eq([2015])
     end
 
-    it 'returns values for matched companies' do
+    it 'returns values for multiple matched companies' do
       get :index, params: {
         attribute_id: api_v3_volume.readonly_attribute.id,
         companies_ids: [api_v3_exporter1_node.id, api_v3_importer1_node.id].join(',')
+      }
+
+      json = JSON.parse(response.body)
+      data = json['data']
+      expect(data.map { |e| e['x'] }).to eq([2015])
+    end
+
+    it 'returns values for multiple matched destinations' do
+      get :index, params: {
+        attribute_id: api_v3_volume.readonly_attribute.id,
+        destinations_ids: [
+          api_v3_country_of_destination1_node.id,
+          api_v3_other_country_of_destination_node.id
+        ].join(',')
       }
 
       json = JSON.parse(response.body)

--- a/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
   describe 'GET index' do
     it 'returns list in alphabetical order' do
       get :index, params: {countries_ids: api_v3_brazil.id}
-      expect(assigns(:collection).map(&:id)).to eq([api_v3_exporter1_node.id, api_v3_importer1_node.id])
+      expect(assigns(:collection).map(&:id)).to include(api_v3_exporter1_node.id, api_v3_importer1_node.id)
     end
 
     it 'returns companies by id' do

--- a/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V3::Dashboards::DestinationsController, type: :controller do
   describe 'GET index' do
     it 'returns list in alphabetical order' do
       get :index, params: {countries_ids: [api_v3_brazil.id].join(',')}
-      expect(assigns(:collection).map(&:id)).to eq([api_v3_country_of_destination1_node.id])
+      expect(assigns(:collection).map(&:id)).to eq([api_v3_other_country_of_destination_node.id, api_v3_country_of_destination1_node.id])
     end
 
     it 'returns destinations by id' do
@@ -30,6 +30,14 @@ RSpec.describe Api::V3::Dashboards::DestinationsController, type: :controller do
         destinations_ids: api_v3_country_of_destination1_node.id
       }
       expect(assigns(:collection).map(&:id)).to eq([api_v3_country_of_destination1_node.id])
+    end
+
+    it 'allows multiple destinations selection' do
+      get :index, params: {
+        countries_ids: [api_v3_brazil.id].join(','),
+        destinations_ids: [api_v3_country_of_destination1_node.id, api_v3_other_country_of_destination_node.id].join(',')
+      }
+      expect(assigns(:collection).map(&:id)).to eq([api_v3_other_country_of_destination_node.id, api_v3_country_of_destination1_node.id])
     end
   end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_flows.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows.rb
@@ -13,7 +13,8 @@ shared_context 'api v3 brazil flows' do
         api_v3_port1_node,
         api_v3_exporter1_node,
         api_v3_importer1_node,
-        api_v3_country_of_destination1_node
+        api_v3_country_of_destination1_node,
+        api_v3_other_country_of_destination_node
       ].map(&:id),
       year: 2015
     )

--- a/spec/support/contexts/api/v3/brazil/brazil_flows.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows.rb
@@ -13,8 +13,7 @@ shared_context 'api v3 brazil flows' do
         api_v3_port1_node,
         api_v3_exporter1_node,
         api_v3_importer1_node,
-        api_v3_country_of_destination1_node,
-        api_v3_other_country_of_destination_node
+        api_v3_country_of_destination1_node
       ].map(&:id),
       year: 2015
     )
@@ -31,6 +30,63 @@ shared_context 'api v3 brazil flows' do
         api_v3_port1_node,
         api_v3_exporter1_node,
         api_v3_importer1_node,
+        api_v3_country_of_destination1_node
+      ].map(&:id),
+      year: 2015
+    )
+  end
+
+  # second destination node - there can be only ONE destination in a single flow
+  let!(:api_v3_flow3) do
+    FactoryBot.create(
+      :api_v3_flow,
+      context: api_v3_context,
+      path: [
+        api_v3_biome_node,
+        api_v3_state_node,
+        api_v3_municipality_node,
+        api_v3_logistics_hub_node,
+        api_v3_port1_node,
+        api_v3_exporter1_node,
+        api_v3_importer1_node,
+        api_v3_other_country_of_destination_node
+      ].map(&:id),
+      year: 2015
+    )
+  end
+
+  # second exporter
+  let!(:api_v3_flow4) do
+    FactoryBot.create(
+      :api_v3_flow,
+      context: api_v3_context,
+      path: [
+        api_v3_biome_node,
+        api_v3_state_node,
+        api_v3_municipality_node,
+        api_v3_logistics_hub_node,
+        api_v3_port1_node,
+        api_v3_other_exporter_node,
+        api_v3_importer1_node,
+        api_v3_country_of_destination1_node
+      ].map(&:id),
+      year: 2015
+    )
+  end
+
+  # second importer
+  let!(:api_v3_flow5) do
+    FactoryBot.create(
+      :api_v3_flow,
+      context: api_v3_context,
+      path: [
+        api_v3_biome_node,
+        api_v3_state_node,
+        api_v3_municipality_node,
+        api_v3_logistics_hub_node,
+        api_v3_port1_node,
+        api_v3_exporter1_node,
+        api_v3_other_importer_node,
         api_v3_country_of_destination1_node
       ].map(&:id),
       year: 2015

--- a/spec/support/contexts/api/v3/brazil/brazil_flows_quants.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows_quants.rb
@@ -18,6 +18,30 @@ shared_context 'api v3 brazil flows quants' do
       value: 15
     )
   end
+  let!(:flow3_volume) do
+    FactoryBot.create(
+      :api_v3_flow_quant,
+      flow: api_v3_flow3,
+      quant: api_v3_volume,
+      value: 20
+    )
+  end
+  let!(:flow4_volume) do
+    FactoryBot.create(
+      :api_v3_flow_quant,
+      flow: api_v3_flow4,
+      quant: api_v3_volume,
+      value: 25
+    )
+  end
+  let!(:flow5_volume) do
+    FactoryBot.create(
+      :api_v3_flow_quant,
+      flow: api_v3_flow5,
+      quant: api_v3_volume,
+      value: 30
+    )
+  end
   let!(:flow1_deforestation_v2) do
     FactoryBot.create(
       :api_v3_flow_quant,


### PR DESCRIPTION
* Fix filtering in the dashboards/chart_data endpoint - use OR operator instead of AND for filtering companies_ids
* Fix filtering in the dashboards/attributes endpoint - use OR operator instead of AND for filtering companies_ids
* Solution: replace ARR1 @> ARR2 operator that checks for EVERY element from ARR2 in ARR1 with && operator checking if the they have ANY elements in common

PT task:
https://www.pivotaltracker.com/n/projects/1637931/stories/164108523
And also:
https://www.pivotaltracker.com/n/projects/1637931/stories/164108677
https://www.pivotaltracker.com/n/projects/1637931/stories/164109281
As the `nodes_ids` in `RetrieveAttributes` service include all `companies_ids`, `destinations_ids` and `sources_ids`.

Testing:
Check `/api/v3/dashboards/chart_data?attribute_id=31&companies_ids=32228,29138` endpoint which previously didn't return any results