### PR TITLE
Feature/endpoint returning dashboards chart urls

### DIFF
--- a/app/controllers/api/v3/dashboards/parametrised_charts_controller.rb
+++ b/app/controllers/api/v3/dashboards/parametrised_charts_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V3
+    module Dashboards
+      class ParametrisedChartsController < ApiController
+        include FilterParams
+        skip_before_action :load_context
+
+        def index
+          ensure_required_param_present(:country_id)
+          ensure_required_param_present(:commodity_id)
+          ensure_required_param_present(:cont_attribute_id)
+
+          render json: ParametrisedCharts.new(ChartParameters.new(chart_params)).call,
+                 root: 'data',
+                 each_serializer: Api::V3::Dashboards::ParametrisedChartSerializer,
+                 url: proc { |options|
+                   send(:"api_v3_dashboards_charts_#{options.delete(:source)}_index_url", options)
+                 }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/v3/dashboards/filter_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/filter_params.rb
@@ -6,6 +6,20 @@ module Api
 
         private
 
+        def chart_params
+          {
+            country_id: string_to_int(params[:country_id]),
+            commodity_id: string_to_int(params[:commodity_id]),
+            start_year: string_to_int(params[:start_year]),
+            end_year: string_to_int(params[:end_year]),
+            cont_attribute_id: string_to_int(params[:cont_attribute_id]),
+            ncont_attribute_id: string_to_int(params[:ncont_attribute_id]),
+            sources_ids: cs_string_to_int_array(params[:sources_ids]),
+            companies_ids: cs_string_to_int_array(params[:companies_ids]),
+            destinations_ids: cs_string_to_int_array(params[:destinations_ids])
+          }
+        end
+
         def filter_params
           {
             countries_ids: cs_string_to_int_array(params[:countries_ids]),

--- a/app/controllers/concerns/exceptions.rb
+++ b/app/controllers/concerns/exceptions.rb
@@ -5,5 +5,9 @@ module Exceptions
     rescue_from ActionController::ParameterMissing do |exception|
       render json: {error: exception.message}, status: 400
     end
+
+    rescue_from ActiveRecord::RecordNotFound do |exception|
+      render json: {error: exception.message}, status: 404
+    end
   end
 end

--- a/app/serializers/api/v3/dashboards/parametrised_chart_serializer.rb
+++ b/app/serializers/api/v3/dashboards/parametrised_chart_serializer.rb
@@ -1,0 +1,10 @@
+module Api
+  module V3
+    module Dashboards
+      class ParametrisedChartSerializer < ActiveModel::Serializer
+        attribute(:type) { object[:type] }
+        attribute(:url) { instance_options[:url].call(object) }
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/chart_data.rb
+++ b/app/services/api/v3/dashboards/chart_data.rb
@@ -8,7 +8,6 @@ module Api
         # @option params [Array<Integer>] sources_ids
         # @option params [Array<Integer>] companies_ids
         # @option params [Array<Integer>] destinations_ids
-        # @option params [Array<Integer>] node_types_ids
         def initialize(params)
           @countries_ids = params[:countries_ids] || []
           @commodities_ids = params[:commodities_ids] || []

--- a/app/services/api/v3/dashboards/chart_parameters.rb
+++ b/app/services/api/v3/dashboards/chart_parameters.rb
@@ -29,11 +29,10 @@ module Api
           @commodity_id = params[:commodity_id]
 
           if @country_id && @commodity_id
-            @context = Api::V3::Context.where(
-              country_id: @country_id, commodity_id: @commodity_id
-            ).first
+            @context = Api::V3::Context.find_by_country_id_and_commodity_id!(
+              @country_id, @commodity_id
+            )
           end
-          raise ActiveRecord::RecordNotFound unless @context
 
           initialize_cont_attribute params[:cont_attribute_id]
           initialize_ncont_attribute params[:ncont_attribute_id]
@@ -54,9 +53,10 @@ module Api
 
           resize_by_attribute = Api::V3::Readonly::ResizeByAttribute.
             select(:attribute_id).
-            where(context_id: @context.id, attribute_id: cont_attribute_id).
             includes(:readonly_attribute).
-            first
+            find_by_context_id_and_attribute_id!(
+              @context.id, cont_attribute_id
+            )
           raise ActiveRecord::RecordNotFound unless resize_by_attribute
 
           @cont_attribute = resize_by_attribute.readonly_attribute
@@ -67,9 +67,10 @@ module Api
 
           recolor_by_attribute = Api::V3::Readonly::RecolorByAttribute.
             select(:attribute_id).
-            where(context_id: @context.id, attribute_id: ncont_attribute_id).
             includes(:readonly_attribute).
-            first
+            find_by_context_id_and_attribute_id!(
+              @context.id, ncont_attribute_id
+            )
           raise ActiveRecord::RecordNotFound unless recolor_by_attribute
 
           @ncont_attribute = recolor_by_attribute.readonly_attribute

--- a/app/services/api/v3/dashboards/chart_parameters.rb
+++ b/app/services/api/v3/dashboards/chart_parameters.rb
@@ -1,0 +1,88 @@
+module Api
+  module V3
+    module Dashboards
+      class ChartParameters
+        attr_reader :country_id,
+                    :commodity_id,
+                    :context,
+                    :cont_attribute,
+                    :ncont_attribute,
+                    :start_year,
+                    :end_year,
+                    :sources_ids,
+                    :companies_ids,
+                    :destinations_ids,
+                    :nodes_ids
+
+        # @param params [Hash]
+        # @option params [Integer] country_id
+        # @option params [Integer] commodity_id
+        # @option params [Integer] cont_attribute_id
+        # @option params [Integer] ncont_attribute_id
+        # @option params [Array<Integer>] sources_ids
+        # @option params [Array<Integer>] companies_ids
+        # @option params [Array<Integer>] destinations_ids
+        # @option params [Integer] start_year
+        # @option params [Integer] end_year
+        def initialize(params)
+          @country_id = params[:country_id]
+          @commodity_id = params[:commodity_id]
+
+          if @country_id && @commodity_id
+            @context = Api::V3::Context.where(
+              country_id: @country_id, commodity_id: @commodity_id
+            ).first
+          end
+          raise ActiveRecord::RecordNotFound unless @context
+
+          initialize_cont_attribute params[:cont_attribute_id]
+          initialize_ncont_attribute params[:ncont_attribute_id]
+
+          @sources_ids = params[:sources_ids] || []
+          @companies_ids = params[:companies_ids] || []
+          @destinations_ids = params[:destinations_ids] || []
+          @nodes_ids = @sources_ids + companies_ids + destinations_ids
+
+          @start_year = params[:start_year]
+          @end_year = params[:end_year]
+        end
+
+        private
+
+        def initialize_cont_attribute(cont_attribute_id)
+          return unless cont_attribute_id.present?
+
+          resize_by_attribute = Api::V3::Readonly::ResizeByAttribute.
+            select(:attribute_id).
+            where(context_id: @context.id, attribute_id: cont_attribute_id).
+            includes(:readonly_attribute).
+            first
+          raise ActiveRecord::RecordNotFound unless resize_by_attribute
+
+          @cont_attribute = resize_by_attribute.readonly_attribute
+        end
+
+        def initialize_ncont_attribute(ncont_attribute_id)
+          return unless ncont_attribute_id.present?
+
+          recolor_by_attribute = Api::V3::Readonly::RecolorByAttribute.
+            select(:attribute_id).
+            where(context_id: @context.id, attribute_id: ncont_attribute_id).
+            includes(:readonly_attribute).
+            first
+          raise ActiveRecord::RecordNotFound unless recolor_by_attribute
+
+          @ncont_attribute = recolor_by_attribute.readonly_attribute
+        end
+
+        def single_year?
+          @start_year.present? && @end_year.present? && @start_year == @end_year
+        end
+
+        def ncont_attribute?
+          @ncont_attribute.present?
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/node_types_to_break_by.rb
+++ b/app/services/api/v3/dashboards/node_types_to_break_by.rb
@@ -1,0 +1,101 @@
+# Returns node types by which to break down for non-global charts,
+# taking into account user selection and availability of node types
+# in the given context.
+module Api
+  module V3
+    module Dashboards
+      class NodeTypesToBreakBy
+        # TODO: incorporate the new "role" attribute here
+        SOURCE_COLUMN_GROUP = 0
+        EXPORTER_COLUMN_GROUP = 1
+        IMPORTER_COLUMN_GROUP = 2
+        DESTINATION_COLUMN_GROUP = 3
+
+        # @param context [Api::V3::Context]
+        # @param [Array<Integer>] source_node_types_ids
+        # @param [Array<Integer>] company_node_types_ids
+        # @param [Array<Integer>] destination_node_types_ids
+        def initialize(context, source_node_types_ids, company_node_types_ids, destination_node_types_ids)
+          @context = context
+          @source_node_types_ids = source_node_types_ids || []
+          @company_node_types_ids = company_node_types_ids || []
+          @destination_node_types_ids = destination_node_types_ids || []
+        end
+
+        def call
+          context_node_types = @context.context_node_types.
+            includes(:context_node_type_property, :node_type)
+          grouped_context_node_types = context_node_types.group_by do |cnt|
+            cnt.context_node_type_property.column_group
+          end
+
+          result =
+            enabled_source_node_types(
+              grouped_context_node_types[SOURCE_COLUMN_GROUP]
+            ) +
+            enabled_exporter_node_types(
+              grouped_context_node_types[EXPORTER_COLUMN_GROUP]
+            ) +
+            enabled_importer_node_types(
+              grouped_context_node_types[IMPORTER_COLUMN_GROUP]
+            ) +
+            enabled_destination_node_types(
+              grouped_context_node_types[DESTINATION_COLUMN_GROUP]
+            )
+
+          result.map(&:node_type)
+        end
+
+        private
+
+        def enabled_source_node_types(source_node_types)
+          return [] unless source_node_types
+
+          source_node_types.select do |cnt|
+            if @source_node_types_ids.any?
+              @source_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+
+        def enabled_exporter_node_types(exporter_node_types)
+          return [] unless exporter_node_types
+
+          exporter_node_types.select do |cnt|
+            if @company_node_types_ids.any?
+              @company_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+
+        def enabled_importer_node_types(importer_node_types)
+          return [] unless importer_node_types
+
+          importer_node_types.select do |cnt|
+            if @company_node_types_ids.any?
+              @company_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+
+        def enabled_destination_node_types(destination_node_types)
+          return [] unless destination_node_types
+
+          destination_node_types.select do |cnt|
+            if @destination_node_types_ids.any?
+              @destination_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/node_types_to_break_by.rb
+++ b/app/services/api/v3/dashboards/node_types_to_break_by.rb
@@ -1,4 +1,4 @@
-# Returns node types by which to break down for non-global charts,
+# Returns node types by which to break down for non-overview charts,
 # taking into account user selection and availability of node types
 # in the given context.
 module Api
@@ -15,7 +15,12 @@ module Api
         # @param [Array<Integer>] source_node_types_ids
         # @param [Array<Integer>] company_node_types_ids
         # @param [Array<Integer>] destination_node_types_ids
-        def initialize(context, source_node_types_ids, company_node_types_ids, destination_node_types_ids)
+        def initialize(
+          context,
+          source_node_types_ids = [],
+          company_node_types_ids = [],
+          destination_node_types_ids = []
+        )
           @context = context
           @source_node_types_ids = source_node_types_ids || []
           @company_node_types_ids = company_node_types_ids || []

--- a/app/services/api/v3/dashboards/parametrised_charts.rb
+++ b/app/services/api/v3/dashboards/parametrised_charts.rb
@@ -1,0 +1,176 @@
+module Api
+  module V3
+    module Dashboards
+      class ParametrisedCharts
+        DYNAMIC_SENTENCE = :dynamic_sentence
+        DONUT_CHART = :donut_chart
+        BAR_CHART = :bar_chart
+        STACKED_BAR_CHART = :stacked_bar_chart
+        HORIZONTAL_BAR_CHART = :horizontal_bar_chart
+        HORIZONTAL_STACKED_BAR_CHART = :horizontal_stacked_bar_chart
+        VALUE_TABLE = :value_table
+
+        # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
+        def initialize(chart_parameters)
+          @country_id = chart_parameters.country_id
+          @commodity_id = chart_parameters.commodity_id
+          @context = chart_parameters.context
+          @cont_attribute = chart_parameters.cont_attribute
+          @ncont_attribute = chart_parameters.ncont_attribute
+          @sources_ids = chart_parameters.sources_ids
+          @companies_ids = chart_parameters.companies_ids
+          @destinations_ids = chart_parameters.destinations_ids
+
+          @start_year = chart_parameters.start_year
+          @end_year = chart_parameters.end_year
+        end
+
+        def call
+          chart_types =
+            if single_year? && !ncont_attribute?
+              single_year_no_ncont_charts
+            elsif single_year? && ncont_attribute?
+              single_year_ncont_charts
+            elsif !single_year? && !ncont_attribute?
+              multi_year_no_ncont_charts
+            else
+              multi_year_ncont_charts
+            end
+          chart_types.map do |chart_params|
+            sanitized_chart_params.merge(chart_params)
+          end
+        end
+
+        private
+
+        def node_types_to_break_by
+          Api::V3::Dashboards::NodeTypesToBreakBy.new(@context).call
+        end
+
+        def single_year?
+          @start_year.present? && @end_year.nil? ||
+            @start_year.present? && @end_year.present? && @start_year == @end_year
+        end
+
+        def ncont_attribute?
+          @ncont_attribute.present?
+        end
+
+        def single_year_no_ncont_charts
+          [single_year_no_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              single_year_no_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def single_year_no_ncont_overview_chart
+          {
+            source: :single_year_no_ncont_overview,
+            type: DYNAMIC_SENTENCE,
+            x: nil
+          }
+        end
+
+        def single_year_no_ncont_by_node_type_chart(node_type)
+          {
+            source: :single_year_no_ncont_by_node_type,
+            type: HORIZONTAL_BAR_CHART,
+            x: :node_type,
+            node_type_id: node_type.id
+          }
+        end
+
+        def single_year_ncont_charts
+          [single_year_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              single_year_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def single_year_ncont_overview_chart
+          {
+            source: :single_year_ncont_overview,
+            type: DONUT_CHART,
+            x: :ncont_attribute
+          }
+        end
+
+        def single_year_ncont_by_node_type_chart(node_type)
+          {
+            source: :single_year_ncont_by_node_type,
+            type: HORIZONTAL_STACKED_BAR_CHART, # TODO: or VALUE_TABLE?
+            x: :node_type,
+            break_by: :ncont_attribute,
+            node_type_id: node_type.id
+          }
+        end
+
+        def multi_year_no_ncont_charts
+          [multi_year_no_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              multi_year_no_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def multi_year_no_ncont_overview_chart
+          {
+            source: :multi_year_no_ncont_overview,
+            type: BAR_CHART,
+            x: :year
+          }
+        end
+
+        def multi_year_no_ncont_by_node_type_chart(node_type)
+          {
+            source: :multi_year_no_ncont_by_node_type,
+            type: STACKED_BAR_CHART,
+            x: :year,
+            break_by: :node_type,
+            node_type_id: node_type.id
+          }
+        end
+
+        def multi_year_ncont_charts
+          [multi_year_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              multi_year_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def multi_year_ncont_overview_chart
+          {
+            source: :multi_year_ncont_overview,
+            type: STACKED_BAR_CHART,
+            x: :year,
+            break_by: :ncont_attribute
+          }
+        end
+
+        def multi_year_ncont_by_node_type_chart(node_type)
+          {
+            source: :multi_year_ncont_by_node_type,
+            type: STACKED_BAR_CHART,
+            x: :year,
+            break_by: :ncont_attribute,
+            filter_by: :node_type,
+            node_type_id: node_type.id
+          }
+        end
+
+        def sanitized_chart_params
+          {
+            cont_attribute_id: @cont_attribute.id,
+            ncont_attribute_id: @ncont_attribute&.id,
+            country_id: @country_id,
+            commodity_id: @commodity_id,
+            sources_ids: @sources_ids,
+            companies_ids: @companies_ids,
+            destinations_ids: @destinations_ids,
+            start_year: @start_year,
+            end_year: @end_year
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/retrieve_attributes.rb
+++ b/app/services/api/v3/dashboards/retrieve_attributes.rb
@@ -8,7 +8,6 @@ module Api
         # @option params [Array<Integer>] sources_ids
         # @option params [Array<Integer>] companies_ids
         # @option params [Array<Integer>] destinations_ids
-        # @option params [Array<Integer>] node_types_ids
         def initialize(params)
           @countries_ids = params[:countries_ids] || []
           @commodities_ids = params[:commodities_ids] || []

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,17 @@ Rails.application.routes.draw do
         resources :attributes
         resources :filter_meta, only: [:index]
         resources :chart_data, only: [:index]
+        namespace :charts do
+          resources :single_year_no_ncont_overview, only: [:index]
+          resources :single_year_no_ncont_by_node_type, only: [:index]
+          resources :single_year_ncont_overview, only: [:index]
+          resources :single_year_ncont_by_node_type, only: [:index]
+          resources :multi_year_no_ncont_overview, only: [:index]
+          resources :multi_year_no_ncont_by_node_type, only: [:index]
+          resources :multi_year_ncont_overview, only: [:index]
+          resources :multi_year_ncont_by_node_type, only: [:index]
+        end
+        resources :parametrised_charts, only: [:index]
       end
     end
     namespace :v2 do

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -1268,13 +1268,53 @@ paths:
                   y1:
                     $ref: "#/definitions/DashboardsChartValue"
 
+  '/dashboards/parametrised_charts':
+    get:
+      tags:
+        - dashboards
+      summary: 'Dynamic chart types matching selected filters'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: "#/parameters/dashboards_country_id"
+        - $ref: "#/parameters/dashboards_commodity_id"
+        - $ref: "#/parameters/dashboards_cont_attribute_id"
+        - $ref: "#/parameters/dashboards_ncont_attribute_id"
+        - $ref: "#/parameters/dashboards_sources_ids"
+        - $ref: "#/parameters/dashboards_companies_ids"
+        - $ref: "#/parameters/dashboards_destinations_ids"
+        - $ref: "#/parameters/dashboards_start_year"
+        - $ref: "#/parameters/dashboards_end_year"
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/definitions/ParametrisedChart'
+
 parameters:
+  dashboards_country_id:
+    name: country_id
+    in: query
+    type: integer
+    required: true
   dashboards_countries_ids:
     name: countries_ids
     in: query
     description: 'String with comma-separated numeric ids'
     required: false
     type: string
+  dashboards_commodity_id:
+    name: commodity_id
+    in: query
+    type: integer
+    required: true
   dashboards_commodities_ids:
     name: commodities_ids
     in: query
@@ -1309,6 +1349,30 @@ parameters:
     name: attribute_id
     in: query
     description: 'Attribute id'
+    required: false
+    type: integer
+  dashboards_cont_attribute_id:
+    name: cont_attribute_id
+    in: query
+    description: 'Continuous attribute id'
+    required: true
+    type: integer
+  dashboards_ncont_attribute_id:
+    name: ncont_attribute_id
+    in: query
+    description: 'Non-continuous attribute id'
+    required: false
+    type: integer
+  dashboards_start_year:
+    name: start_year
+    in: query
+    description: 'Start year'
+    required: true
+    type: integer
+  dashboards_end_year:
+    name: end_year
+    in: query
+    description: 'End year (not required for single year selection)'
     required: false
     type: integer
   page:
@@ -2699,3 +2763,12 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Chart'
+
+  ParametrisedChart:
+    type: object
+    properties:
+      type:
+        type: string
+        example: 'stacked_bar_chart'
+      url:
+        type: string

--- a/spec/models/api/v3/resize_by_attribute_spec.rb
+++ b/spec/models/api/v3/resize_by_attribute_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Api::V3::ResizeByAttribute, type: :model do
       FactoryBot.build(
         :api_v3_resize_by_attribute,
         context: api_v3_context,
-        group_number: api_v3_area_resize_by_attribute.group_number,
-        position: api_v3_area_resize_by_attribute.position
+        group_number: api_v3_volume_resize_by_attribute.group_number,
+        position: api_v3_volume_resize_by_attribute.position
       )
     }
     it 'fails when context missing' do

--- a/spec/responses/api/v3/dashboards/parametrised_charts_spec.rb
+++ b/spec/responses/api/v3/dashboards/parametrised_charts_spec.rb
@@ -12,6 +12,62 @@ RSpec.describe 'ParametrisedCharts', type: :request do
       Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
     end
 
+    let(:filter_params) {
+      {
+        country_id: api_v3_brazil.id,
+        commodity_id: api_v3_soy.id,
+        cont_attribute_id: api_v3_volume.readonly_attribute.id
+      }
+    }
+
+    it 'requires country_id' do
+      get '/api/v3/dashboards/parametrised_charts', params: filter_params.except(:country_id)
+      expect(@response).to have_http_status(:bad_request)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param country_id missing'
+      )
+    end
+
+    it 'requires commodity_id' do
+      get '/api/v3/dashboards/parametrised_charts', params: filter_params.except(:commodity_id)
+      expect(@response).to have_http_status(:bad_request)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param commodity_id missing'
+      )
+    end
+
+    it 'requires cont_attribute_id' do
+      get '/api/v3/dashboards/parametrised_charts', params: filter_params.except(:cont_attribute_id)
+      expect(@response).to have_http_status(:bad_request)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param cont_attribute_id missing'
+      )
+    end
+
+    it 'returns not found if context not found' do
+      get '/api/v3/dashboards/parametrised_charts', params: filter_params.merge(commodity_id: -1)
+      expect(@response).to have_http_status(:not_found)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => "Couldn't find Api::V3::Context"
+      )
+    end
+
+    it 'returns not found if resize by not found' do
+      get '/api/v3/dashboards/parametrised_charts', params: filter_params.merge(cont_attribute_id: -1)
+      expect(@response).to have_http_status(:not_found)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => "Couldn't find Api::V3::Readonly::ResizeByAttribute"
+      )
+    end
+
+    it 'returns not found if recolor by not found' do
+      get '/api/v3/dashboards/parametrised_charts', params: filter_params.merge(ncont_attribute_id: -1)
+      expect(@response).to have_http_status(:not_found)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => "Couldn't find Api::V3::Readonly::RecolorByAttribute"
+      )
+    end
+
     it 'has the correct response structure' do
       get '/api/v3/dashboards/parametrised_charts', params: {
         country_id: api_v3_brazil.id,

--- a/spec/responses/api/v3/dashboards/parametrised_charts_spec.rb
+++ b/spec/responses/api/v3/dashboards/parametrised_charts_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'ParametrisedCharts', type: :request do
+  include_context 'api v3 brazil context node types'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil resize by attributes'
+
+  describe 'GET /api/v3/dashboards/parametrised_charts' do
+    before(:each) do
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+    end
+
+    it 'has the correct response structure' do
+      get '/api/v3/dashboards/parametrised_charts', params: {
+        country_id: api_v3_brazil.id,
+        commodity_id: api_v3_soy.id,
+        cont_attribute_id: api_v3_volume.readonly_attribute.id
+      }
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_parametrised_charts')
+    end
+  end
+end

--- a/spec/responses/api/v3/exporter_profile_spec.rb
+++ b/spec/responses/api/v3/exporter_profile_spec.rb
@@ -23,15 +23,19 @@ RSpec.describe 'Exporter profile', type: :request do
   }
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/basic_attributes' do
-    it 'validates node types' do
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_country_of_destination1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_port1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_municipality_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_logistics_hub_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_biome_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_state_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_exporter1_node.id}/basic_attributes" }.to_not raise_error
+    it 'returns not found if exporter node not found' do
+      [
+        api_v3_biome_node,
+        api_v3_state_node,
+        api_v3_municipality_node,
+        api_v3_logistics_hub_node,
+        api_v3_port1_node,
+        api_v3_country_of_destination1_node
+      ].each do |non_exporter_node|
+        get "/api/v3/contexts/#{api_v3_context.id}/actors/#{non_exporter_node.id}/basic_attributes"
+        expect(@response).to have_http_status(:not_found)
+        expect(JSON.parse(@response.body)['error']).to match("Couldn't find Api::V3::Node with")
+      end
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/importer_profile_spec.rb
+++ b/spec/responses/api/v3/importer_profile_spec.rb
@@ -23,15 +23,19 @@ RSpec.describe 'Importer profile', type: :request do
   }
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/basic_attributes' do
-    it 'validates node types' do
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_country_of_destination1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_port1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_municipality_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_logistics_hub_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_biome_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_state_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/basic_attributes" }.to_not raise_error
+    it 'returns not found if importer node not found' do
+      [
+        api_v3_biome_node,
+        api_v3_state_node,
+        api_v3_municipality_node,
+        api_v3_logistics_hub_node,
+        api_v3_port1_node,
+        api_v3_country_of_destination1_node
+      ].each do |non_importer_node|
+        get "/api/v3/contexts/#{api_v3_context.id}/actors/#{non_importer_node.id}/basic_attributes"
+        expect(@response).to have_http_status(:not_found)
+        expect(JSON.parse(@response.body)['error']).to match("Couldn't find Api::V3::Node with")
+      end
     end
 
     it 'has the correct response structure' do

--- a/spec/responses/api/v3/place_profile_spec.rb
+++ b/spec/responses/api/v3/place_profile_spec.rb
@@ -20,16 +20,17 @@ RSpec.describe 'Place profile', type: :request do
   }
 
   describe 'GET /api/v3/contexts/:context_id/places/:id/basic_attributes' do
-    it 'validates node types' do
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_country_of_destination1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_exporter1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_importer1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_port1_node.id}/basic_attributes" }.to raise_error(ActiveRecord::RecordNotFound)
-
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_municipality_node.id}/basic_attributes" }.to_not raise_error
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_logistics_hub_node.id}/basic_attributes" }.to_not raise_error
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_biome_node.id}/basic_attributes" }.to_not raise_error
-      expect { get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_state_node.id}/basic_attributes" }.to_not raise_error
+    it 'returns not found if place node not found' do
+      [
+        api_v3_exporter1_node,
+        api_v3_importer1_node,
+        api_v3_port1_node,
+        api_v3_country_of_destination1_node
+      ].each do |non_place_node|
+        get "/api/v3/contexts/#{api_v3_context.id}/places/#{non_place_node.id}/basic_attributes"
+        expect(@response).to have_http_status(:not_found)
+        expect(JSON.parse(@response.body)['error']).to match("Couldn't find Api::V3::Node with")
+      end
     end
 
     it 'has the correct response structure' do

--- a/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
+++ b/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
@@ -1,0 +1,151 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
+  include_context 'api v3 node types'
+
+  let(:context) { FactoryBot.create(:api_v3_context) }
+
+  let!(:exporter_node_type) {
+    cnt = FactoryBot.create(
+      :api_v3_context_node_type, context: context, node_type: api_v3_exporter_node_type
+    )
+    FactoryBot.create(
+      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 1
+    )
+  }
+
+  let!(:destination_node_type) {
+    cnt = FactoryBot.create(
+      :api_v3_context_node_type, context: context, node_type: api_v3_country_node_type
+    )
+    FactoryBot.create(
+      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 3
+    )
+  }
+
+  describe 'call' do
+    context 'when subnational context with importer node' do
+      let!(:source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_biome_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+      let!(:another_source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_state_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+
+      let!(:importer_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_importer_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2
+        )
+      }
+
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [api_v3_biome_node_type.id],
+          [api_v3_exporter_node_type.id, api_v3_importer_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_biome_node_type,
+          api_v3_exporter_node_type,
+          api_v3_importer_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+
+    context 'when national context with importer node' do
+      let!(:importer_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_importer_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2
+        )
+      }
+
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [],
+          [api_v3_exporter_node_type.id, api_v3_importer_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_exporter_node_type,
+          api_v3_importer_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+
+    context 'when subnational context without importer node' do
+      let!(:source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_biome_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+      let!(:another_source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_state_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [api_v3_biome_node_type.id],
+          [api_v3_exporter_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_biome_node_type,
+          api_v3_exporter_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+
+    context 'when national context without importer node' do
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [],
+          [api_v3_exporter_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_exporter_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/parametrised_charts_spec.rb
+++ b/spec/services/api/v3/dashboards/parametrised_charts_spec.rb
@@ -1,0 +1,193 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
+  include_context 'api v3 brazil context node types'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil resize by attributes'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+  let(:ncont_attribute) { api_v3_forest_500.readonly_attribute }
+  let(:mandatory_parameters) {
+    {
+      country_id: api_v3_context.country_id,
+      commodity_id: api_v3_context.commodity_id,
+      cont_attribute_id: cont_attribute.id
+    }
+  }
+  let(:no_flow_path_filters) {
+    {
+      sources_ids: [],
+      companies_ids: [],
+      destinations_ids: []
+    }
+  }
+  let(:single_year) { {start_year: 2017, end_year: 2017} }
+  let(:multi_year) { {start_year: 2016, end_year: 2017} }
+
+  let(:chart_types) {
+    Api::V3::Dashboards::ParametrisedCharts.new(
+      Api::V3::Dashboards::ChartParameters.new(parameters)
+    ).call
+  }
+
+  let(:expected_chart_types) {
+    simplified_expected_chart_types.map do |chart_type|
+      chart_type.merge(parameters)
+    end
+  }
+
+  context 'when single year, no non-cont indicator, no flow-path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(single_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: nil
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :single_year_no_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::DYNAMIC_SENTENCE,
+          x: nil
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :single_year_no_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::HORIZONTAL_BAR_CHART,
+          x: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+
+  context 'when multiple years, no non-cont indicator, no flow path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(multi_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: nil
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_no_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::BAR_CHART,
+          x: :year
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+
+  context 'when single year, non-cont indicator, no flow path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(single_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :single_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::DONUT_CHART,
+          x: :ncont_attribute
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :single_year_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::HORIZONTAL_STACKED_BAR_CHART,
+          x: :node_type,
+          break_by: :ncont_attribute,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+
+  context 'when multiple years, non-cont indicator, no flow path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(multi_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          filter_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+end

--- a/spec/support/contexts/api/v3/brazil/brazil_resize_by_attributes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_resize_by_attributes.rb
@@ -2,17 +2,17 @@ shared_context 'api v3 brazil resize by attributes' do
   include_context 'api v3 brazil contexts'
   include_context 'api v3 quants'
 
-  let!(:api_v3_area_resize_by_attribute) do
+  let!(:api_v3_volume_resize_by_attribute) do
     resize_by_attribute = Api::V3::ResizeByQuant.
       includes(:resize_by_attribute).
       where(
         'resize_by_attributes.context_id' => api_v3_context.id,
-        quant_id: api_v3_area.id
+        quant_id: api_v3_volume.id
       ).first&.resize_by_attribute
     unless resize_by_attribute
       resize_by_attribute = FactoryBot.create(
         :api_v3_resize_by_attribute,
-        tooltip_text: 'area tooltip text',
+        tooltip_text: 'Amount of the traded commodity (tonnes)',
         context: api_v3_context,
         position: 1,
         years: [],
@@ -23,23 +23,23 @@ shared_context 'api v3 brazil resize by attributes' do
       FactoryBot.create(
         :api_v3_resize_by_quant,
         resize_by_attribute: resize_by_attribute,
-        quant: api_v3_area
+        quant: api_v3_volume
       )
     end
     resize_by_attribute
   end
 
-  let!(:api_v3_land_conflict_resize_by_attribute) do
+  let!(:api_v3_fob_resize_by_attribute) do
     resize_by_attribute = Api::V3::ResizeByQuant.
       includes(:resize_by_attribute).
       where(
         'resize_by_attributes.context_id' => api_v3_context.id,
-        quant_id: api_v3_land_conflicts.id
+        quant_id: api_v3_fob.id
       ).first&.resize_by_attribute
     unless resize_by_attribute
       resize_by_attribute = FactoryBot.create(
         :api_v3_resize_by_attribute,
-        tooltip_text: 'land conflict tooltip text',
+        tooltip_text: 'Value of the traded product in US dollars',
         context: api_v3_context,
         position: 2,
         years: [],
@@ -50,7 +50,7 @@ shared_context 'api v3 brazil resize by attributes' do
       FactoryBot.create(
         :api_v3_resize_by_quant,
         resize_by_attribute: resize_by_attribute,
-        quant: api_v3_land_conflicts
+        quant: api_v3_fob
       )
     end
     resize_by_attribute

--- a/spec/support/schemas/dashboards_parametrised_charts.json
+++ b/spec/support/schemas/dashboards_parametrised_charts.json
@@ -1,0 +1,44 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "$id": "#/properties/data",
+      "type": "array",
+      "title": "The Data Schema",
+      "items": {
+        "$id": "#/properties/data/items",
+        "type": "object",
+        "required": [
+          "type",
+          "url"
+        ],
+        "properties": {
+          "type": {
+            "$id": "#/properties/data/items/properties/type",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "bar_chart"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "url": {
+            "$id": "#/properties/data/items/properties/url",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "http://localhost:3000/api/v3/dashboards/chart_data?chart_type=bar_chart&commodity_id=1&cont_attribute_id=1&country_id=27&start_year=2015&x=year&y=cont_attribute&y_id=1"
+            ],
+            "pattern": "^(.*)$"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
New endpoint that dynamically calculates the types of charts to be rendered for selected parameters and returns the chart types and data urls.

This follows the spec in ["Dashboards filters: Visualizations to be used for each filter selection"](https://docs.google.com/document/d/1jBMhDs4_51cW4xC3fSH2AboGj934OPh-DEMFPFyY7b0/edit?usp=sharing). Adds a new endpoint which accepts the currently selected filters and parameters, and returns a list of chart types and urls to fetch data for the charts. The data endpoints are not finished, just the routes were added here and implementation will follow in further PRs.

Swagger docs were updated.