### PR TITLE
Fix/grid list pagination

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
@@ -84,7 +84,7 @@ export function* getDashboardPanelSectionTabs(dashboardElement, optionsType) {
 }
 
 export function* removeLoadingSpinner() {
-  yield delay(1000);
+  yield delay(750);
   yield put(setDashboardPanelLoadingItems(false));
 }
 

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -109,8 +109,6 @@ const dashboardElementReducer = {
   [DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA](state, action) {
     const { key, data, tab, direction } = action.payload;
     const panelName = `${key}Panel`;
-    const oldData = tab ? state.data[key][tab] : state.data[key];
-    let together;
 
     if (data.length === 0) {
       return {
@@ -122,6 +120,8 @@ const dashboardElementReducer = {
       };
     }
 
+    const oldData = tab ? state.data[key][tab] : state.data[key];
+    let together;
     if (direction === 'backward' && data.length > 0) {
       together = [...data, ...oldData];
     } else if (direction === 'forward' && data.length > 0) {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -108,11 +108,23 @@ const dashboardElementReducer = {
   },
   [DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA](state, action) {
     const { key, data, tab, direction } = action.payload;
+    const panelName = `${key}Panel`;
     const oldData = tab ? state.data[key][tab] : state.data[key];
     let together;
-    if (direction === 'backwards') {
+
+    if (data.length === 0) {
+      return {
+        ...state,
+        [panelName]: {
+          ...state[panelName],
+          page: state[panelName].page - 1
+        }
+      };
+    }
+
+    if (direction === 'backward' && data.length > 0) {
       together = [...data, ...oldData];
-    } else if (direction === 'forwards') {
+    } else if (direction === 'forward' && data.length > 0) {
       together = [...oldData, ...data];
     }
     const newData = tab ? { ...state.data[key], [tab]: together } : together;

--- a/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
+++ b/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
@@ -48,7 +48,7 @@ class GridList extends React.Component {
     }
   }
 
-  getMoreItems = ({ scrollTop, scrollUpdateWasRequested }) => {
+  getMoreItems = ({ scrollTop, scrollUpdateWasRequested, verticalScrollDirection }) => {
     const { items, height, rowHeight, page, columnCount } = this.props;
     const current = parseInt((scrollTop + height) / rowHeight, 10);
     const buffer = 1;
@@ -59,11 +59,15 @@ class GridList extends React.Component {
 
     // TODO: add backwards support
     // const reachedPageStart = current === columnCount;
-    // if (reachedPageStart && !scrollUpdateWasRequested && page > 0) {
+    // if (reachedPageStart && !scrollUpdateWasRequested && page > 0 && verticalScrollDirection === 'backward') {
     //   getMoreItems(page - 1, 'backwards');
     // }
-    if ((reachedPageEnd || reachedPageEndWithBuffer) && !scrollUpdateWasRequested) {
-      this.debouncedGetMoreItemsCb(page + 1, 'forwards');
+    if (
+      (reachedPageEnd || reachedPageEndWithBuffer) &&
+      !scrollUpdateWasRequested &&
+      verticalScrollDirection === 'forward'
+    ) {
+      this.debouncedGetMoreItemsCb(page + 1, 'forward');
     }
   };
 

--- a/frontend/scripts/tests/dashboard-element/reducer.test.js
+++ b/frontend/scripts/tests/dashboard-element/reducer.test.js
@@ -192,7 +192,7 @@ describe(DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA, () => {
         tab: null,
         data: moreData,
         key: 'commodities',
-        direction: 'forwards'
+        direction: 'forward'
       }
     };
     const state = {
@@ -219,7 +219,7 @@ describe(DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA, () => {
         tab: 1,
         data: moreData,
         key: 'sources',
-        direction: 'forwards'
+        direction: 'forward'
       }
     };
     const state = {

--- a/frontend/scripts/tests/dashboard-element/reducer.test.js
+++ b/frontend/scripts/tests/dashboard-element/reducer.test.js
@@ -185,6 +185,7 @@ describe(DASHBOARD_ELEMENT__SET_PANEL_DATA, () => {
 describe(DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA, () => {
   const someData = [{ id: 0, name: 'name0' }, { id: 1, name: 'name1' }];
   const moreData = [{ id: 0, name: 'Whatever' }];
+
   it('adds more data to an array entity', () => {
     const action = {
       type: DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
@@ -204,15 +205,15 @@ describe(DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA, () => {
     };
     const newState = reducer(state, action);
     expect(newState).toEqual({
-      ...initialState,
+      ...state,
       data: {
-        ...initialState.data,
+        ...state.data,
         commodities: [...someData, ...moreData]
       }
     });
   });
 
-  it('adds more data to an array entity', () => {
+  it('adds more data to an object entity', () => {
     const action = {
       type: DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
       payload: {
@@ -226,7 +227,6 @@ describe(DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA, () => {
       ...initialState,
       data: {
         ...initialState.data,
-        commodities: someData,
         sources: {
           1: someData,
           2: someData
@@ -235,13 +235,44 @@ describe(DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA, () => {
     };
     const newState = reducer(state, action);
     expect(newState).toEqual({
-      ...initialState,
+      ...state,
       data: {
         ...state.data,
         sources: {
           1: [...someData, ...moreData],
           2: someData
         }
+      }
+    });
+  });
+
+  it('resets the page number when theres no new data', () => {
+    const action = {
+      type: DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
+      payload: {
+        tab: 1,
+        data: [],
+        key: 'commodities',
+        direction: 'forward'
+      }
+    };
+    const state = {
+      ...initialState,
+      data: {
+        ...initialState.data,
+        commodities: someData
+      },
+      commoditiesPanel: {
+        ...initialState.commoditiesPanel,
+        page: 3
+      }
+    };
+    const newState = reducer(state, action);
+    expect(newState).toEqual({
+      ...state,
+      commoditiesPanel: {
+        ...state.commoditiesPanel,
+        page: 2
       }
     });
   });


### PR DESCRIPTION
This PR fixes some issues in the grid-list and in the add more data action.
- Don't fetch data when scrolling backwards
- Don't increase the page number after reaching the end.