### PR TITLE
Fix: prevent dashboards unnecessary fetch

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -141,7 +141,10 @@ const dashboardElementReducer = {
     const activePanelTabs = tabs[state.activePanelId];
     const firstTab = activePanelTabs && activePanelTabs[0];
     const existingTab =
-      activePanelTabs && activePanelTabs.find(tab => tab.id === state[panelName].activeTab);
+      activePanelTabs &&
+      activePanelTabs.find(
+        tab => tab.id === (state[panelName].activeTab && state[panelName].activeTab.id)
+      );
     return {
       ...state,
       tabs,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -138,13 +138,16 @@ const dashboardElementReducer = {
     const getSection = n => n.section && n.section.toLowerCase();
     const tabs = data.reduce((acc, next) => ({ ...acc, [getSection(next)]: next.tabs }), {});
     const panelName = `${state.activePanelId}Panel`;
-    const firstTab = tabs[state.activePanelId] && tabs[state.activePanelId][0];
+    const activePanelTabs = tabs[state.activePanelId];
+    const firstTab = activePanelTabs && activePanelTabs[0];
+    const existingTab =
+      activePanelTabs && activePanelTabs.find(tab => tab.id === state[panelName].activeTab);
     return {
       ...state,
       tabs,
       [panelName]: {
         ...state[panelName],
-        activeTab: state[panelName].activeTab || firstTab,
+        activeTab: existingTab || firstTab,
         page: initialState[panelName].page
       }
     };

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -140,15 +140,19 @@ function* fetchDataOnItemChange() {
 }
 
 /**
- * Listens to DASHBOARD_ELEMENT__CLEAR_PANEL and fetches the necessary data after a filter clear
+ * Listens to DASHBOARD_ELEMENT__CLEAR_PANEL and fetches the necessary data after a filter clear.
+ * On sources and companies we don't need to call getDashboardPanelData because getDashboardPanelSectionTabs
+ * dispatches an action that trigger it.
  */
 export function* onFilterClear() {
   const { dashboardElement } = yield select();
   if (dashboardElement.activePanelId === 'sources') {
     yield fork(getDashboardPanelData, dashboardElement, 'countries');
     if (dashboardElement.countriesPanel.activeItem !== null) {
-      yield fork(getDashboardPanelData, dashboardElement, 'sources');
+      yield fork(getDashboardPanelSectionTabs, dashboardElement, dashboardElement.activePanelId);
     }
+  } else if (dashboardElement.activePanelId === 'companies') {
+    yield fork(getDashboardPanelSectionTabs, dashboardElement, dashboardElement.activePanelId);
   } else {
     yield fork(getDashboardPanelData, dashboardElement, dashboardElement.activePanelId);
   }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -1,4 +1,4 @@
-import { take, select, all, fork, takeLatest } from 'redux-saga/effects';
+import { take, select, all, fork, takeLatest, cancel } from 'redux-saga/effects';
 import {
   DASHBOARD_ELEMENT__CLEAR_PANEL,
   DASHBOARD_ELEMENT__SET_ACTIVE_PANEL,
@@ -38,6 +38,7 @@ export function* fetchDashboardPanelInitialData(action) {
 export function* fetchDataOnPanelChange() {
   let loaded = [];
   let activePanelState = null;
+  let task = null;
   const hasChanged = panel => {
     if (!activePanelState) return false;
     const changes = [];
@@ -67,7 +68,10 @@ export function* fetchDataOnPanelChange() {
       loaded = changes;
     }
     if (!activePanelState || !loaded.includes(activePanel.payload.activePanelId)) {
-      yield fork(fetchDashboardPanelInitialData, activePanel);
+      if (task !== null) {
+        yield cancel(task);
+      }
+      task = yield fork(fetchDashboardPanelInitialData, activePanel);
       if (!loaded.includes(activePanel.payload.activePanelId)) {
         loaded.push(activePanel.payload.activePanelId);
       }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -42,10 +42,10 @@ export function* fetchDataOnPanelChange() {
   const hasChanged = panel => {
     if (!activePanelState) return false;
     const changes = [];
-    if (panel.sourcesPanel.activeItem !== activePanelState.sourcesPanel.activeItem) {
-      changes.push('sources');
-    }
-    if (panel.countriesPanel.activeItem !== activePanelState.countriesPanel.activeItem) {
+    if (
+      panel.sourcesPanel.activeItem !== activePanelState.sourcesPanel.activeItem ||
+      panel.countriesPanel.activeItem !== activePanelState.countriesPanel.activeItem
+    ) {
       changes.push('sources');
     }
     if (panel.commoditiesPanel.activeItem !== activePanelState.commoditiesPanel.activeItem) {
@@ -65,7 +65,7 @@ export function* fetchDataOnPanelChange() {
     const newPanelState = yield select(state => state.dashboardElement);
     const changes = hasChanged(newPanelState);
     if (changes) {
-      loaded = changes;
+      loaded = changes.filter(id => id !== activePanel.payload.activePanelId);
     }
     if (!activePanelState || !loaded.includes(activePanel.payload.activePanelId)) {
       if (task !== null) {
@@ -126,7 +126,10 @@ export function* onItemChange(action) {
   if (panel === 'countries') {
     yield fork(getDashboardPanelSectionTabs, dashboardElement, panel);
   } else if (items && !activeItemExists) {
-    yield fork(getDashboardPanelData, dashboardElement, panel);
+    // only reload list if clearing item from a different panel than the one that is active
+    // if (!activeItem && panel !== dashboardElement.activePanelId) {
+    //   yield fork(getDashboardPanelData, dashboardElement, panel);
+    // }
   }
 }
 

--- a/frontend/scripts/tests/dashboard-element/reducer.test.js
+++ b/frontend/scripts/tests/dashboard-element/reducer.test.js
@@ -317,6 +317,52 @@ describe(DASHBOARD_ELEMENT__SET_PANEL_TABS, () => {
       }
     });
   });
+
+  it('sets activeTab to previous value if it exists in new tabs', () => {
+    const state = {
+      ...initialState,
+      tabs: { sources: expectedTabs.sources },
+      activePanelId: 'sources',
+      sourcesPanel: {
+        ...initialState.sourcesPanel,
+        activeTab: expectedTabs.sources[1]
+      }
+    };
+    const newState = reducer(state, action);
+    expect(newState).toEqual({
+      ...state,
+      tabs: expectedTabs
+    });
+  });
+
+  it('sets activeTab to first value if previous value doesnt exists in new tabs', () => {
+    const newData = [...data];
+    newData[0].tabs = [expectedTabs.sources[0]];
+    const newAction = {
+      type: DASHBOARD_ELEMENT__SET_PANEL_TABS,
+      payload: {
+        data: newData
+      }
+    };
+    const state = {
+      ...initialState,
+      tabs: { sources: [expectedTabs.sources[0]] },
+      activePanelId: 'sources',
+      sourcesPanel: {
+        ...initialState.sourcesPanel,
+        activeTab: expectedTabs.sources[1]
+      }
+    };
+    const newState = reducer(state, newAction);
+    expect(newState).toEqual({
+      ...state,
+      tabs: { ...expectedTabs, sources: newData[0].tabs },
+      sourcesPanel: {
+        ...state.sourcesPanel,
+        activeTab: expectedTabs.sources[0]
+      }
+    });
+  });
 });
 
 test(DASHBOARD_ELEMENT__SET_ACTIVE_TAB, () => {

--- a/frontend/scripts/tests/dashboard-element/reducer.test.js
+++ b/frontend/scripts/tests/dashboard-element/reducer.test.js
@@ -296,14 +296,14 @@ describe(DASHBOARD_ELEMENT__SET_PANEL_TABS, () => {
     });
   });
 
-  it('loads tabs after panel pagination', () => {
+  it('resets page to inital state after loading tabs', () => {
     const state = {
       ...initialState,
-      tabs: { sources: expectedTabs.companies },
+      tabs: { sources: expectedTabs.sources },
       activePanelId: 'sources',
       sourcesPanel: {
         ...initialState.sourcesPanel,
-        activeTab: { id: 0, name: 'someTab' },
+        activeTab: expectedTabs.sources[0],
         page: 4
       }
     };

--- a/frontend/scripts/tests/dashboard-element/saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/saga.test.js
@@ -339,23 +339,23 @@ describe('onFilterClear', () => {
       }
     }
   };
-  const countriesState = {
+  const companiesState = {
     dashboardElement: {
       ...state.dashboardElement,
-      activePanelId: 'countries',
-      countriesPanel: {
-        ...state.dashboardElement.countriesPanel,
+      activePanelId: 'companies',
+      companiesPanel: {
+        ...state.dashboardElement.companiesPanel,
         activeTab: {
-          id: 2
-        },
-        page: 2
+          id: 1
+        }
       }
     }
   };
 
   const clearAction = clearDashboardPanel('companies');
+  const clearAction2 = clearDashboardPanel('commodities');
 
-  it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_DATA} for countries if the active panel is sources`, async () => {
+  it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_DATA} for countries if the active panel is sources and doesnt load sources`, async () => {
     const dispatched = await recordSaga(onFilterClear, clearAction, state);
     // Clears data
     expect(dispatched).toContainEqual({
@@ -369,14 +369,8 @@ describe('onFilterClear', () => {
       type: DASHBOARD_ELEMENT__SET_PANEL_DATA
     });
     expect(dispatched).not.toContainEqual({
-      payload: {
-        key: 'sources',
-        data: null,
-        meta: null,
-        tab: 2,
-        loading: true
-      },
-      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
+      type: DASHBOARD_ELEMENT__SET_PANEL_TABS,
+      payload: { data }
     });
     // Sets data
     expect(dispatched).toContainEqual({
@@ -391,7 +385,7 @@ describe('onFilterClear', () => {
     });
   });
 
-  it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_DATA} for sources too if activeItem for that panel exists`, async () => {
+  it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_DATA} for countries and ${DASHBOARD_ELEMENT__SET_PANEL_TABS} for sources too if countries activeItem exists`, async () => {
     const dispatched = await recordSaga(onFilterClear, clearAction, sourcesStateWithActiveItem);
     // Clears data
     expect(dispatched).toContainEqual({
@@ -404,16 +398,6 @@ describe('onFilterClear', () => {
       },
       type: DASHBOARD_ELEMENT__SET_PANEL_DATA
     });
-    expect(dispatched).toContainEqual({
-      payload: {
-        key: 'sources',
-        data: null,
-        meta: null,
-        tab: 2,
-        loading: true
-      },
-      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
-    });
     // Sets data
     expect(dispatched).toContainEqual({
       payload: {
@@ -426,29 +410,16 @@ describe('onFilterClear', () => {
       type: DASHBOARD_ELEMENT__SET_PANEL_DATA
     });
     expect(dispatched).toContainEqual({
-      payload: {
-        key: 'sources',
-        data,
-        meta,
-        loading: false,
-        tab: 2
-      },
-      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
+      type: DASHBOARD_ELEMENT__SET_PANEL_TABS,
+      payload: { data }
     });
   });
 
-  it('Calls getDashboardPanelData for countries with the active panel if is not sources', async () => {
-    const dispatched = await recordSaga(onFilterClear, clearAction, countriesState);
-    // Clears data
+  it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_TABS} if is companies`, async () => {
+    const dispatched = await recordSaga(onFilterClear, clearAction2, companiesState);
     expect(dispatched).toContainEqual({
-      payload: {
-        key: 'countries',
-        data: null,
-        meta: null,
-        tab: 2,
-        loading: true
-      },
-      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
+      type: DASHBOARD_ELEMENT__SET_PANEL_TABS,
+      payload: { data }
     });
   });
 });

--- a/frontend/scripts/tests/dashboard-element/saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/saga.test.js
@@ -1,5 +1,7 @@
+import { take, fork } from 'redux-saga/effects';
 import { initialState } from 'react-components/dashboard-element/dashboard-element.reducer';
 import {
+  fetchDataOnPanelChange,
   fetchDashboardPanelInitialData,
   getSearchResults,
   onTabChange,
@@ -19,7 +21,8 @@ import {
   DASHBOARD_ELEMENT__SET_PANEL_DATA,
   setDashboardPanelActiveItemWithSearch,
   DASHBOARD_ELEMENT__SET_SEARCH_RESULTS,
-  DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA
+  DASHBOARD_ELEMENT__SET_MORE_PANEL_DATA,
+  DASHBOARD_ELEMENT__SET_ACTIVE_PANEL
 } from 'react-components/dashboard-element/dashboard-element.actions';
 import { getURLFromParams } from 'utils/getURLFromParams';
 import { fetchWithCancel } from 'react-components/dashboard-element/fetch-with-cancel';
@@ -293,21 +296,6 @@ describe('onItemChange', () => {
     });
   });
 
-  it('Recalculates getDashboardPanelData if the active item is missing', async () => {
-    const dispatched = await recordSaga(onItemChange, changeToSourcesAction, state);
-
-    expect(dispatched).toContainEqual({
-      payload: {
-        key: 'sources',
-        data,
-        meta,
-        loading: false,
-        tab: 6
-      },
-      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
-    });
-  });
-
   it('Does not call getDashboardPanelData if we have the active item', async () => {
     const dispatched = await recordSaga(onItemChange, changeToSourcesAction, otherState);
 
@@ -507,5 +495,42 @@ describe('onStepChange', () => {
       },
       type: DASHBOARD_ELEMENT__SET_PANEL_DATA
     });
+  });
+});
+
+describe('fetchDataOnPanelChange', () => {
+  const action = setDashboardActivePanel('companies');
+  const generator = fetchDataOnPanelChange();
+  it(`calls fetchDashboardPanelInitialData on first visit to panel`, () => {
+    generator.next();
+    // saga read the current dashboardElement state
+    generator.next(action);
+    // saga calls fetchDashboardPanelInitialData
+    expect(generator.next(baseState.dashboardElement).value).toEqual(
+      fork(fetchDashboardPanelInitialData, action)
+    );
+  });
+
+  it(`doesn't call fetchDashboardPanelInitialData on second visit to panel`, () => {
+    generator.next();
+    generator.next(action);
+    // saga calls fetchDashboardPanelInitialData
+    expect(generator.next(baseState.dashboardElement).value).toEqual(
+      take(DASHBOARD_ELEMENT__SET_ACTIVE_PANEL)
+    );
+  });
+
+  it(`calls fetchDashboardPanelInitialData when an item has changed`, () => {
+    const state = {
+      ...baseState.dashboardElement,
+      sourcesPanel: {
+        ...baseState.dashboardElement.sourcesPanel,
+        activeItem: { id: 0, name: 'source' }
+      }
+    };
+    generator.next(action);
+    generator.next(state);
+    // saga calls fetchDashboardPanelInitialData
+    expect(generator.next().value).toEqual(fork(fetchDashboardPanelInitialData, action));
   });
 });

--- a/frontend/scripts/tests/utils/record-saga.js
+++ b/frontend/scripts/tests/utils/record-saga.js
@@ -11,6 +11,5 @@ export async function recordSaga(saga, initialAction, state) {
     saga,
     initialAction
   ).done;
-  dispatched._saga = saga;
   return dispatched;
 }

--- a/frontend/scripts/tests/utils/record-saga.js
+++ b/frontend/scripts/tests/utils/record-saga.js
@@ -11,5 +11,6 @@ export async function recordSaga(saga, initialAction, state) {
     saga,
     initialAction
   ).done;
+  dispatched._saga = saga;
   return dispatched;
 }


### PR DESCRIPTION
So I finally tackled the annoying situation where changing panels would cause data reload even if nothing had actually changed. The solution is pretty cool, I'm using `redux-saga's take()` effect to calculate the changes between panel changes 😏 .

Besides that, I discovered another bug on the tabs selection:

#### Current Behavior
1. Fetch new tabs according to selection change.
2. If a selected tab existed prior to tabs fetch, use it as default, otherwise use `tabs[0]`.

Problem? We weren't checking if the selected tab also existed in the new tabs, leaving an invalid selection as default.

#### New Behavior
1. Fetch new tabs according to selection change.
2. If a selected tab existed prior to tabs fetch and exists in new tabs, use it as default, otherwise use `tabs[0]`.

Another issue that is fixed here:
When selecting and deselectin an item the page would reload.

**TODO**
- [x] Add regression test for tabs default value.
- [x] Add test for `fetchDataOnPanelChange` saga.