### PR TITLE
Fix/automate db documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
         - postgresql
       addons:
         postgresql: 10
+      before_install:
+        - sudo apt-get install -y graphviz
       before_script:
         - bundle exec rake db:drop db:create db:structure:load RAILS_ENV=test
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -29,6 +31,17 @@ matrix:
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
+      before_deploy:
+        - bundle exec rake db:doc:html
+
+      deploy:
+        provider: pages
+        skip-cleanup: true
+        github-token: $GITHUB_TOKEN # Set in the settings page of your repository, as a secure variable
+        keep-history: true
+        local-dir: doc/db/gh-pages
+        on:
+          branch: master
 
     - language: node_js
       node_js:

--- a/doc/trase/automated_documentation.md
+++ b/doc/trase/automated_documentation.md
@@ -10,13 +10,14 @@ That is done using a dedicated rake task:
     `rake db:doc:sql`
 
     Note: this rake task also creates a new dump of structure.sql, as comments are part of the schema.
-2. Once comments are in place, it is possible to generate html documentation of the database schema using an external tool. One os such tools is SchemaSpy, which is an open source java library.
+2. Once comments are in place, it is possible to generate html documentation of the database schema using an external tool. One of such tools is SchemaSpy, which is an open source java library.
     1. install [Java](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
     2. install [Graphviz](http://www.graphviz.org/)
-    3. the [SchemaSpy 6.0.0-rc2](http://schemaspy.readthedocs.io/en/latest/index.html) jar file and [PostgreSQL driver](https://jdbc.postgresql.org/download.html) file are already in doc/db
+    3. the [SchemaSpy](http://schemaspy.readthedocs.io/en/latest/index.html) jar file and [PostgreSQL driver](https://jdbc.postgresql.org/download.html) file are already in doc/db
     4. `rake db:doc:html`
-    5. output files are in `doc/db/all_tables` (complete schema) and `doc/db/blue_tables` (only blue tables)
-3. to update the [GH pages site](https://vizzuality.github.io/trase-api/) all the generated files from `doc/db/all_tables` and `doc/db/blue_tables` need to land in the top-level of the `gh-pages` branch. This is currently a manual process, easiest to have the repo checked out twice on local drive to be able to copy between branches (not great and not final.)
+    5. output files are in `doc/db/gh-pages/all_tables` (complete schema) and `doc/db/gh-pages/blue_tables` (only blue tables)
+3. regenerating the documentation and updating gh-pages is a part of the Travis CI build. When building against `master`, Travis will push to gh pages after a successful build. This uses the [Deployment Pages](https://docs.travis-ci.com/user/deployment/pages/) feature of Travis, and currently is set up using a personal GITHUB_TOKEN defined directly in Travis CI repo settings.
+4. to regenerate html docs and update the [GH pages site](https://vizzuality.github.io/trase-api/) on demand, run `bundle exec rake db:doc:html_2_gh_pages`
 
 ## Ruby code documentation
 

--- a/lib/tasks/db_doc.rake
+++ b/lib/tasks/db_doc.rake
@@ -1,5 +1,6 @@
 require 'db_helpers/search_path_helpers.rb'
 require 'db_helpers/comment_helpers.rb'
+require 'English'
 include SearchPathHelpers
 include CommentHelpers
 
@@ -70,6 +71,39 @@ namespace :db do
       schema_spy_options << "-s #{schema_name}" if schema_name
       schema_spy_options << "-i \"#{tables.join('|')}\"" if tables
       system("java #{schema_spy_options.join(' ')}")
+    end
+
+    desc 'Generate html schema documentation and push to GH pages'
+    task html_2_gh_pages: [:html, :gh_pages]
+
+    desc 'Generate html schema documentation and push to GH pages'
+    task gh_pages: [:environment] do
+      run_gh_pages_update
+    end
+
+    def run_gh_pages_update
+      tmp_dir = 'tmp-gh-pages'
+      repo_name = 'trase'
+
+      # get current revision (this assumes we've just pushed to develop)"
+      revision = `git rev-parse HEAD`.chomp
+      raise('Cannot read current revision') unless revision
+
+      [
+        "mkdir -p #{tmp_dir}",
+        # clone gh pages branch
+        "cd #{tmp_dir}; git clone --depth=1 --branch=gh-pages git@github.com:Vizzuality/#{repo_name}.git",
+        # copy html files (this assumes we've just regenerated them)
+        "cp -a #{OUTPUT_DIR}/ #{tmp_dir}/#{repo_name}/",
+        # push to gh-pages
+        "cd #{tmp_dir}/#{repo_name}; git add .; git commit -m \"Update #{revision}\"; git push origin gh-pages"
+      ].each do |cmd|
+        puts "#{Time.now.strftime('%Y%m%d-%H:%M:%S%:z')}: #{cmd}"
+        system(cmd)
+        raise('Updating gh-pages failed') unless $CHILD_STATUS.success?
+      end
+    ensure
+      `rm -rf #{tmp_dir}` if File.directory?(tmp_dir)
     end
   end
 end


### PR DESCRIPTION
This automates generating the db documentation using Travis CI deploy pages feature. On the master branch it builds the docs using `rake db:doc:html` and then pushes the outputs to the `gh-pages` branch. The published schema documentation is at https://vizzuality.github.io/trase/all_tables/.

Note: before I set the branch to master, I tested it on the current branch, so you can check out the automated commits in https://github.com/Vizzuality/trase/tree/gh-pages

PS: Travis also supports deploying to surge: https://docs.travis-ci.com/user/deployment/surge/