### PR TITLE
Add tables to support context specific, country specific and commodit…

### DIFF
--- a/app/models/api/v3/chart.rb
+++ b/app/models/api/v3/chart.rb
@@ -10,7 +10,20 @@
 #  position   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  chart_type :text
+#  chart_type :string
+#
+# Indexes
+#
+#  charts_profile_id_parent_id_identifier_key  (profile_id,parent_id,identifier) UNIQUE
+#  charts_profile_id_parent_id_position_key    (profile_id,parent_id,position) UNIQUE
+#  index_charts_on_parent_id                   (parent_id)
+#  index_charts_on_profile_id                  (profile_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (parent_id => charts.id) ON DELETE => cascade
+#  fk_rails_...  (profile_id => profiles.id) ON DELETE => cascade
+#
 
 # Indexes
 #

--- a/app/models/api/v3/commodity.rb
+++ b/app/models/api/v3/commodity.rb
@@ -19,6 +19,10 @@ module Api
       has_many :dashboard_template_commodities
       has_many :dashboard_templates, through: :dashboard_template_commodities
 
+      has_many :ind_commodity_properties
+      has_many :quant_commodity_properties
+      has_many :qual_commodity_properties
+
       validates :name, presence: true, uniqueness: true
 
       def self.import_key

--- a/app/models/api/v3/context.rb
+++ b/app/models/api/v3/context.rb
@@ -39,6 +39,10 @@ module Api
       has_many :map_attributes, through: :map_attribute_groups
       has_many :flows
 
+      has_many :ind_context_properties
+      has_many :quant_context_properties
+      has_many :qual_context_properties
+
       delegate :is_default, to: :context_property
       delegate :is_disabled, to: :context_property
       delegate :is_subnational, to: :context_property

--- a/app/models/api/v3/country.rb
+++ b/app/models/api/v3/country.rb
@@ -21,6 +21,10 @@ module Api
       has_many :dashboard_template_countries
       has_many :dashboard_templates, through: :dashboard_template_countries
 
+      has_many :ind_country_properties
+      has_many :quant_country_properties
+      has_many :qual_country_properties
+
       delegate :latitude, to: :country_property
       delegate :longitude, to: :country_property
       delegate :zoom, to: :country_property

--- a/app/models/api/v3/ind.rb
+++ b/app/models/api/v3/ind.rb
@@ -17,6 +17,9 @@ module Api
     class Ind < BlueTable
       has_one :ind_property
       has_many :node_inds
+      has_many :ind_context_properties
+      has_many :ind_commodity_properties
+      has_many :ind_country_properties
 
       delegate :display_name, to: :ind_property, allow_nil: true
 

--- a/app/models/api/v3/ind_commodity_property.rb
+++ b/app/models/api/v3/ind_commodity_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: ind_commodity_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  commodity_id :bigint(8)
+#  ind_id       :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_ind_commodity_properties_on_commodity_id  (commodity_id)
+#  index_ind_commodity_properties_on_ind_id        (ind_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (commodity_id => commodities.id)
+#  fk_rails_...  (ind_id => inds.id)
+#
+
+module Api
+  module V3
+    class IndCommodityProperty < ApplicationRecord
+      belongs_to :commodity
+      belongs_to :ind
+    end
+  end
+end

--- a/app/models/api/v3/ind_context_property.rb
+++ b/app/models/api/v3/ind_context_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: ind_context_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  context_id   :bigint(8)
+#  ind_id       :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_ind_context_properties_on_context_id  (context_id)
+#  index_ind_context_properties_on_ind_id      (ind_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (context_id => contexts.id)
+#  fk_rails_...  (ind_id => inds.id)
+#
+
+module Api
+  module V3
+    class IndContextProperty < ApplicationRecord
+      belongs_to :context
+      belongs_to :ind
+    end
+  end
+end

--- a/app/models/api/v3/ind_country_property.rb
+++ b/app/models/api/v3/ind_country_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: ind_country_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  country_id   :bigint(8)
+#  ind_id       :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_ind_country_properties_on_country_id  (country_id)
+#  index_ind_country_properties_on_ind_id      (ind_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (country_id => countries.id)
+#  fk_rails_...  (ind_id => inds.id)
+#
+
+module Api
+  module V3
+    class IndCountryProperty < ApplicationRecord
+      belongs_to :country
+      belongs_to :ind
+    end
+  end
+end

--- a/app/models/api/v3/qual.rb
+++ b/app/models/api/v3/qual.rb
@@ -16,6 +16,9 @@ module Api
     class Qual < BlueTable
       has_one :qual_property
       has_many :node_quals
+      has_many :qual_context_properties
+      has_many :qual_commodity_properties
+      has_many :qual_country_properties
 
       delegate :display_name, to: :qual_property, allow_nil: true
 

--- a/app/models/api/v3/qual_commodity_property.rb
+++ b/app/models/api/v3/qual_commodity_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: qual_commodity_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  commodity_id :bigint(8)
+#  qual_id      :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_qual_commodity_properties_on_commodity_id  (commodity_id)
+#  index_qual_commodity_properties_on_qual_id       (qual_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (commodity_id => commodities.id)
+#  fk_rails_...  (qual_id => quals.id)
+#
+
+module Api
+  module V3
+    class QualCommodityProperty < ApplicationRecord
+      belongs_to :commodity
+      belongs_to :qual
+    end
+  end
+end

--- a/app/models/api/v3/qual_context_property.rb
+++ b/app/models/api/v3/qual_context_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: qual_context_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  context_id   :bigint(8)
+#  qual_id      :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_qual_context_properties_on_context_id  (context_id)
+#  index_qual_context_properties_on_qual_id     (qual_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (context_id => contexts.id)
+#  fk_rails_...  (qual_id => quals.id)
+#
+
+module Api
+  module V3
+    class QualContextProperty < ApplicationRecord
+      belongs_to :context
+      belongs_to :qual
+    end
+  end
+end

--- a/app/models/api/v3/qual_country_property.rb
+++ b/app/models/api/v3/qual_country_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: qual_country_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  country_id   :bigint(8)
+#  qual_id      :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_qual_country_properties_on_country_id  (country_id)
+#  index_qual_country_properties_on_qual_id     (qual_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (country_id => countries.id)
+#  fk_rails_...  (qual_id => quals.id)
+#
+
+module Api
+  module V3
+    class QualCountryProperty < ApplicationRecord
+      belongs_to :country
+      belongs_to :qual
+    end
+  end
+end

--- a/app/models/api/v3/quant.rb
+++ b/app/models/api/v3/quant.rb
@@ -17,6 +17,9 @@ module Api
     class Quant < BlueTable
       has_one :quant_property
       has_many :node_quants
+      has_many :quant_context_properties
+      has_many :quant_commodity_properties
+      has_many :quant_country_properties
 
       delegate :display_name, to: :quant_property, allow_nil: true
 

--- a/app/models/api/v3/quant_commodity_property.rb
+++ b/app/models/api/v3/quant_commodity_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: quant_commodity_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  commodity_id :bigint(8)
+#  quant_id     :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_quant_commodity_properties_on_commodity_id  (commodity_id)
+#  index_quant_commodity_properties_on_quant_id      (quant_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (commodity_id => commodities.id)
+#  fk_rails_...  (quant_id => quants.id)
+#
+
+module Api
+  module V3
+    class QuantCommodityProperty < ApplicationRecord
+      belongs_to :commodity
+      belongs_to :quant
+    end
+  end
+end

--- a/app/models/api/v3/quant_context_property.rb
+++ b/app/models/api/v3/quant_context_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: quant_context_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  context_id   :bigint(8)
+#  quant_id     :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_quant_context_properties_on_context_id  (context_id)
+#  index_quant_context_properties_on_quant_id    (quant_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (context_id => contexts.id)
+#  fk_rails_...  (quant_id => quants.id)
+#
+
+module Api
+  module V3
+    class QuantContextProperty < ApplicationRecord
+      belongs_to :context
+      belongs_to :quant
+    end
+  end
+end

--- a/app/models/api/v3/quant_country_property.rb
+++ b/app/models/api/v3/quant_country_property.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: quant_country_properties
+#
+#  id           :bigint(8)        not null, primary key
+#  tooltip_text :text
+#  country_id   :bigint(8)
+#  quant_id     :bigint(8)
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_quant_country_properties_on_country_id  (country_id)
+#  index_quant_country_properties_on_quant_id    (quant_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (country_id => countries.id)
+#  fk_rails_...  (quant_id => quants.id)
+#
+
+module Api
+  module V3
+    class QuantCountryProperty < ApplicationRecord
+      belongs_to :country
+      belongs_to :quant
+    end
+  end
+end

--- a/app/models/api/v3/readonly/commodity_attribute_property.rb
+++ b/app/models/api/v3/readonly/commodity_attribute_property.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: commodity_attribute_properties_mv
+#
+#  id           :bigint(8)        primary key
+#  commodity_id :bigint(8)
+#  tooltip_text :text
+#  qual_id      :bigint(8)
+#  ind_id       :bigint(8)
+#  quant_id     :bigint(8)
+#
+# Indexes
+#
+#  index_commodity_attribute_properties_mv_id_idx  (id) UNIQUE
+#
+
+module Api
+  module V3
+    module Readonly
+      class CommodityAttributeProperty < Api::V3::Readonly::BaseModel
+        self.table_name = 'commodity_attribute_properties_mv'
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/context_attribute_property.rb
+++ b/app/models/api/v3/readonly/context_attribute_property.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: context_attribute_properties_mv
+#
+#  id           :bigint(8)        primary key
+#  context_id   :bigint(8)
+#  tooltip_text :text
+#  qual_id      :bigint(8)
+#  ind_id       :bigint(8)
+#  quant_id     :bigint(8)
+#
+# Indexes
+#
+#  index_context_attribute_properties_mv_id_idx  (id) UNIQUE
+#
+
+module Api
+  module V3
+    module Readonly
+      class ContextAttributeProperty < Api::V3::Readonly::BaseModel
+        self.table_name = 'context_attribute_properties_mv'
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/country_attribute_property.rb
+++ b/app/models/api/v3/readonly/country_attribute_property.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: country_attribute_properties_mv
+#
+#  id           :bigint(8)        primary key
+#  country_id   :bigint(8)
+#  tooltip_text :text
+#  qual_id      :bigint(8)
+#  ind_id       :bigint(8)
+#  quant_id     :bigint(8)
+#
+# Indexes
+#
+#  index_country_attribute_properties_mv_id_idx  (id) UNIQUE
+#
+
+module Api
+  module V3
+    module Readonly
+      class CountryAttributeProperty < Api::V3::Readonly::BaseModel
+        self.table_name = 'country_attribute_properties_mv'
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/download_flow.rb
+++ b/app/models/api/v3/readonly/download_flow.rb
@@ -63,6 +63,7 @@ module Api
           def after_refresh(options = {})
             Api::V3::Download::PrecomputedDownload.clear
             return if options[:skip_precompute]
+
             Api::V3::Download::PrecomputedDownload.refresh_later
           end
         end

--- a/app/services/api/v3/actors/sustainability_table.rb
+++ b/app/services/api/v3/actors/sustainability_table.rb
@@ -11,6 +11,7 @@ module Api
           @context = context
           @node = node
           @year = year
+
           # Assumption: Volume is a special quant which always exists
           @volume_attribute = Dictionary::Quant.instance.get('Volume')
           raise 'Quant Volume not found' unless @volume_attribute.present?
@@ -82,7 +83,7 @@ module Api
                     {
                       name: ro_chart_attribute.display_name,
                       unit: ro_chart_attribute.unit,
-                      tooltip: ro_chart_attribute.tooltip_text
+                      tooltip: get_tooltip(ro_chart_attribute)
                     }
                   end,
             rows: rows
@@ -134,6 +135,26 @@ module Api
                 {value: attribute_total} if attribute_total
               end
           }
+        end
+
+        def get_tooltip(ro_chart_attribute)
+          attr_id = "#{ro_chart_attribute.original_type.downcase}_id".to_sym
+          context_tooltip = Api::V3::Readonly::ContextAttributeProperty.
+            find_by(attr_id.to_sym => ro_chart_attribute.original_id,
+                    context_id: @context.id)
+          return context_tooltip unless context_tooltip.nil?
+
+          country_tooltip = Api::V3::Readonly::CountryAttributeProperty.
+            find_by(attr_id.to_sym => ro_chart_attribute.original_id,
+                    country_id: @context.country_id)
+          return country_tooltip unless country_tooltip.nil?
+
+          commodity_tooltip = Api::V3::Readonly::CommodityAttributeProperty.
+            find_by(attr_id.to_sym => ro_chart_attribute.original_id,
+                    commodity_id: @context.commodity_id)
+          return commodity_tooltip unless commodity_tooltip.nil?
+
+          ro_chart_attribute.tooltip_text
         end
       end
     end

--- a/db/migrate/20190228115321_create_ind_context_properties.rb
+++ b/db/migrate/20190228115321_create_ind_context_properties.rb
@@ -1,0 +1,11 @@
+class CreateIndContextProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :ind_context_properties do |t|
+      t.text :tooltip_text
+      t.references :context, foreign_key: true
+      t.references :ind, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190228115345_create_quant_context_properties.rb
+++ b/db/migrate/20190228115345_create_quant_context_properties.rb
@@ -1,0 +1,11 @@
+class CreateQuantContextProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :quant_context_properties do |t|
+      t.text :tooltip_text
+      t.references :context, foreign_key: true
+      t.references :quant, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190228115409_create_qual_context_properties.rb
+++ b/db/migrate/20190228115409_create_qual_context_properties.rb
@@ -1,0 +1,11 @@
+class CreateQualContextProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :qual_context_properties do |t|
+      t.text :tooltip_text
+      t.references :context, foreign_key: true
+      t.references :qual, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190301121434_create_context_attribute_properties_mv.rb
+++ b/db/migrate/20190301121434_create_context_attribute_properties_mv.rb
@@ -1,0 +1,8 @@
+class CreateContextAttributePropertiesMv < ActiveRecord::Migration[5.2]
+  def change
+    create_view :context_attribute_properties_mv, version: 1, materialized: true
+
+    add_index :context_attribute_properties_mv, :id, unique: true,
+        name: 'index_context_attribute_properties_mv_id_idx'
+  end
+end

--- a/db/migrate/20190301170044_create_qual_commodity_properties.rb
+++ b/db/migrate/20190301170044_create_qual_commodity_properties.rb
@@ -1,0 +1,11 @@
+class CreateQualCommodityProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :qual_commodity_properties do |t|
+      t.text :tooltip_text
+      t.references :commodity, foreign_key: true
+      t.references :qual, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190301170114_create_quant_commodity_properties.rb
+++ b/db/migrate/20190301170114_create_quant_commodity_properties.rb
@@ -1,0 +1,11 @@
+class CreateQuantCommodityProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :quant_commodity_properties do |t|
+      t.text :tooltip_text
+      t.references :commodity, foreign_key: true
+      t.references :quant, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190301170138_create_ind_commodity_properties.rb
+++ b/db/migrate/20190301170138_create_ind_commodity_properties.rb
@@ -1,0 +1,11 @@
+class CreateIndCommodityProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :ind_commodity_properties do |t|
+      t.text :tooltip_text
+      t.references :commodity, foreign_key: true
+      t.references :ind, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190301170523_create_commodity_attribute_properties_mv.rb
+++ b/db/migrate/20190301170523_create_commodity_attribute_properties_mv.rb
@@ -1,0 +1,8 @@
+class CreateCommodityAttributePropertiesMv < ActiveRecord::Migration[5.2]
+  def change
+    create_view :commodity_attribute_properties_mv, version: 1, materialized: true
+
+    add_index :commodity_attribute_properties_mv, :id, unique: true,
+        name: 'index_commodity_attribute_properties_mv_id_idx'
+  end
+end

--- a/db/migrate/20190301173716_create_qual_country_properties.rb
+++ b/db/migrate/20190301173716_create_qual_country_properties.rb
@@ -1,0 +1,11 @@
+class CreateQualCountryProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :qual_country_properties do |t|
+      t.text :tooltip_text
+      t.references :country, foreign_key: true
+      t.references :qual, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190301173748_create_quant_country_properties.rb
+++ b/db/migrate/20190301173748_create_quant_country_properties.rb
@@ -1,0 +1,11 @@
+class CreateQuantCountryProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :quant_country_properties do |t|
+      t.text :tooltip_text
+      t.references :country, foreign_key: true
+      t.references :quant, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190301173808_create_ind_country_properties.rb
+++ b/db/migrate/20190301173808_create_ind_country_properties.rb
@@ -1,0 +1,11 @@
+class CreateIndCountryProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :ind_country_properties do |t|
+      t.text :tooltip_text
+      t.references :country, foreign_key: true
+      t.references :ind, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190301173824_create_country_attribute_properties_mv.rb
+++ b/db/migrate/20190301173824_create_country_attribute_properties_mv.rb
@@ -1,0 +1,8 @@
+class CreateCountryAttributePropertiesMv < ActiveRecord::Migration[5.2]
+  def change
+    create_view :country_attribute_properties_mv, version: 1, materialized: true
+
+    add_index :country_attribute_properties_mv, :id, unique: true,
+        name: 'index_country_attribute_properties_mv_id_idx'
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -31,6 +31,87 @@ tables:
         comment: Only used for trajectory deforestation plot in place profiles
   - name: chart_inds
     comment: Inds to display in a chart (see chart_attributes.)
+  - name: ind_context_properties
+    comment: Context specific properties for ind (like tooltip text)
+    columns:
+      - name: context_id
+        comment: Reference to context
+      - name: ind_id
+        comment: Reference to ind
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: quant_context_properties
+    comment: Context specific properties for quant (like tooltip text)
+    columns:
+      - name: context_id
+        comment: Reference to context
+      - name: quant_id
+        comment: Reference to quant
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: qual_context_properties
+    comment: Context specific properties for qual (like tooltip text)
+    columns:
+      - name: context_id
+        comment: Reference to context
+      - name: qual_id
+        comment: Reference to qual
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: ind_commodity_properties
+    comment: Commodity specific properties for ind
+    columns:
+      - name: commodity_id
+        comment: Reference to commodity
+      - name: ind_id
+        comment: Reference to ind
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: quant_commodity_properties
+    comment: Commodity specific properties for quant
+    columns:
+      - name: commodity_id
+        comment: Reference to commodity
+      - name: quant_id
+        comment: Reference to quant
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: qual_commodity_properties
+    comment: Commodity specific properties for qual
+    columns:
+      - name: commodity_id
+        comment: Reference to commodity
+      - name: qual_id
+        comment: Reference to qual
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: ind_country_properties
+    comment: Country specific properties for ind
+    columns:
+      - name: country_id
+        comment: Reference to country
+      - name: ind_id
+        comment: Reference to ind
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: quant_country_properties
+    comment: Country specific properties for quant
+    columns:
+      - name: country_id
+        comment: Reference to country
+      - name: quant_id
+        comment: Reference to quant
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: qual_country_properties
+    comment: Country specific properties for qual
+    columns:
+      - name: country_id
+        comment: Reference to country
+      - name: qual_id
+        comment: Reference to qual
+      - name: tooltip_text
+        comment: Tooltip text
   - name: chart_node_types
     comment: Node types to display in a chart.
     columns:
@@ -495,3 +576,42 @@ materialized_views:
     columns:
       - name: attribute_id
         comment: References the unique id in attributes_mv.
+  - name: context_attribute_properties_mv
+    comment: Materialized view combining context specific properties for inds, quals and quants.
+    columns:
+      - name: ind_id
+        comment: Reference to ind
+      - name: quant_id
+        comment: Reference to quant
+      - name: qual_id
+        comment: Reference to qual 
+      - name: context_id
+        comment: Reference to context
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: commodity_attribute_properties_mv
+    comment: Materialized view combining commodity specific properties for inds, quals and quants.
+    columns:
+      - name: ind_id
+        comment: Reference to ind
+      - name: quant_id
+        comment: Reference to quant
+      - name: qual_id
+        comment: Reference to qual 
+      - name: commodity_id
+        comment: Reference to commodity
+      - name: tooltip_text
+        comment: Tooltip text
+  - name: country_attribute_properties_mv
+    comment: Materialized view combining country specific properties for inds, quals and quants.
+    columns:
+      - name: ind_id
+        comment: Reference to ind
+      - name: quant_id
+        comment: Reference to quant
+      - name: qual_id
+        comment: Reference to qual 
+      - name: country_id
+        comment: Reference to country
+      - name: tooltip_text
+        comment: Tooltip text

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -770,7 +770,7 @@ CREATE MATERIALIZED VIEW public.attributes_mv AS
             NULL::text AS text
            FROM (public.quals
              LEFT JOIN public.qual_properties qp ON ((qp.qual_id = quals.id)))) s
-  WITH NO DATA;
+  WITH DATA;
 
 
 --
@@ -1102,7 +1102,7 @@ UNION ALL
    FROM ((public.chart_inds chi
      JOIN public.chart_attributes cha ON ((cha.id = chi.chart_attribute_id)))
      JOIN public.attributes_mv a ON (((a.original_id = chi.ind_id) AND (a.original_type = 'Ind'::text))))
-  WITH NO DATA;
+  WITH DATA;
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1431,7 +1431,7 @@ UNION ALL
     ind_commodity_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_commodity_properties
-  WITH NO DATA;
+  WITH DATA;
 
 
 --
@@ -1504,7 +1504,7 @@ UNION ALL
     ind_context_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_context_properties
-  WITH NO DATA;
+  WITH DATA;
 
 
 --
@@ -2018,7 +2018,7 @@ UNION ALL
     ind_country_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_country_properties
-  WITH NO DATA;
+  WITH DATA;
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1362,6 +1362,152 @@ ALTER SEQUENCE public.commodities_id_seq OWNED BY public.commodities.id;
 
 
 --
+-- Name: ind_commodity_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ind_commodity_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    commodity_id bigint,
+    ind_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: qual_commodity_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.qual_commodity_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    commodity_id bigint,
+    qual_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: quant_commodity_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quant_commodity_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    commodity_id bigint,
+    quant_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: commodity_attribute_properties_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.commodity_attribute_properties_mv AS
+ SELECT qual_commodity_properties.id,
+    qual_commodity_properties.commodity_id,
+    qual_commodity_properties.tooltip_text,
+    qual_commodity_properties.qual_id,
+    '-1'::integer AS ind_id,
+    '-1'::integer AS quant_id
+   FROM public.qual_commodity_properties
+UNION ALL
+ SELECT quant_commodity_properties.id,
+    quant_commodity_properties.commodity_id,
+    quant_commodity_properties.tooltip_text,
+    '-1'::integer AS qual_id,
+    '-1'::integer AS ind_id,
+    quant_commodity_properties.quant_id
+   FROM public.quant_commodity_properties
+UNION ALL
+ SELECT ind_commodity_properties.id,
+    ind_commodity_properties.commodity_id,
+    ind_commodity_properties.tooltip_text,
+    '-1'::integer AS qual_id,
+    ind_commodity_properties.ind_id,
+    '-1'::integer AS quant_id
+   FROM public.ind_commodity_properties
+  WITH NO DATA;
+
+
+--
+-- Name: ind_context_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ind_context_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    context_id bigint,
+    ind_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: qual_context_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.qual_context_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    context_id bigint,
+    qual_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: quant_context_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quant_context_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    context_id bigint,
+    quant_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: context_attribute_properties_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.context_attribute_properties_mv AS
+ SELECT qual_context_properties.id,
+    qual_context_properties.context_id,
+    qual_context_properties.tooltip_text,
+    qual_context_properties.qual_id,
+    '-1'::integer AS ind_id,
+    '-1'::integer AS quant_id
+   FROM public.qual_context_properties
+UNION ALL
+ SELECT quant_context_properties.id,
+    quant_context_properties.context_id,
+    quant_context_properties.tooltip_text,
+    '-1'::integer AS qual_id,
+    '-1'::integer AS ind_id,
+    quant_context_properties.quant_id
+   FROM public.quant_context_properties
+UNION ALL
+ SELECT ind_context_properties.id,
+    ind_context_properties.context_id,
+    ind_context_properties.tooltip_text,
+    '-1'::integer AS qual_id,
+    ind_context_properties.ind_id,
+    '-1'::integer AS quant_id
+   FROM public.ind_context_properties
+  WITH NO DATA;
+
+
+--
 -- Name: context_node_type_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1800,6 +1946,79 @@ CREATE SEQUENCE public.countries_id_seq
 --
 
 ALTER SEQUENCE public.countries_id_seq OWNED BY public.countries.id;
+
+
+--
+-- Name: ind_country_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ind_country_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    country_id bigint,
+    ind_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: qual_country_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.qual_country_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    country_id bigint,
+    qual_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: quant_country_properties; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.quant_country_properties (
+    id bigint NOT NULL,
+    tooltip_text text,
+    country_id bigint,
+    quant_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: country_attribute_properties_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.country_attribute_properties_mv AS
+ SELECT qual_country_properties.id,
+    qual_country_properties.country_id,
+    qual_country_properties.tooltip_text,
+    qual_country_properties.qual_id,
+    '-1'::integer AS ind_id,
+    '-1'::integer AS quant_id
+   FROM public.qual_country_properties
+UNION ALL
+ SELECT quant_country_properties.id,
+    quant_country_properties.country_id,
+    quant_country_properties.tooltip_text,
+    '-1'::integer AS qual_id,
+    '-1'::integer AS ind_id,
+    quant_country_properties.quant_id
+   FROM public.quant_country_properties
+UNION ALL
+ SELECT ind_country_properties.id,
+    ind_country_properties.country_id,
+    ind_country_properties.tooltip_text,
+    '-1'::integer AS qual_id,
+    ind_country_properties.ind_id,
+    '-1'::integer AS quant_id
+   FROM public.ind_country_properties
+  WITH NO DATA;
 
 
 --
@@ -3538,6 +3757,63 @@ ALTER SEQUENCE public.flows_id_seq OWNED BY public.flows.id;
 
 
 --
+-- Name: ind_commodity_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ind_commodity_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ind_commodity_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ind_commodity_properties_id_seq OWNED BY public.ind_commodity_properties.id;
+
+
+--
+-- Name: ind_context_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ind_context_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ind_context_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ind_context_properties_id_seq OWNED BY public.ind_context_properties.id;
+
+
+--
+-- Name: ind_country_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ind_country_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ind_country_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ind_country_properties_id_seq OWNED BY public.ind_country_properties.id;
+
+
+--
 -- Name: ind_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -4176,6 +4452,63 @@ ALTER SEQUENCE public.profiles_id_seq OWNED BY public.profiles.id;
 
 
 --
+-- Name: qual_commodity_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.qual_commodity_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: qual_commodity_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.qual_commodity_properties_id_seq OWNED BY public.qual_commodity_properties.id;
+
+
+--
+-- Name: qual_context_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.qual_context_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: qual_context_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.qual_context_properties_id_seq OWNED BY public.qual_context_properties.id;
+
+
+--
+-- Name: qual_country_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.qual_country_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: qual_country_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.qual_country_properties_id_seq OWNED BY public.qual_country_properties.id;
+
+
+--
 -- Name: qual_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -4211,6 +4544,63 @@ CREATE SEQUENCE public.quals_id_seq
 --
 
 ALTER SEQUENCE public.quals_id_seq OWNED BY public.quals.id;
+
+
+--
+-- Name: quant_commodity_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.quant_commodity_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: quant_commodity_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.quant_commodity_properties_id_seq OWNED BY public.quant_commodity_properties.id;
+
+
+--
+-- Name: quant_context_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.quant_context_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: quant_context_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.quant_context_properties_id_seq OWNED BY public.quant_context_properties.id;
+
+
+--
+-- Name: quant_country_properties_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.quant_country_properties_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: quant_country_properties_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.quant_country_properties_id_seq OWNED BY public.quant_country_properties.id;
 
 
 --
@@ -5005,6 +5395,27 @@ ALTER TABLE ONLY public.flows ALTER COLUMN id SET DEFAULT nextval('public.flows_
 
 
 --
+-- Name: ind_commodity_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_commodity_properties ALTER COLUMN id SET DEFAULT nextval('public.ind_commodity_properties_id_seq'::regclass);
+
+
+--
+-- Name: ind_context_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_context_properties ALTER COLUMN id SET DEFAULT nextval('public.ind_context_properties_id_seq'::regclass);
+
+
+--
+-- Name: ind_country_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_country_properties ALTER COLUMN id SET DEFAULT nextval('public.ind_country_properties_id_seq'::regclass);
+
+
+--
 -- Name: ind_properties id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5096,6 +5507,27 @@ ALTER TABLE ONLY public.profiles ALTER COLUMN id SET DEFAULT nextval('public.pro
 
 
 --
+-- Name: qual_commodity_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_commodity_properties ALTER COLUMN id SET DEFAULT nextval('public.qual_commodity_properties_id_seq'::regclass);
+
+
+--
+-- Name: qual_context_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_context_properties ALTER COLUMN id SET DEFAULT nextval('public.qual_context_properties_id_seq'::regclass);
+
+
+--
+-- Name: qual_country_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_country_properties ALTER COLUMN id SET DEFAULT nextval('public.qual_country_properties_id_seq'::regclass);
+
+
+--
 -- Name: qual_properties id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5107,6 +5539,27 @@ ALTER TABLE ONLY public.qual_properties ALTER COLUMN id SET DEFAULT nextval('pub
 --
 
 ALTER TABLE ONLY public.quals ALTER COLUMN id SET DEFAULT nextval('public.quals_id_seq'::regclass);
+
+
+--
+-- Name: quant_commodity_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_commodity_properties ALTER COLUMN id SET DEFAULT nextval('public.quant_commodity_properties_id_seq'::regclass);
+
+
+--
+-- Name: quant_context_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_context_properties ALTER COLUMN id SET DEFAULT nextval('public.quant_context_properties_id_seq'::regclass);
+
+
+--
+-- Name: quant_country_properties id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_country_properties ALTER COLUMN id SET DEFAULT nextval('public.quant_country_properties_id_seq'::regclass);
 
 
 --
@@ -5759,6 +6212,30 @@ ALTER TABLE ONLY public.flows
 
 
 --
+-- Name: ind_commodity_properties ind_commodity_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_commodity_properties
+    ADD CONSTRAINT ind_commodity_properties_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ind_context_properties ind_context_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_context_properties
+    ADD CONSTRAINT ind_context_properties_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ind_country_properties ind_country_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_country_properties
+    ADD CONSTRAINT ind_country_properties_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: ind_properties ind_properties_ind_id_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5959,6 +6436,30 @@ ALTER TABLE ONLY public.profiles
 
 
 --
+-- Name: qual_commodity_properties qual_commodity_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_commodity_properties
+    ADD CONSTRAINT qual_commodity_properties_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: qual_context_properties qual_context_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_context_properties
+    ADD CONSTRAINT qual_context_properties_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: qual_country_properties qual_country_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_country_properties
+    ADD CONSTRAINT qual_country_properties_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: qual_properties qual_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5988,6 +6489,30 @@ ALTER TABLE ONLY public.quals
 
 ALTER TABLE ONLY public.quals
     ADD CONSTRAINT quals_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quant_commodity_properties quant_commodity_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_commodity_properties
+    ADD CONSTRAINT quant_commodity_properties_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quant_context_properties quant_context_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_context_properties
+    ADD CONSTRAINT quant_context_properties_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: quant_country_properties quant_country_properties_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_country_properties
+    ADD CONSTRAINT quant_country_properties_pkey PRIMARY KEY (id);
 
 
 --
@@ -6615,6 +7140,20 @@ CREATE INDEX index_charts_on_profile_id ON public.charts USING btree (profile_id
 
 
 --
+-- Name: index_commodity_attribute_properties_mv_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_commodity_attribute_properties_mv_id_idx ON public.commodity_attribute_properties_mv USING btree (id);
+
+
+--
+-- Name: index_context_attribute_properties_mv_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_context_attribute_properties_mv_id_idx ON public.context_attribute_properties_mv USING btree (id);
+
+
+--
 -- Name: index_context_node_type_properties_on_context_node_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6661,6 +7200,13 @@ CREATE INDEX index_contexts_on_country_id ON public.contexts USING btree (countr
 --
 
 CREATE INDEX index_contextual_layers_on_context_id ON public.contextual_layers USING btree (context_id);
+
+
+--
+-- Name: index_country_attribute_properties_mv_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_country_attribute_properties_mv_id_idx ON public.country_attribute_properties_mv USING btree (id);
 
 
 --
@@ -6818,6 +7364,48 @@ CREATE INDEX index_flows_on_path ON public.flows USING btree (path);
 
 
 --
+-- Name: index_ind_commodity_properties_on_commodity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ind_commodity_properties_on_commodity_id ON public.ind_commodity_properties USING btree (commodity_id);
+
+
+--
+-- Name: index_ind_commodity_properties_on_ind_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ind_commodity_properties_on_ind_id ON public.ind_commodity_properties USING btree (ind_id);
+
+
+--
+-- Name: index_ind_context_properties_on_context_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ind_context_properties_on_context_id ON public.ind_context_properties USING btree (context_id);
+
+
+--
+-- Name: index_ind_context_properties_on_ind_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ind_context_properties_on_ind_id ON public.ind_context_properties USING btree (ind_id);
+
+
+--
+-- Name: index_ind_country_properties_on_country_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ind_country_properties_on_country_id ON public.ind_country_properties USING btree (country_id);
+
+
+--
+-- Name: index_ind_country_properties_on_ind_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ind_country_properties_on_ind_id ON public.ind_country_properties USING btree (ind_id);
+
+
+--
 -- Name: index_ind_properties_on_ind_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6902,10 +7490,94 @@ CREATE INDEX index_profiles_on_context_node_type_id ON public.profiles USING btr
 
 
 --
+-- Name: index_qual_commodity_properties_on_commodity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_qual_commodity_properties_on_commodity_id ON public.qual_commodity_properties USING btree (commodity_id);
+
+
+--
+-- Name: index_qual_commodity_properties_on_qual_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_qual_commodity_properties_on_qual_id ON public.qual_commodity_properties USING btree (qual_id);
+
+
+--
+-- Name: index_qual_context_properties_on_context_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_qual_context_properties_on_context_id ON public.qual_context_properties USING btree (context_id);
+
+
+--
+-- Name: index_qual_context_properties_on_qual_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_qual_context_properties_on_qual_id ON public.qual_context_properties USING btree (qual_id);
+
+
+--
+-- Name: index_qual_country_properties_on_country_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_qual_country_properties_on_country_id ON public.qual_country_properties USING btree (country_id);
+
+
+--
+-- Name: index_qual_country_properties_on_qual_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_qual_country_properties_on_qual_id ON public.qual_country_properties USING btree (qual_id);
+
+
+--
 -- Name: index_qual_properties_on_qual_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_qual_properties_on_qual_id ON public.qual_properties USING btree (qual_id);
+
+
+--
+-- Name: index_quant_commodity_properties_on_commodity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quant_commodity_properties_on_commodity_id ON public.quant_commodity_properties USING btree (commodity_id);
+
+
+--
+-- Name: index_quant_commodity_properties_on_quant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quant_commodity_properties_on_quant_id ON public.quant_commodity_properties USING btree (quant_id);
+
+
+--
+-- Name: index_quant_context_properties_on_context_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quant_context_properties_on_context_id ON public.quant_context_properties USING btree (context_id);
+
+
+--
+-- Name: index_quant_context_properties_on_quant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quant_context_properties_on_quant_id ON public.quant_context_properties USING btree (quant_id);
+
+
+--
+-- Name: index_quant_country_properties_on_country_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quant_country_properties_on_country_id ON public.quant_country_properties USING btree (country_id);
+
+
+--
+-- Name: index_quant_country_properties_on_quant_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_quant_country_properties_on_quant_id ON public.quant_country_properties USING btree (quant_id);
 
 
 --
@@ -7133,6 +7805,14 @@ ALTER TABLE ONLY public.context_node_types
 
 
 --
+-- Name: ind_country_properties fk_rails_162974f66c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_country_properties
+    ADD CONSTRAINT fk_rails_162974f66c FOREIGN KEY (country_id) REFERENCES public.countries(id);
+
+
+--
 -- Name: download_attributes fk_rails_163b9bb8d8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7213,6 +7893,22 @@ ALTER TABLE ONLY public.chart_inds
 
 
 --
+-- Name: quant_country_properties fk_rails_2cb9ec5128; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_country_properties
+    ADD CONSTRAINT fk_rails_2cb9ec5128 FOREIGN KEY (quant_id) REFERENCES public.quants(id);
+
+
+--
+-- Name: ind_context_properties fk_rails_2d523de840; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_context_properties
+    ADD CONSTRAINT fk_rails_2d523de840 FOREIGN KEY (ind_id) REFERENCES public.inds(id);
+
+
+--
 -- Name: flow_quants fk_rails_2dbc0a565f; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7277,6 +7973,14 @@ ALTER TABLE ONLY public.map_inds
 
 
 --
+-- Name: qual_country_properties fk_rails_4d7c9be019; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_country_properties
+    ADD CONSTRAINT fk_rails_4d7c9be019 FOREIGN KEY (country_id) REFERENCES public.countries(id);
+
+
+--
 -- Name: node_properties fk_rails_4dcde982df; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7298,6 +8002,22 @@ ALTER TABLE ONLY public.dashboards_inds
 
 ALTER TABLE ONLY public.recolor_by_quals
     ADD CONSTRAINT fk_rails_5294e7fccd FOREIGN KEY (recolor_by_attribute_id) REFERENCES public.recolor_by_attributes(id) ON DELETE CASCADE;
+
+
+--
+-- Name: qual_context_properties fk_rails_58bc3d5bcf; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_context_properties
+    ADD CONSTRAINT fk_rails_58bc3d5bcf FOREIGN KEY (context_id) REFERENCES public.contexts(id);
+
+
+--
+-- Name: ind_commodity_properties fk_rails_5c0dcf9d64; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_commodity_properties
+    ADD CONSTRAINT fk_rails_5c0dcf9d64 FOREIGN KEY (ind_id) REFERENCES public.inds(id);
 
 
 --
@@ -7325,6 +8045,22 @@ ALTER TABLE ONLY public.chart_quants
 
 
 --
+-- Name: ind_context_properties fk_rails_6b25018f3c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_context_properties
+    ADD CONSTRAINT fk_rails_6b25018f3c FOREIGN KEY (context_id) REFERENCES public.contexts(id);
+
+
+--
+-- Name: quant_context_properties fk_rails_6e05c978da; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_context_properties
+    ADD CONSTRAINT fk_rails_6e05c978da FOREIGN KEY (context_id) REFERENCES public.contexts(id);
+
+
+--
 -- Name: flow_quals fk_rails_6e55ca4cbc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7341,11 +8077,35 @@ ALTER TABLE ONLY public.ind_properties
 
 
 --
+-- Name: qual_commodity_properties fk_rails_721d9b2c40; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_commodity_properties
+    ADD CONSTRAINT fk_rails_721d9b2c40 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id);
+
+
+--
 -- Name: charts fk_rails_805a6066ad; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.charts
     ADD CONSTRAINT fk_rails_805a6066ad FOREIGN KEY (parent_id) REFERENCES public.charts(id) ON DELETE CASCADE;
+
+
+--
+-- Name: quant_context_properties fk_rails_8c0d4513c3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_context_properties
+    ADD CONSTRAINT fk_rails_8c0d4513c3 FOREIGN KEY (quant_id) REFERENCES public.quants(id);
+
+
+--
+-- Name: quant_country_properties fk_rails_90fcd1e231; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_country_properties
+    ADD CONSTRAINT fk_rails_90fcd1e231 FOREIGN KEY (country_id) REFERENCES public.countries(id);
 
 
 --
@@ -7370,6 +8130,14 @@ ALTER TABLE ONLY public.resize_by_attributes
 
 ALTER TABLE ONLY public.recolor_by_inds
     ADD CONSTRAINT fk_rails_93051274e4 FOREIGN KEY (ind_id) REFERENCES public.inds(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: quant_commodity_properties fk_rails_93e2577ebb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_commodity_properties
+    ADD CONSTRAINT fk_rails_93e2577ebb FOREIGN KEY (commodity_id) REFERENCES public.commodities(id);
 
 
 --
@@ -7421,6 +8189,14 @@ ALTER TABLE ONLY public.charts
 
 
 --
+-- Name: ind_commodity_properties fk_rails_a8310a8e25; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_commodity_properties
+    ADD CONSTRAINT fk_rails_a8310a8e25 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id);
+
+
+--
 -- Name: dashboards_quants fk_rails_b49efb2529; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7458,6 +8234,14 @@ ALTER TABLE ONLY public.flows
 
 ALTER TABLE ONLY public.resize_by_quants
     ADD CONSTRAINT fk_rails_c63dc992e3 FOREIGN KEY (quant_id) REFERENCES public.quants(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: qual_context_properties fk_rails_c67757078e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_context_properties
+    ADD CONSTRAINT fk_rails_c67757078e FOREIGN KEY (qual_id) REFERENCES public.quals(id);
 
 
 --
@@ -7541,6 +8325,22 @@ ALTER TABLE ONLY public.chart_quants
 
 
 --
+-- Name: ind_country_properties fk_rails_e01a20acf1; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ind_country_properties
+    ADD CONSTRAINT fk_rails_e01a20acf1 FOREIGN KEY (ind_id) REFERENCES public.inds(id);
+
+
+--
+-- Name: qual_commodity_properties fk_rails_e18327427d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_commodity_properties
+    ADD CONSTRAINT fk_rails_e18327427d FOREIGN KEY (qual_id) REFERENCES public.quals(id);
+
+
+--
 -- Name: download_quants fk_rails_e3b3c104f3; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7570,6 +8370,14 @@ ALTER TABLE ONLY public.download_quals
 
 ALTER TABLE ONLY public.contexts
     ADD CONSTRAINT fk_rails_eea78f436e FOREIGN KEY (commodity_id) REFERENCES public.commodities(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: quant_commodity_properties fk_rails_f026110265; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.quant_commodity_properties
+    ADD CONSTRAINT fk_rails_f026110265 FOREIGN KEY (quant_id) REFERENCES public.quants(id);
 
 
 --
@@ -7610,6 +8418,14 @@ ALTER TABLE ONLY public.map_attributes
 
 ALTER TABLE ONLY public.node_inds
     ADD CONSTRAINT fk_rails_fe29817503 FOREIGN KEY (node_id) REFERENCES public.nodes(id) ON DELETE CASCADE;
+
+
+--
+-- Name: qual_country_properties fk_rails_fe3d71a6cc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.qual_country_properties
+    ADD CONSTRAINT fk_rails_fe3d71a6cc FOREIGN KEY (qual_id) REFERENCES public.quals(id);
 
 
 --
@@ -7753,6 +8569,18 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190110094614'),
 ('20190110140539'),
 ('20190111121850'),
-('20190215113824');
+('20190215113824'),
+('20190228115321'),
+('20190228115345'),
+('20190228115409'),
+('20190301121434'),
+('20190301170044'),
+('20190301170114'),
+('20190301170138'),
+('20190301170523'),
+('20190301173716'),
+('20190301173748'),
+('20190301173808'),
+('20190301173824');
 
 

--- a/db/views/commodity_attribute_properties_mv_v01.sql
+++ b/db/views/commodity_attribute_properties_mv_v01.sql
@@ -1,0 +1,12 @@
+SELECT id, commodity_id, tooltip_text, qual_id, -1 as ind_id, -1 as quant_id
+FROM qual_commodity_properties
+
+UNION ALL
+
+SELECT id, commodity_id, tooltip_text, -1 as qual_id, -1 as ind_id, quant_id
+FROM quant_commodity_properties
+
+UNION ALL
+
+SELECT id, commodity_id, tooltip_text, -1 as qual_id, ind_id, -1 as quant_id
+FROM ind_commodity_properties

--- a/db/views/context_attribute_properties_mv_v01.sql
+++ b/db/views/context_attribute_properties_mv_v01.sql
@@ -1,0 +1,12 @@
+SELECT id, context_id, tooltip_text, qual_id, -1 as ind_id, -1 as quant_id
+FROM qual_context_properties
+
+UNION ALL
+
+SELECT id, context_id, tooltip_text, -1 as qual_id, -1 as ind_id, quant_id
+FROM quant_context_properties
+
+UNION ALL
+
+SELECT id, context_id, tooltip_text, -1 as qual_id, ind_id, -1 as quant_id
+FROM ind_context_properties

--- a/db/views/country_attribute_properties_mv_v01.sql
+++ b/db/views/country_attribute_properties_mv_v01.sql
@@ -1,0 +1,12 @@
+SELECT id, country_id, tooltip_text, qual_id, -1 as ind_id, -1 as quant_id
+FROM qual_country_properties
+
+UNION ALL
+
+SELECT id, country_id, tooltip_text, -1 as qual_id, -1 as ind_id, quant_id
+FROM quant_country_properties
+
+UNION ALL
+
+SELECT id, country_id, tooltip_text, -1 as qual_id, ind_id, -1 as quant_id
+FROM ind_country_properties

--- a/lib/api/v3/profiles/get_tooltip_per_attribute.rb
+++ b/lib/api/v3/profiles/get_tooltip_per_attribute.rb
@@ -52,19 +52,19 @@ module Api
         def context_specific_tooltip
           context_specific_property.
             find_by(attribute => ro_chart_attribute.original_id,
-                    context_id: context.id)
+                    context_id: context.id)&.tooltip_text
         end
 
         def country_specific_tooltip
           country_specific_property.
             find_by(attribute => ro_chart_attribute.original_id,
-                    country_id: context.country_id)
+                    country_id: context.country_id)&.tooltip_text
         end
 
         def commodity_specific_tooltip
           commodity_specific_property.
             find_by(attribute => ro_chart_attribute.original_id,
-                    commodity_id: context.commodity_id)
+                    commodity_id: context.commodity_id)&.tooltip_text
         end
       end
     end

--- a/lib/api/v3/profiles/get_tooltip_per_attribute.rb
+++ b/lib/api/v3/profiles/get_tooltip_per_attribute.rb
@@ -1,0 +1,72 @@
+module Api
+  module V3
+    module Profiles
+      class GetTooltipPerAttribute
+        include ActiveSupport::Configurable
+
+        attr_reader :ro_chart_attribute, :context
+
+        config_accessor :context_specific_property do
+          Api::V3::Readonly::ContextAttributeProperty
+        end
+
+        config_accessor :country_specific_property do
+          Api::V3::Readonly::CountryAttributeProperty
+        end
+
+        config_accessor :commodity_specific_property do
+          Api::V3::Readonly::CommodityAttributeProperty
+        end
+
+        class << self
+          def call(ro_chart_attribute:, context:)
+            new(
+              ro_chart_attribute: ro_chart_attribute,
+              context: context
+            ).call
+          end
+        end
+
+        def initialize(ro_chart_attribute:, context:)
+          @ro_chart_attribute = ro_chart_attribute
+          @context = context
+        end
+
+        def call
+          tooltip
+        end
+
+        private
+
+        def tooltip
+          context_specific_tooltip ||
+            country_specific_tooltip ||
+            commodity_specific_tooltip ||
+            ro_chart_attribute.tooltip_text
+        end
+
+        def attribute
+          "#{ro_chart_attribute.original_type.downcase}_id".to_sym
+        end
+
+        def context_specific_tooltip
+          context_specific_property.
+            find_by(attribute => ro_chart_attribute.original_id,
+                    context_id: context.id)
+        end
+
+        def country_specific_tooltip
+          country_specific_property.
+            find_by(attribute => ro_chart_attribute.original_id,
+                    country_id: context.country_id)
+        end
+
+        def commodity_specific_tooltip
+          commodity_specific_property.
+            find_by(attribute => ro_chart_attribute.original_id,
+                    commodity_id: context.commodity_id)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/api/v3/api_v3_ind_commodity_properties.rb
+++ b/spec/factories/api/v3/api_v3_ind_commodity_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_ind_commodity_property, class: 'Api::V3::IndCommodityProperty' do
+    association :ind, factory: :api_v3_ind
+    association :commodity, factory: :api_v3_commodity
+    tooltip_text { 'Commodity specific tooltip text for IND' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_ind_context_properties.rb
+++ b/spec/factories/api/v3/api_v3_ind_context_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_ind_context_property, class: 'Api::V3::IndContextProperty' do
+    association :ind, factory: :api_v3_ind
+    association :context, factory: :api_v3_context
+    tooltip_text { 'Context specific tooltip text for IND' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_ind_country_properties.rb
+++ b/spec/factories/api/v3/api_v3_ind_country_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_ind_country_property, class: 'Api::V3::IndCountryProperty' do
+    association :ind, factory: :api_v3_ind
+    association :country, factory: :api_v3_country
+    tooltip_text { 'Country specific tooltip text for IND' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_qual_commodity_properties.rb
+++ b/spec/factories/api/v3/api_v3_qual_commodity_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_qual_commodity_property, class: 'Api::V3::QualCommodityProperty' do
+    association :qual, factory: :api_v3_qual
+    association :commodity, factory: :api_v3_commodity
+    tooltip_text { 'Commodity specific tooltip text for QUAL' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_qual_context_properties.rb
+++ b/spec/factories/api/v3/api_v3_qual_context_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_qual_context_property, class: 'Api::V3::QualContextProperty' do
+    association :qual, factory: :api_v3_qual
+    association :context, factory: :api_v3_context
+    tooltip_text { 'Context specific tooltip text for QUAL' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_qual_country_properties.rb
+++ b/spec/factories/api/v3/api_v3_qual_country_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_qual_country_property, class: 'Api::V3::QualCountryProperty' do
+    association :qual, factory: :api_v3_qual
+    association :country, factory: :api_v3_country
+    tooltip_text { 'Country specific tooltip text for QUAL' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_quant_commodity_properties.rb
+++ b/spec/factories/api/v3/api_v3_quant_commodity_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_quant_commodity_property, class: 'Api::V3::QuantCommodityProperty' do
+    association :quant, factory: :api_v3_quant
+    association :commodity, factory: :api_v3_commodity
+    tooltip_text { 'Commodity specific tooltip text for QUANT' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_quant_context_properties.rb
+++ b/spec/factories/api/v3/api_v3_quant_context_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_quant_context_property, class: 'Api::V3::QuantContextProperty' do
+    association :quant, factory: :api_v3_quant
+    association :context, factory: :api_v3_context
+    tooltip_text { 'Context specific tooltip text for QUANT' }
+  end
+end

--- a/spec/factories/api/v3/api_v3_quant_country_properties.rb
+++ b/spec/factories/api/v3/api_v3_quant_country_properties.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_v3_quant_country_property, class: 'Api::V3::QuantCountryProperty' do
+    association :quant, factory: :api_v3_quant
+    association :country, factory: :api_v3_country
+    tooltip_text { 'Country specific tooltip text for QUANT' }
+  end
+end

--- a/spec/lib/api/v3/profiles/get_tooltip_per_attribute_spec.rb
+++ b/spec/lib/api/v3/profiles/get_tooltip_per_attribute_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Profiles::GetTooltipPerAttribute, :service do
+  include_context 'minimal config for tooltips'
+
+  describe :call do
+    before(:each) do
+      Api::V3::Readonly::Attribute.refresh
+      Api::V3::Readonly::ChartAttribute.refresh
+    end
+
+    def refresh_dependent_materialized_views
+      Api::V3::Readonly::CountryAttributeProperty.refresh
+      Api::V3::Readonly::ContextAttributeProperty.refresh
+      Api::V3::Readonly::CommodityAttributeProperty.refresh
+    end
+
+    let(:ro_chart_attribute) { 
+      Api::V3::Readonly::ChartAttribute.find_by(original_type: type) 
+    }
+
+    subject do
+      Api::V3::Profiles::GetTooltipPerAttribute.call(
+        context: context,
+        ro_chart_attribute: ro_chart_attribute
+      )
+    end
+
+    context 'inds' do
+      let(:type) { 'Ind' }
+
+      it 'returns context specific tooltip if there is one for that context and attribute' do
+        ind_context_property
+        ind_country_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(context_tooltip_text)
+      end
+
+      it 'returns country specific tooltip if there is no context one' do
+        ind_country_property
+        ind_commodity_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(country_tooltip_text)
+      end
+
+      it 'returns commodity specific tooltip if there is no context nor country one' do
+        ind_commodity_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(commodity_tooltip_text)
+      end
+
+      it 'returns the tooltip defined in (ind|quant|qual)_property' do
+        refresh_dependent_materialized_views
+        expect(subject).to eq(ro_chart_attribute.tooltip_text)
+      end
+    end
+
+    context 'quants' do
+      let(:type) { 'Quant' }
+
+      it 'returns context specific tooltip if there is one for that context and attribute' do
+        quant_context_property
+        quant_country_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(context_tooltip_text)
+      end
+
+      it 'returns country specific tooltip if there is no context one' do
+        quant_country_property
+        quant_commodity_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(country_tooltip_text)
+      end
+
+      it 'returns commodity specific tooltip if there is no context nor country one' do
+        quant_commodity_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(commodity_tooltip_text)
+      end
+
+      it 'returns the tooltip defined in (ind|quant|qual)_property' do
+        refresh_dependent_materialized_views
+        expect(subject).to eq(ro_chart_attribute.tooltip_text)
+      end
+    end
+
+    context 'quals' do
+      let(:type) { 'Qual' }
+
+      it 'returns context specific tooltip if there is one for that context and attribute' do
+        qual_context_property
+        qual_country_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(context_tooltip_text)
+      end
+
+      it 'returns country specific tooltip if there is no context one' do
+        qual_country_property
+        qual_commodity_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(country_tooltip_text)
+      end
+
+      it 'returns commodity specific tooltip if there is no context nor country one' do
+        qual_commodity_property
+        refresh_dependent_materialized_views
+        expect(subject).to eq(commodity_tooltip_text)
+      end
+
+      it 'returns the tooltip defined in (ind|quant|qual)_property' do
+        refresh_dependent_materialized_views
+        expect(subject).to eq(ro_chart_attribute.tooltip_text)
+      end
+    end
+  end
+end

--- a/spec/support/contexts/api/v3/minimal_config_for_tooltips.rb
+++ b/spec/support/contexts/api/v3/minimal_config_for_tooltips.rb
@@ -1,0 +1,146 @@
+shared_context 'minimal config for tooltips' do
+  include_context 'minimum complete configuration'
+
+  ### Boilerplate
+
+  let!(:chart) {
+    FactoryBot.create(:api_v3_chart)
+  }
+
+  let!(:chart_attribute) {
+    FactoryBot.create(
+      :api_v3_chart_attribute,
+      chart: chart
+    )
+  }
+
+  let!(:chart_attribute2) {
+    FactoryBot.create(
+      :api_v3_chart_attribute,
+      chart: chart
+    )
+  }
+
+  let!(:chart_attribute3) {
+    FactoryBot.create(
+      :api_v3_chart_attribute,
+      chart: chart
+    )
+  }
+
+  let!(:chart_ind) {
+    FactoryBot.create(
+      :api_v3_chart_ind,
+      chart_attribute: chart_attribute,
+      ind: ind
+    )
+  }
+
+  let!(:chart_quant) {
+    FactoryBot.create(
+      :api_v3_chart_quant,
+      chart_attribute: chart_attribute2,
+      quant: quant
+    )
+  }
+
+  let!(:chart_qual) {
+    FactoryBot.create(
+      :api_v3_chart_qual,
+      chart_attribute: chart_attribute3,
+      qual: qual
+    )
+  }
+
+  ### Context specific
+
+  let(:context_tooltip_text) { 'Context specific tooltip text' }
+  let(:ind_context_property) {
+    FactoryBot.create(
+      :api_v3_ind_context_property,
+      context: context,
+      ind: ind,
+      tooltip_text: context_tooltip_text
+    )
+  }
+
+  let(:quant_context_property) {
+    FactoryBot.create(
+      :api_v3_quant_context_property,
+      context: context,
+      quant: quant,
+      tooltip_text: context_tooltip_text
+    )
+  }
+
+  let(:qual_context_property) {
+    FactoryBot.create(
+      :api_v3_qual_context_property,
+      context: context,
+      qual: qual,
+      tooltip_text: context_tooltip_text
+    )
+  }
+
+  ### Country specific
+
+  let(:country_tooltip_text) { 'Country specific tooltip text' }
+
+  let(:ind_country_property) {
+    FactoryBot.create(
+      :api_v3_ind_country_property,
+      country_id: context.country_id,
+      ind: ind,
+      tooltip_text: country_tooltip_text
+    )
+  }
+
+  let(:quant_country_property) {
+    FactoryBot.create(
+      :api_v3_quant_country_property,
+      country_id: context.country_id,
+      quant: quant,
+      tooltip_text: country_tooltip_text
+    )
+  }
+
+  let(:qual_country_property) {
+    FactoryBot.create(
+      :api_v3_qual_country_property,
+      country_id: context.country_id,
+      qual: qual,
+      tooltip_text: country_tooltip_text
+    )
+  }
+
+  ### Commodity specific
+
+  let(:commodity_tooltip_text) { 'Commodity specific tooltip text' }
+
+  let(:ind_commodity_property) {
+    FactoryBot.create(
+      :api_v3_ind_commodity_property,
+      commodity_id: context.commodity_id,
+      ind: ind,
+      tooltip_text: commodity_tooltip_text
+    )
+  }
+
+  let(:quant_commodity_property) {
+    FactoryBot.create(
+      :api_v3_quant_commodity_property,
+      commodity_id: context.commodity_id,
+      quant: quant,
+      tooltip_text: commodity_tooltip_text
+    )
+  }
+
+  let(:qual_commodity_property) {
+    FactoryBot.create(
+      :api_v3_qual_commodity_property,
+      commodity_id: context.commodity_id,
+      qual: qual,
+      tooltip_text: commodity_tooltip_text
+    )
+  }
+end


### PR DESCRIPTION
…y specific properties for inds, quants and quals

This PR adds 9 tables (3 per context, 3 per country, 3 per commodity) to support specific properties (tooltips) respectively for context, country and commodity for inds, quals and quants.
I also added three materialized views which combine all attributes (inds, quals and quants) in one view.
The main change resides in `sustainability_table` service.

I have not worked with materialized views before, so double-check if it makes sense 🙏 