### PR TITLE
Feature/overview chart data endpoints

### DIFF
--- a/app/controllers/api/v3/dashboards/charts/multi_year_ncont_overview_controller.rb
+++ b/app/controllers/api/v3/dashboards/charts/multi_year_ncont_overview_controller.rb
@@ -1,0 +1,25 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class MultiYearNcontOverviewController < ApiController
+          include FilterParams
+          skip_before_action :load_context
+
+          def index
+            ensure_required_param_present(:country_id)
+            ensure_required_param_present(:commodity_id)
+            ensure_required_param_present(:start_year)
+            ensure_required_param_present(:end_year)
+            ensure_required_param_present(:cont_attribute_id)
+            ensure_required_param_present(:ncont_attribute_id)
+
+            render json: MultiYearNcontOverview.new(
+              ChartParameters.new(chart_params)
+            ).call
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/dashboards/charts/multi_year_no_ncont_overview_controller.rb
+++ b/app/controllers/api/v3/dashboards/charts/multi_year_no_ncont_overview_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class MultiYearNoNcontOverviewController < ApiController
+          include FilterParams
+          skip_before_action :load_context
+
+          def index
+            ensure_required_param_present(:country_id)
+            ensure_required_param_present(:commodity_id)
+            ensure_required_param_present(:start_year)
+            ensure_required_param_present(:end_year)
+            ensure_required_param_present(:cont_attribute_id)
+
+            render json: MultiYearNoNcontOverview.new(
+              ChartParameters.new(chart_params)
+            ).call
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/dashboards/charts/single_year_ncont_overview_controller.rb
+++ b/app/controllers/api/v3/dashboards/charts/single_year_ncont_overview_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class SingleYearNcontOverviewController < ApiController
+          include FilterParams
+          skip_before_action :load_context
+
+          def index
+            ensure_required_param_present(:country_id)
+            ensure_required_param_present(:commodity_id)
+            ensure_required_param_present(:start_year)
+            ensure_required_param_present(:cont_attribute_id)
+            ensure_required_param_present(:ncont_attribute_id)
+
+            render json: SingleYearNcontOverview.new(
+              ChartParameters.new(chart_params)
+            ).call
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/dashboards/charts/single_year_no_ncont_overview_controller.rb
+++ b/app/controllers/api/v3/dashboards/charts/single_year_no_ncont_overview_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class SingleYearNoNcontOverviewController < ApiController
+          include FilterParams
+          skip_before_action :load_context
+
+          def index
+            ensure_required_param_present(:country_id)
+            ensure_required_param_present(:commodity_id)
+            ensure_required_param_present(:start_year)
+            ensure_required_param_present(:cont_attribute_id)
+
+            render json: SingleYearNoNcontOverview.new(
+              ChartParameters.new(chart_params)
+            ).call
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/dashboards/parametrised_charts_controller.rb
+++ b/app/controllers/api/v3/dashboards/parametrised_charts_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V3
+    module Dashboards
+      class ParametrisedChartsController < ApiController
+        include FilterParams
+        skip_before_action :load_context
+
+        def index
+          ensure_required_param_present(:country_id)
+          ensure_required_param_present(:commodity_id)
+          ensure_required_param_present(:cont_attribute_id)
+
+          render json: ParametrisedCharts.new(ChartParameters.new(chart_params)).call,
+                 root: 'data',
+                 each_serializer: Api::V3::Dashboards::ParametrisedChartSerializer,
+                 url: proc { |options|
+                   send(:"api_v3_dashboards_charts_#{options.delete(:source)}_index_url", options)
+                 }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/api/v3/dashboards/filter_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/filter_params.rb
@@ -6,6 +6,20 @@ module Api
 
         private
 
+        def chart_params
+          {
+            country_id: string_to_int(params[:country_id]),
+            commodity_id: string_to_int(params[:commodity_id]),
+            start_year: string_to_int(params[:start_year]),
+            end_year: string_to_int(params[:end_year]),
+            cont_attribute_id: string_to_int(params[:cont_attribute_id]),
+            ncont_attribute_id: string_to_int(params[:ncont_attribute_id]),
+            sources_ids: cs_string_to_int_array(params[:sources_ids]),
+            companies_ids: cs_string_to_int_array(params[:companies_ids]),
+            destinations_ids: cs_string_to_int_array(params[:destinations_ids])
+          }
+        end
+
         def filter_params
           {
             countries_ids: cs_string_to_int_array(params[:countries_ids]),

--- a/app/serializers/api/v3/dashboards/parametrised_chart_serializer.rb
+++ b/app/serializers/api/v3/dashboards/parametrised_chart_serializer.rb
@@ -1,0 +1,10 @@
+module Api
+  module V3
+    module Dashboards
+      class ParametrisedChartSerializer < ActiveModel::Serializer
+        attribute(:type) { object[:type] }
+        attribute(:url) { instance_options[:url].call(object) }
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/chart_data.rb
+++ b/app/services/api/v3/dashboards/chart_data.rb
@@ -8,7 +8,6 @@ module Api
         # @option params [Array<Integer>] sources_ids
         # @option params [Array<Integer>] companies_ids
         # @option params [Array<Integer>] destinations_ids
-        # @option params [Array<Integer>] node_types_ids
         def initialize(params)
           @countries_ids = params[:countries_ids] || []
           @commodities_ids = params[:commodities_ids] || []

--- a/app/services/api/v3/dashboards/chart_parameters.rb
+++ b/app/services/api/v3/dashboards/chart_parameters.rb
@@ -41,7 +41,7 @@ module Api
           @sources_ids = params[:sources_ids] || []
           @companies_ids = params[:companies_ids] || []
           @destinations_ids = params[:destinations_ids] || []
-          @nodes_ids = @sources_ids + companies_ids + destinations_ids
+          @nodes_ids = @sources_ids + @companies_ids + @destinations_ids
 
           @start_year = params[:start_year]
           @end_year = params[:end_year]

--- a/app/services/api/v3/dashboards/chart_parameters.rb
+++ b/app/services/api/v3/dashboards/chart_parameters.rb
@@ -1,0 +1,88 @@
+module Api
+  module V3
+    module Dashboards
+      class ChartParameters
+        attr_reader :country_id,
+                    :commodity_id,
+                    :context,
+                    :cont_attribute,
+                    :ncont_attribute,
+                    :start_year,
+                    :end_year,
+                    :sources_ids,
+                    :companies_ids,
+                    :destinations_ids,
+                    :nodes_ids
+
+        # @param params [Hash]
+        # @option params [Integer] country_id
+        # @option params [Integer] commodity_id
+        # @option params [Integer] cont_attribute_id
+        # @option params [Integer] ncont_attribute_id
+        # @option params [Array<Integer>] sources_ids
+        # @option params [Array<Integer>] companies_ids
+        # @option params [Array<Integer>] destinations_ids
+        # @option params [Integer] start_year
+        # @option params [Integer] end_year
+        def initialize(params)
+          @country_id = params[:country_id]
+          @commodity_id = params[:commodity_id]
+
+          if @country_id && @commodity_id
+            @context = Api::V3::Context.where(
+              country_id: @country_id, commodity_id: @commodity_id
+            ).first
+          end
+          raise ActiveRecord::RecordNotFound unless @context
+
+          initialize_cont_attribute params[:cont_attribute_id]
+          initialize_ncont_attribute params[:ncont_attribute_id]
+
+          @sources_ids = params[:sources_ids] || []
+          @companies_ids = params[:companies_ids] || []
+          @destinations_ids = params[:destinations_ids] || []
+          @nodes_ids = @sources_ids + companies_ids + destinations_ids
+
+          @start_year = params[:start_year]
+          @end_year = params[:end_year]
+        end
+
+        private
+
+        def initialize_cont_attribute(cont_attribute_id)
+          return unless cont_attribute_id.present?
+
+          resize_by_attribute = Api::V3::Readonly::ResizeByAttribute.
+            select(:attribute_id).
+            where(context_id: @context.id, attribute_id: cont_attribute_id).
+            includes(:readonly_attribute).
+            first
+          raise ActiveRecord::RecordNotFound unless resize_by_attribute
+
+          @cont_attribute = resize_by_attribute.readonly_attribute
+        end
+
+        def initialize_ncont_attribute(ncont_attribute_id)
+          return unless ncont_attribute_id.present?
+
+          recolor_by_attribute = Api::V3::Readonly::RecolorByAttribute.
+            select(:attribute_id).
+            where(context_id: @context.id, attribute_id: ncont_attribute_id).
+            includes(:readonly_attribute).
+            first
+          raise ActiveRecord::RecordNotFound unless recolor_by_attribute
+
+          @ncont_attribute = recolor_by_attribute.readonly_attribute
+        end
+
+        def single_year?
+          @start_year.present? && @end_year.present? && @start_year == @end_year
+        end
+
+        def ncont_attribute?
+          @ncont_attribute.present?
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
@@ -1,0 +1,104 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class MultiYearNcontOverview
+          # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
+          def initialize(chart_parameters)
+            @cont_attribute = chart_parameters.cont_attribute
+            @context = chart_parameters.context
+            @start_year = chart_parameters.start_year
+            @end_year = chart_parameters.end_year
+            @ncont_attribute = chart_parameters.ncont_attribute
+            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
+            initialize_query
+          end
+
+          def call
+            break_by_values_indexes = Hash[
+              break_by_values.map.with_index { |v, idx| [v, idx] }
+            ]
+            data_by_x = {}
+            @query.each do |record|
+              idx = break_by_values_indexes[record['break_by']]
+              data_by_x[record['x']] ||= {}
+              data_by_x[record['x']]["y#{idx}"] = record['y']
+            end
+
+            @data = data_by_x.map do |key, value|
+              value.symbolize_keys.merge(x: key)
+            end
+
+            @meta = {
+              xAxis: {
+                label: 'Year',
+                prefix: '',
+                format: '',
+                suffix: ''
+              },
+              yAxis: {
+                label: @cont_attribute.display_name,
+                prefix: '',
+                format: '',
+                suffix: @cont_attribute.unit
+              },
+              x: {
+                type: 'category', # category || date || number
+                label: 'Year',
+                tooltip: {prefix: '', format: '', suffix: ''}
+              }
+            }
+
+            break_by_values_indexes.each do |break_by, idx|
+              @meta[:"y#{idx}"] = {
+                type: 'category',
+                label: break_by,
+                tooltip: {prefix: '', format: '', suffix: ''}
+              }
+            end
+
+            {data: @data, meta: @meta}
+          end
+
+          private
+
+          def initialize_query
+            cont_attr_table = @cont_attribute.flow_values_class.table_name
+            ncont_attr_table = @ncont_attribute.flow_values_class.table_name
+            @query = Api::V3::Flow.
+              select([
+                'year AS x',
+                "#{ncont_attr_table}.value AS break_by",
+                "SUM(#{cont_attr_table}.value) AS y"
+              ]).
+              joins(cont_attr_table.to_sym).
+              joins("LEFT JOIN #{ncont_attr_table} ON #{ncont_attr_table}.flow_id = flows.id").
+              where(
+                context_id: @context.id,
+                "#{cont_attr_table}.#{@cont_attribute.attribute_id_name}" =>
+                  @cont_attribute.original_id,
+                "#{ncont_attr_table}.#{@ncont_attribute.attribute_id_name}" =>
+                  @ncont_attribute.original_id
+              ).
+              where('year BETWEEN ? AND ?', @start_year, @end_year).
+              group(1, 2)
+
+            @nodes_ids_by_position.each do |position, nodes_ids|
+              @query = @query.where('ARRAY[flows.path[?]] && ARRAY[?]', position + 1, nodes_ids)
+            end
+          end
+
+          def break_by_values
+            @ncont_attribute.
+              flow_values_class.
+              where(@ncont_attribute.attribute_id_name => @ncont_attribute.original_id).
+              select(:value).
+              order(:value).
+              distinct.
+              map(&:value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
@@ -33,13 +33,12 @@ module Api
 
             @meta = {
               xAxis: year_axis_meta,
-              yAxis: axis_meta(@cont_attribute),
+              yAxis: axis_meta(@cont_attribute, type: 'category'),
               x: year_legend_meta
             }
 
             break_by_values_indexes.each do |break_by, idx|
               @meta[:"y#{idx}"] = {
-                type: 'category',
                 label: break_by,
                 tooltip: {prefix: '', format: '', suffix: ''}
               }

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
@@ -21,9 +21,9 @@ module Api
             end
             @meta = {
               xAxis: year_axis_meta,
-              yAxis: axis_meta(@cont_attribute),
+              yAxis: axis_meta(@cont_attribute, 'number'),
               x: year_legend_meta,
-              y0: legend_meta(@cont_attribute, 'number')
+              y0: legend_meta(@cont_attribute)
             }
             {data: @data, meta: @meta}
           end

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
@@ -3,6 +3,8 @@ module Api
     module Dashboards
       module Charts
         class MultiYearNoNcontOverview
+          include Api::V3::Dashboards::Charts::Helpers
+
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
             @cont_attribute = chart_parameters.cont_attribute
@@ -18,28 +20,10 @@ module Api
               r.attributes.slice('x', 'y0').symbolize_keys
             end
             @meta = {
-              xAxis: {
-                label: 'Year',
-                prefix: '',
-                format: '',
-                suffix: ''
-              },
-              yAxis: {
-                label: @cont_attribute.display_name,
-                prefix: '',
-                format: '',
-                suffix: @cont_attribute.unit
-              },
-              x: {
-                type: 'category', # category || date || number
-                label: 'Year',
-                tooltip: {prefix: '', format: '', suffix: ''}
-              },
-              y0: {
-                type: 'number',
-                label: '',
-                tooltip: {prefix: '', format: '', suffix: ''}
-              }
+              xAxis: year_axis_meta,
+              yAxis: axis_meta(@cont_attribute),
+              x: year_legend_meta,
+              y0: legend_meta(@cont_attribute, 'number')
             }
             {data: @data, meta: @meta}
           end
@@ -47,20 +31,11 @@ module Api
           private
 
           def initialize_query
-            cont_attr_table = @cont_attribute.flow_values_class.table_name
-            @query = Api::V3::Flow.
-              select("year AS x, SUM(#{cont_attr_table}.value) AS y0").
-              joins(cont_attr_table.to_sym).
-              where(
-                context_id: @context.id,
-                "#{cont_attr_table}.#{@cont_attribute.attribute_id_name}" =>
-                  @cont_attribute.original_id
-              ).
-              where('year BETWEEN ? AND ?', @start_year, @end_year).
-              group(1)
-            @nodes_ids_by_position.each do |position, nodes_ids|
-              @query = @query.where('ARRAY[flows.path[?]] && ARRAY[?]', position + 1, nodes_ids)
-            end
+            @query = flow_query
+            apply_year_x
+            apply_cont_attribute_y
+            apply_multi_year_filter
+            apply_flow_path_filters
           end
         end
       end

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
@@ -1,0 +1,69 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class MultiYearNoNcontOverview
+          # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
+          def initialize(chart_parameters)
+            @cont_attribute = chart_parameters.cont_attribute
+            @context = chart_parameters.context
+            @start_year = chart_parameters.start_year
+            @end_year = chart_parameters.end_year
+            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
+            initialize_query
+          end
+
+          def call
+            @data = @query.map do |r|
+              r.attributes.slice('x', 'y0').symbolize_keys
+            end
+            @meta = {
+              xAxis: {
+                label: 'Year',
+                prefix: '',
+                format: '',
+                suffix: ''
+              },
+              yAxis: {
+                label: @cont_attribute.display_name,
+                prefix: '',
+                format: '',
+                suffix: @cont_attribute.unit
+              },
+              x: {
+                type: 'category', # category || date || number
+                label: 'Year',
+                tooltip: {prefix: '', format: '', suffix: ''}
+              },
+              y0: {
+                type: 'number',
+                label: '',
+                tooltip: {prefix: '', format: '', suffix: ''}
+              }
+            }
+            {data: @data, meta: @meta}
+          end
+
+          private
+
+          def initialize_query
+            cont_attr_table = @cont_attribute.flow_values_class.table_name
+            @query = Api::V3::Flow.
+              select("year AS x, SUM(#{cont_attr_table}.value) AS y0").
+              joins(cont_attr_table.to_sym).
+              where(
+                context_id: @context.id,
+                "#{cont_attr_table}.#{@cont_attribute.attribute_id_name}" =>
+                  @cont_attribute.original_id
+              ).
+              where('year BETWEEN ? AND ?', @start_year, @end_year).
+              group(1)
+            @nodes_ids_by_position.each do |position, nodes_ids|
+              @query = @query.where('ARRAY[flows.path[?]] && ARRAY[?]', position + 1, nodes_ids)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
@@ -1,0 +1,77 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class SingleYearNcontOverview
+          # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
+          def initialize(chart_parameters)
+            @cont_attribute = chart_parameters.cont_attribute
+            @context = chart_parameters.context
+            @year = chart_parameters.start_year
+            @ncont_attribute = chart_parameters.ncont_attribute
+            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
+            initialize_query
+          end
+
+          def call
+            @data = @query.map do |r|
+              r.attributes.slice('x', 'y0').symbolize_keys
+            end
+            @meta = {
+              xAxis: {
+                label: @ncont_attribute.display_name,
+                prefix: '',
+                format: '',
+                suffix: @ncont_attribute.unit
+              },
+              yAxis: {
+                label: @cont_attribute.display_name,
+                prefix: '',
+                format: '',
+                suffix: @cont_attribute.unit
+              },
+              x: {
+                type: 'category', # category || date || number
+                label: @ncont_attribute.display_name,
+                tooltip: {prefix: '', format: '', suffix: ''}
+              },
+              y0: {
+                type: 'number',
+                label: @cont_attribute.display_name,
+                tooltip: {prefix: '', format: '', suffix: ''}
+              }
+            }
+            {data: @data, meta: @meta}
+          end
+
+          private
+
+          def initialize_query
+            cont_attr_table = @cont_attribute.flow_values_class.table_name
+            ncont_attr_table = @ncont_attribute.flow_values_class.table_name
+            @query = Api::V3::Flow.
+              select([
+                "#{ncont_attr_table}.value AS x",
+                "SUM(#{cont_attr_table}.value) AS y0"
+              ]).
+              joins(cont_attr_table.to_sym).
+              joins("LEFT JOIN #{ncont_attr_table} ON #{ncont_attr_table}.flow_id = flows.id").
+              where(
+                context_id: @context.id,
+                year: @year,
+                "#{cont_attr_table}.#{@cont_attribute.attribute_id_name}" =>
+                  @cont_attribute.original_id,
+                "#{ncont_attr_table}.#{@ncont_attribute.attribute_id_name}" =>
+                  @ncont_attribute.original_id
+              ).
+              group(1)
+
+            @nodes_ids_by_position.each do |position, nodes_ids|
+              @query = @query.where('ARRAY[flows.path[?]] && ARRAY[?]', position + 1, nodes_ids)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
@@ -20,10 +20,10 @@ module Api
               r.attributes.slice('x', 'y0').symbolize_keys
             end
             @meta = {
-              xAxis: axis_meta(@ncont_attribute),
-              yAxis: axis_meta(@cont_attribute),
-              x: legend_meta(@ncont_attribute, 'category'),
-              y0: legend_meta(@cont_attribute, 'number')
+              xAxis: axis_meta(@ncont_attribute, 'category'),
+              yAxis: axis_meta(@cont_attribute, 'number'),
+              x: legend_meta(@ncont_attribute),
+              y0: legend_meta(@cont_attribute)
             }
             {data: @data, meta: @meta}
           end

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
@@ -1,0 +1,59 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        class SingleYearNoNcontOverview
+          # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
+          def initialize(chart_parameters)
+            @cont_attribute = chart_parameters.cont_attribute
+            @context = chart_parameters.context
+            @year = chart_parameters.start_year
+            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
+            initialize_query
+          end
+
+          def call
+            @data = @query.map do |r|
+              r.attributes.slice('y0').symbolize_keys
+            end
+            @meta = {
+              xAxis: {},
+              yAxis: {
+                label: @cont_attribute.display_name,
+                prefix: '',
+                format: '',
+                suffix: @cont_attribute.unit
+              },
+              x: {},
+              y0: {
+                type: 'number',
+                label: '',
+                tooltip: {prefix: '', format: '', suffix: ''}
+              }
+            }
+            {data: @data, meta: @meta}
+          end
+
+          private
+
+          def initialize_query
+            cont_attr_table = @cont_attribute.flow_values_class.table_name
+            @query = Api::V3::Flow.
+              select("SUM(#{cont_attr_table}.value) AS y0").
+              joins(cont_attr_table.to_sym).
+              where(
+                context_id: @context.id,
+                year: @year,
+                "#{cont_attr_table}.#{@cont_attribute.attribute_id_name}" =>
+                  @cont_attribute.original_id
+              ).
+              order(false)
+            @nodes_ids_by_position.each do |position, nodes_ids|
+              @query = @query.where('ARRAY[flows.path[?]] && ARRAY[?]', position + 1, nodes_ids)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
@@ -20,9 +20,9 @@ module Api
             end
             @meta = {
               xAxis: {},
-              yAxis: axis_meta(@cont_attribute),
+              yAxis: axis_meta(@cont_attribute, 'number'),
               x: {},
-              y0: legend_meta(@cont_attribute, 'number')
+              y0: legend_meta(@cont_attribute)
             }
             {data: @data, meta: @meta}
           end

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
@@ -3,6 +3,8 @@ module Api
     module Dashboards
       module Charts
         class SingleYearNoNcontOverview
+          include Api::V3::Dashboards::Charts::Helpers
+
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
             @cont_attribute = chart_parameters.cont_attribute
@@ -18,18 +20,9 @@ module Api
             end
             @meta = {
               xAxis: {},
-              yAxis: {
-                label: @cont_attribute.display_name,
-                prefix: '',
-                format: '',
-                suffix: @cont_attribute.unit
-              },
+              yAxis: axis_meta(@cont_attribute),
               x: {},
-              y0: {
-                type: 'number',
-                label: '',
-                tooltip: {prefix: '', format: '', suffix: ''}
-              }
+              y0: legend_meta(@cont_attribute, 'number')
             }
             {data: @data, meta: @meta}
           end
@@ -37,20 +30,10 @@ module Api
           private
 
           def initialize_query
-            cont_attr_table = @cont_attribute.flow_values_class.table_name
-            @query = Api::V3::Flow.
-              select("SUM(#{cont_attr_table}.value) AS y0").
-              joins(cont_attr_table.to_sym).
-              where(
-                context_id: @context.id,
-                year: @year,
-                "#{cont_attr_table}.#{@cont_attribute.attribute_id_name}" =>
-                  @cont_attribute.original_id
-              ).
-              order(false)
-            @nodes_ids_by_position.each do |position, nodes_ids|
-              @query = @query.where('ARRAY[flows.path[?]] && ARRAY[?]', position + 1, nodes_ids)
-            end
+            @query = flow_query
+            apply_cont_attribute_y
+            apply_single_year_filter
+            apply_flow_path_filters
           end
         end
       end

--- a/app/services/api/v3/dashboards/node_types_to_break_by.rb
+++ b/app/services/api/v3/dashboards/node_types_to_break_by.rb
@@ -1,0 +1,101 @@
+# Returns node types by which to break down for non-global charts,
+# taking into account user selection and availability of node types
+# in the given context.
+module Api
+  module V3
+    module Dashboards
+      class NodeTypesToBreakBy
+        # TODO: incorporate the new "role" attribute here
+        SOURCE_COLUMN_GROUP = 0
+        EXPORTER_COLUMN_GROUP = 1
+        IMPORTER_COLUMN_GROUP = 2
+        DESTINATION_COLUMN_GROUP = 3
+
+        # @param context [Api::V3::Context]
+        # @param [Array<Integer>] source_node_types_ids
+        # @param [Array<Integer>] company_node_types_ids
+        # @param [Array<Integer>] destination_node_types_ids
+        def initialize(context, source_node_types_ids, company_node_types_ids, destination_node_types_ids)
+          @context = context
+          @source_node_types_ids = source_node_types_ids || []
+          @company_node_types_ids = company_node_types_ids || []
+          @destination_node_types_ids = destination_node_types_ids || []
+        end
+
+        def call
+          context_node_types = @context.context_node_types.
+            includes(:context_node_type_property, :node_type)
+          grouped_context_node_types = context_node_types.group_by do |cnt|
+            cnt.context_node_type_property.column_group
+          end
+
+          result =
+            enabled_source_node_types(
+              grouped_context_node_types[SOURCE_COLUMN_GROUP]
+            ) +
+            enabled_exporter_node_types(
+              grouped_context_node_types[EXPORTER_COLUMN_GROUP]
+            ) +
+            enabled_importer_node_types(
+              grouped_context_node_types[IMPORTER_COLUMN_GROUP]
+            ) +
+            enabled_destination_node_types(
+              grouped_context_node_types[DESTINATION_COLUMN_GROUP]
+            )
+
+          result.map(&:node_type)
+        end
+
+        private
+
+        def enabled_source_node_types(source_node_types)
+          return [] unless source_node_types
+
+          source_node_types.select do |cnt|
+            if @source_node_types_ids.any?
+              @source_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+
+        def enabled_exporter_node_types(exporter_node_types)
+          return [] unless exporter_node_types
+
+          exporter_node_types.select do |cnt|
+            if @company_node_types_ids.any?
+              @company_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+
+        def enabled_importer_node_types(importer_node_types)
+          return [] unless importer_node_types
+
+          importer_node_types.select do |cnt|
+            if @company_node_types_ids.any?
+              @company_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+
+        def enabled_destination_node_types(destination_node_types)
+          return [] unless destination_node_types
+
+          destination_node_types.select do |cnt|
+            if @destination_node_types_ids.any?
+              @destination_node_types_ids.include?(cnt.node_type_id)
+            else
+              true
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/node_types_to_break_by.rb
+++ b/app/services/api/v3/dashboards/node_types_to_break_by.rb
@@ -1,4 +1,4 @@
-# Returns node types by which to break down for non-global charts,
+# Returns node types by which to break down for non-overview charts,
 # taking into account user selection and availability of node types
 # in the given context.
 module Api
@@ -15,7 +15,12 @@ module Api
         # @param [Array<Integer>] source_node_types_ids
         # @param [Array<Integer>] company_node_types_ids
         # @param [Array<Integer>] destination_node_types_ids
-        def initialize(context, source_node_types_ids, company_node_types_ids, destination_node_types_ids)
+        def initialize(
+          context,
+          source_node_types_ids = [],
+          company_node_types_ids = [],
+          destination_node_types_ids = []
+        )
           @context = context
           @source_node_types_ids = source_node_types_ids || []
           @company_node_types_ids = company_node_types_ids || []

--- a/app/services/api/v3/dashboards/parametrised_charts.rb
+++ b/app/services/api/v3/dashboards/parametrised_charts.rb
@@ -1,0 +1,176 @@
+module Api
+  module V3
+    module Dashboards
+      class ParametrisedCharts
+        DYNAMIC_SENTENCE = :dynamic_sentence
+        DONUT_CHART = :donut_chart
+        BAR_CHART = :bar_chart
+        STACKED_BAR_CHART = :stacked_bar_chart
+        HORIZONTAL_BAR_CHART = :horizontal_bar_chart
+        HORIZONTAL_STACKED_BAR_CHART = :horizontal_stacked_bar_chart
+        VALUE_TABLE = :value_table
+
+        # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
+        def initialize(chart_parameters)
+          @country_id = chart_parameters.country_id
+          @commodity_id = chart_parameters.commodity_id
+          @context = chart_parameters.context
+          @cont_attribute = chart_parameters.cont_attribute
+          @ncont_attribute = chart_parameters.ncont_attribute
+          @sources_ids = chart_parameters.sources_ids
+          @companies_ids = chart_parameters.companies_ids
+          @destinations_ids = chart_parameters.destinations_ids
+
+          @start_year = chart_parameters.start_year
+          @end_year = chart_parameters.end_year
+        end
+
+        def call
+          chart_types =
+            if single_year? && !ncont_attribute?
+              single_year_no_ncont_charts
+            elsif single_year? && ncont_attribute?
+              single_year_ncont_charts
+            elsif !single_year? && !ncont_attribute?
+              multi_year_no_ncont_charts
+            else
+              multi_year_ncont_charts
+            end
+          chart_types.map do |chart_params|
+            sanitized_chart_params.merge(chart_params)
+          end
+        end
+
+        private
+
+        def node_types_to_break_by
+          Api::V3::Dashboards::NodeTypesToBreakBy.new(@context).call
+        end
+
+        def single_year?
+          @start_year.present? && @end_year.nil? ||
+            @start_year.present? && @end_year.present? && @start_year == @end_year
+        end
+
+        def ncont_attribute?
+          @ncont_attribute.present?
+        end
+
+        def single_year_no_ncont_charts
+          [single_year_no_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              single_year_no_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def single_year_no_ncont_overview_chart
+          {
+            source: :single_year_no_ncont_overview,
+            type: DYNAMIC_SENTENCE,
+            x: nil
+          }
+        end
+
+        def single_year_no_ncont_by_node_type_chart(node_type)
+          {
+            source: :single_year_no_ncont_by_node_type,
+            type: HORIZONTAL_BAR_CHART,
+            x: :node_type,
+            node_type_id: node_type.id
+          }
+        end
+
+        def single_year_ncont_charts
+          [single_year_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              single_year_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def single_year_ncont_overview_chart
+          {
+            source: :single_year_ncont_overview,
+            type: DONUT_CHART,
+            x: :ncont_attribute
+          }
+        end
+
+        def single_year_ncont_by_node_type_chart(node_type)
+          {
+            source: :single_year_ncont_by_node_type,
+            type: HORIZONTAL_STACKED_BAR_CHART, # TODO: or VALUE_TABLE?
+            x: :node_type,
+            break_by: :ncont_attribute,
+            node_type_id: node_type.id
+          }
+        end
+
+        def multi_year_no_ncont_charts
+          [multi_year_no_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              multi_year_no_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def multi_year_no_ncont_overview_chart
+          {
+            source: :multi_year_no_ncont_overview,
+            type: BAR_CHART,
+            x: :year
+          }
+        end
+
+        def multi_year_no_ncont_by_node_type_chart(node_type)
+          {
+            source: :multi_year_no_ncont_by_node_type,
+            type: STACKED_BAR_CHART,
+            x: :year,
+            break_by: :node_type,
+            node_type_id: node_type.id
+          }
+        end
+
+        def multi_year_ncont_charts
+          [multi_year_ncont_overview_chart] +
+            node_types_to_break_by.map do |node_type|
+              multi_year_ncont_by_node_type_chart(node_type)
+            end
+        end
+
+        def multi_year_ncont_overview_chart
+          {
+            source: :multi_year_ncont_overview,
+            type: STACKED_BAR_CHART,
+            x: :year,
+            break_by: :ncont_attribute
+          }
+        end
+
+        def multi_year_ncont_by_node_type_chart(node_type)
+          {
+            source: :multi_year_ncont_by_node_type,
+            type: STACKED_BAR_CHART,
+            x: :year,
+            break_by: :ncont_attribute,
+            filter_by: :node_type,
+            node_type_id: node_type.id
+          }
+        end
+
+        def sanitized_chart_params
+          {
+            cont_attribute_id: @cont_attribute.id,
+            ncont_attribute_id: @ncont_attribute&.id,
+            country_id: @country_id,
+            commodity_id: @commodity_id,
+            sources_ids: @sources_ids,
+            companies_ids: @companies_ids,
+            destinations_ids: @destinations_ids,
+            start_year: @start_year,
+            end_year: @end_year
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/retrieve_attributes.rb
+++ b/app/services/api/v3/dashboards/retrieve_attributes.rb
@@ -8,7 +8,6 @@ module Api
         # @option params [Array<Integer>] sources_ids
         # @option params [Array<Integer>] companies_ids
         # @option params [Array<Integer>] destinations_ids
-        # @option params [Array<Integer>] node_types_ids
         def initialize(params)
           @countries_ids = params[:countries_ids] || []
           @commodities_ids = params[:commodities_ids] || []

--- a/app/services/concerns/api/v3/dashboards/charts/helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/helpers.rb
@@ -1,0 +1,105 @@
+module Api
+  module V3
+    module Dashboards
+      module Charts
+        module Helpers
+          private
+
+          def flow_query
+            Api::V3::Flow.where(context_id: @context.id).order(false)
+          end
+
+          def apply_cont_attribute_y
+            cont_attr_table = @cont_attribute.flow_values_class.table_name
+            @query = @query.
+              select("SUM(#{cont_attr_table}.value) AS y0").
+              joins(cont_attr_table.to_sym).
+              where(
+                "#{cont_attr_table}.#{@cont_attribute.attribute_id_name}" =>
+                  @cont_attribute.original_id
+              )
+          end
+
+          def apply_ncont_attribute_x
+            ncont_attr_table = @ncont_attribute.flow_values_class.table_name
+            @query = @query.
+              select("#{ncont_attr_table}.value AS x").
+              joins("LEFT JOIN #{ncont_attr_table} ON #{ncont_attr_table}.flow_id = flows.id").
+              where(
+                "#{ncont_attr_table}.#{@ncont_attribute.attribute_id_name}" =>
+                  @ncont_attribute.original_id
+              ).
+              group("#{ncont_attr_table}.value")
+          end
+
+          def apply_year_x
+            @query = @query.select('year AS x').
+              group(:year)
+          end
+
+          def apply_ncont_attribute_break_by
+            ncont_attr_table = @ncont_attribute.flow_values_class.table_name
+            @query = @query.
+              select("#{ncont_attr_table}.value AS break_by").
+              joins("LEFT JOIN #{ncont_attr_table} ON #{ncont_attr_table}.flow_id = flows.id").
+              where(
+                "#{ncont_attr_table}.#{@ncont_attribute.attribute_id_name}" =>
+                  @ncont_attribute.original_id
+              ).
+              group("#{ncont_attr_table}.value")
+          end
+
+          def apply_single_year_filter
+            @query = @query.where(year: @year)
+          end
+
+          def apply_multi_year_filter
+            @query = @query.where('year BETWEEN ? AND ?', @start_year, @end_year)
+          end
+
+          def apply_flow_path_filters
+            @nodes_ids_by_position.each do |position, nodes_ids|
+              @query = @query.where(
+                'ARRAY[flows.path[?]] && ARRAY[?]', position + 1, nodes_ids
+              )
+            end
+          end
+
+          def axis_meta(attribute)
+            {
+              label: attribute.display_name,
+              prefix: '',
+              format: '',
+              suffix: attribute.unit
+            }
+          end
+
+          def year_axis_meta
+            {
+              label: 'Year',
+              prefix: '',
+              format: '',
+              suffix: ''
+            }
+          end
+
+          def legend_meta(attribute, type)
+            {
+              type: type,
+              label: attribute.display_name,
+              tooltip: {prefix: '', format: '', suffix: attribute.unit}
+            }
+          end
+
+          def year_legend_meta
+            {
+              type: 'category', # category || date || number
+              label: 'Year',
+              tooltip: {prefix: '', format: '', suffix: ''}
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/concerns/api/v3/dashboards/charts/helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/helpers.rb
@@ -65,8 +65,9 @@ module Api
             end
           end
 
-          def axis_meta(attribute)
+          def axis_meta(attribute, type)
             {
+              type: type,
               label: attribute.display_name,
               prefix: '',
               format: '',
@@ -76,6 +77,7 @@ module Api
 
           def year_axis_meta
             {
+              type: 'category', # category || date || number
               label: 'Year',
               prefix: '',
               format: '',
@@ -83,9 +85,8 @@ module Api
             }
           end
 
-          def legend_meta(attribute, type)
+          def legend_meta(attribute)
             {
-              type: type,
               label: attribute.display_name,
               tooltip: {prefix: '', format: '', suffix: attribute.unit}
             }
@@ -93,7 +94,6 @@ module Api
 
           def year_legend_meta
             {
-              type: 'category', # category || date || number
               label: 'Year',
               tooltip: {prefix: '', format: '', suffix: ''}
             }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,17 @@ Rails.application.routes.draw do
         resources :attributes
         resources :filter_meta, only: [:index]
         resources :chart_data, only: [:index]
+        namespace :charts do
+          resources :single_year_no_ncont_overview, only: [:index]
+          resources :single_year_no_ncont_by_node_type, only: [:index]
+          resources :single_year_ncont_overview, only: [:index]
+          resources :single_year_ncont_by_node_type, only: [:index]
+          resources :multi_year_no_ncont_overview, only: [:index]
+          resources :multi_year_no_ncont_by_node_type, only: [:index]
+          resources :multi_year_ncont_overview, only: [:index]
+          resources :multi_year_ncont_by_node_type, only: [:index]
+        end
+        resources :parametrised_charts, only: [:index]
       end
     end
     namespace :v2 do

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -1618,6 +1618,9 @@ components:
     DashboardsNcontXAxis:
       type: object
       properties:
+        type:
+          type: string
+          example: category
         label:
           type: string
           example: Forest 500 score
@@ -1635,6 +1638,9 @@ components:
     DashboardsYearXAxis:
       type: object
       properties:
+        type:
+          type: string
+          example: category
         label:
           type: string
           example: Year
@@ -1653,6 +1659,9 @@ components:
     DashboardsYAxis:
       type: object
       properties:
+        type:
+          type: string
+          example: numeric
         label:
           type: string
           example: Trade Volume
@@ -1706,9 +1715,6 @@ components:
     DashboardsYearXLegend:
       type: object
       properties:
-        type:
-          type: string
-          example: category
         label:
           type: string
           example: Year
@@ -1730,9 +1736,6 @@ components:
     DashboardsYLegend:
       type: object
       properties:
-        type:
-          type: string
-          example: numeric
         label:
           type: string
           example: Trade Volume
@@ -1753,9 +1756,6 @@ components:
     DashboardsNcontYLegend:
       type: object
       properties:
-        type:
-          type: string
-          example: category
         label:
           type: string
           example: "1.0"

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -1268,13 +1268,53 @@ paths:
                   y1:
                     $ref: "#/definitions/DashboardsChartValue"
 
+  '/dashboards/parametrised_charts':
+    get:
+      tags:
+        - dashboards
+      summary: 'Dynamic chart types matching selected filters'
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: "#/parameters/dashboards_country_id"
+        - $ref: "#/parameters/dashboards_commodity_id"
+        - $ref: "#/parameters/dashboards_cont_attribute_id"
+        - $ref: "#/parameters/dashboards_ncont_attribute_id"
+        - $ref: "#/parameters/dashboards_sources_ids"
+        - $ref: "#/parameters/dashboards_companies_ids"
+        - $ref: "#/parameters/dashboards_destinations_ids"
+        - $ref: "#/parameters/dashboards_start_year"
+        - $ref: "#/parameters/dashboards_end_year"
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/definitions/ParametrisedChart'
+
 parameters:
+  dashboards_country_id:
+    name: country_id
+    in: query
+    type: integer
+    required: true
   dashboards_countries_ids:
     name: countries_ids
     in: query
     description: 'String with comma-separated numeric ids'
     required: false
     type: string
+  dashboards_commodity_id:
+    name: commodity_id
+    in: query
+    type: integer
+    required: true
   dashboards_commodities_ids:
     name: commodities_ids
     in: query
@@ -1309,6 +1349,30 @@ parameters:
     name: attribute_id
     in: query
     description: 'Attribute id'
+    required: false
+    type: integer
+  dashboards_cont_attribute_id:
+    name: cont_attribute_id
+    in: query
+    description: 'Continuous attribute id'
+    required: true
+    type: integer
+  dashboards_ncont_attribute_id:
+    name: ncont_attribute_id
+    in: query
+    description: 'Non-continuous attribute id'
+    required: false
+    type: integer
+  dashboards_start_year:
+    name: start_year
+    in: query
+    description: 'Start year'
+    required: true
+    type: integer
+  dashboards_end_year:
+    name: end_year
+    in: query
+    description: 'End year (not required for single year selection)'
     required: false
     type: integer
   page:
@@ -2699,3 +2763,12 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Chart'
+
+  ParametrisedChart:
+    type: object
+    properties:
+      type:
+        type: string
+        example: 'stacked_bar_chart'
+      url:
+        type: string

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -1,2424 +1,2534 @@
-swagger: '2.0'
+openapi: 3.0.0
 info:
   description: Trase API V3
   version: 3.0.0
   title: Trase API
-  termsOfService: 'https://trase.earth/terms-of-use.html'
+  termsOfService: https://trase.earth/terms-of-use.html
   contact:
     email: info@trase.earth
   license:
     name: MIT License
-host: trase.earth
-basePath: /api/v3
 tags:
   - name: context
   - name: flow
   - name: node
-schemes:
-  - https
 paths:
   /contexts:
     get:
       tags:
         - context
-      summary: ''
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: ""
+      description: ""
       responses:
-        '200':
+        "200":
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/Context'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Context"
   /nodes/search:
     get:
       tags:
         - node
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: query
           in: query
           required: true
-          type: integer
-          description: 'Search string to use'
+          description: Search string to use
+          schema:
+            type: integer
         - name: context_id
           in: query
           required: false
-          type: integer
-          description: 'If provided, limit results to nodes of a given context'
+          description: If provided, limit results to nodes of a given context
+          schema:
+            type: integer
         - name: profile_only
           in: query
-          type: boolean
-          description: 'If provided, only show results that have a profile type defined'
-      responses:
-        '200':
-          description: successful operation
+          description: If provided, only show results that have a profile type defined
           schema:
-            type: array
-            items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                mainId:
-                  type: integer
-                name:
-                  type: string
-                nodeType:
-                  type: string
-                  example: 'EXPORTER'
-                contextId:
-                  type: integer
-                profile:
-                  type: string
-                  example: 'actor'
-  '/contexts/{context_id}/columns':
+            type: boolean
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    mainId:
+                      type: integer
+                    name:
+                      type: string
+                    nodeType:
+                      type: string
+                      example: EXPORTER
+                    contextId:
+                      type: integer
+                    profile:
+                      type: string
+                      example: actor
+  "/contexts/{context_id}/columns":
     get:
       tags:
         - context
-      summary: ''
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: ""
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/Column'
-  '/contexts/{context_id}/map_layers':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Column"
+  "/contexts/{context_id}/map_layers":
     get:
       tags:
         - context
-      summary: ''
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: ""
+      description: ""
       parameters:
         - name: context_id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: start_year
           in: query
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: end_year
           in: query
-          type: integer
-      responses:
-        '200':
-          description: successful operation
           schema:
-            $ref: '#/definitions/MapGroup'
-  '/contexts/{context_id}/download_attributes':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MapGroup"
+  "/contexts/{context_id}/download_attributes":
     get:
       tags:
         - context
-      summary: ''
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: ""
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              indicators:
-                type: array
-                items:
-                  $ref: '#/definitions/DownloadAttribute'
-  '/contexts/{context_id}/flows':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  indicators:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DownloadAttribute"
+  "/contexts/{context_id}/flows":
     get:
       tags:
         - flow
-      summary: ''
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: ""
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: include_columns
           in: query
           description: List of node type ids
           required: true
-          type: array
-          items:
-            type: integer
+          schema:
+            type: array
+            items:
+              type: integer
         - name: flow_quant
           in: query
           description: Name of quant for resizing
           required: true
-          type: string
+          schema:
+            type: string
         - name: flow_ind
           in: query
           description: Name of ind for recoloring
           required: false
-          type: string
+          schema:
+            type: string
         - name: flow_qual
           in: query
           description: Name of qual for recoloring
           required: false
-          type: string
+          schema:
+            type: string
         - name: selected_nodes
           in: query
           description: List of selected node ids
           required: false
-          type: array
-          items:
-            type: integer
+          schema:
+            type: array
+            items:
+              type: integer
         - name: biome_filter_id
           in: query
           description: Id of biome to filter by
           required: false
-          type: integer
+          schema:
+            type: integer
         - name: start_year
           in: query
           description: Year range start
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: end_year
           in: query
           description: Year range end (defaults to start)
           required: false
-          type: integer
+          schema:
+            type: integer
         - name: n_nodes
           in: query
           description: Number of top nodes (defaults to 100)
           required: false
-          type: integer
+          schema:
+            type: integer
         - name: locked_nodes
           in: query
-          description: Ids of nodes to keep selected even if they are out of range of current selection
+          description: Ids of nodes to keep selected even if they are out of range of
+            current selection
           required: false
-          type: array
-          items:
-            type: integer
-      responses:
-        '200':
-          description: successful operation
           schema:
             type: array
             items:
-              $ref: '#/definitions/FlowResult'
-        '400':
-          description: bad request
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-  '/contexts/{context_id}/nodes':
-    get:
-      tags:
-        - node
-      summary: 'All nodes for a context'
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - name: context_id
-          in: path
-          description: ''
-          required: true
-          type: integer
+              type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
+          content:
+            application/json:
+              schema:
                 type: array
                 items:
-                  $ref: '#/definitions/Node'
-
-  '/contexts/{context_id}/nodes/attributes':
+                  $ref: "#/components/schemas/FlowResult"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+  "/contexts/{context_id}/nodes":
     get:
       tags:
         - node
-      summary: ''
-      description: 'Aggregated values of inds and quants for all nodes in context'
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: All nodes for a context
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Node"
+  "/contexts/{context_id}/nodes/attributes":
+    get:
+      tags:
+        - node
+      summary: ""
+      description: Aggregated values of inds and quants for all nodes in context
+      parameters:
+        - name: context_id
+          in: path
+          description: ""
+          required: true
+          schema:
+            type: integer
         - name: start_year
           in: query
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: end_year
           in: query
           required: true
-          type: integer
+          schema:
+            type: integer
       responses:
-        '200':
+        "200":
           description: successful operation
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/NodeAttribute'
-        '400':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/NodeAttribute"
+        "400":
           description: bad request
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-
-  '/contexts/{context_id}/nodes/{node_id}/profile_metadata':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+  "/contexts/{context_id}/nodes/{node_id}/profile_metadata":
     get:
       tags:
         - node
-      summary: 'Profile metadata for a node'
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: Profile metadata for a node
       parameters:
         - name: context_id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: node_id
           in: path
           required: true
-          type: integer
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
                 type: object
-                $ref: '#/definitions/ProfileMetadata'
-
-  '/contexts/{context_id}/nodes/{id}/actor':
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ProfileMetadata"
+  "/contexts/{context_id}/nodes/{id}/actor":
     get:
       deprecated: true
       tags:
         - node
-      summary: 'Data for actor profile'
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: Data for actor profile
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
                 type: object
-                $ref: '#/definitions/ActorNode'
-
-  '/contexts/{context_id}/actors/{id}/basic_attributes':
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ActorNode"
+  "/contexts/{context_id}/actors/{id}/basic_attributes":
     get:
       tags:
         - node
         - actor
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/ActorBasicAttributes'
-
-  '/contexts/{context_id}/actors/{id}/top_countries':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ActorBasicAttributes"
+  "/contexts/{context_id}/actors/{id}/top_countries":
     get:
       tags:
         - node
         - actor
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/ActorTopCountries'
-
-  '/contexts/{context_id}/actors/{id}/top_sources':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ActorTopCountries"
+  "/contexts/{context_id}/actors/{id}/top_sources":
     get:
       tags:
         - node
         - actor
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/ActorTopSources'
-
-  '/contexts/{context_id}/actors/{id}/sustainability':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ActorTopSources"
+  "/contexts/{context_id}/actors/{id}/sustainability":
     get:
       tags:
         - node
         - actor
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/ActorSustainability'
-
-  '/contexts/{context_id}/actors/{id}/exporting_companies':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ActorSustainability"
+  "/contexts/{context_id}/actors/{id}/exporting_companies":
     get:
       tags:
         - node
         - actor
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/ActorExportingCompanies'
-
-  '/contexts/{context_id}/nodes/{id}/place':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/ActorExportingCompanies"
+  "/contexts/{context_id}/nodes/{id}/place":
     get:
       deprecated: true
       tags:
         - node
-      summary: 'Data for place profile'
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: Data for place profile
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/PlaceNode'
-
-  '/contexts/{context_id}/places/{id}/basic_attributes':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PlaceNode"
+  "/contexts/{context_id}/places/{id}/basic_attributes":
     get:
       tags:
         - node
         - place
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/PlaceBasicAttributes'
-
-  '/contexts/{context_id}/places/{id}/top_consumer_actors':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PlaceBasicAttributes"
+  "/contexts/{context_id}/places/{id}/top_consumer_actors":
     get:
       tags:
         - node
         - place
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/PlaceTopConsumerActors'
-
-  '/contexts/{context_id}/places/{id}/top_consumer_countries':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PlaceTopConsumerActors"
+  "/contexts/{context_id}/places/{id}/top_consumer_countries":
     get:
       tags:
         - node
         - place
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/PlaceTopConsumerCountries'
-
-  '/contexts/{context_id}/places/{id}/indicators':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PlaceTopConsumerCountries"
+  "/contexts/{context_id}/places/{id}/indicators":
     get:
       tags:
         - node
         - place
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/PlaceIndicators'
-
-  '/contexts/{context_id}/places/{id}/trajectory_deforestation':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PlaceIndicators"
+  "/contexts/{context_id}/places/{id}/trajectory_deforestation":
     get:
       tags:
         - node
         - place
-      consumes:
-        - application/json
-      produces:
-        - application/json
       parameters:
         - name: context_id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                $ref: '#/definitions/PlaceTrajectoryDeforestation'
-
-  '/contexts/{context_id}/nodes/{id}/linked_nodes':
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/PlaceTrajectoryDeforestation"
+  "/contexts/{context_id}/nodes/{id}/linked_nodes":
     get:
       tags:
         - node
-      summary: ''
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: ""
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: year
           in: query
-          type: integer
-          description: 'Defaults to context default year'
+          description: Defaults to context default year
           required: false
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/LinkedNode'
+            type: integer
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LinkedNode"
   /newsletter_subscriptions:
     post:
       tags:
         - newsletter_subscription
       summary: Adds a new email to the subscriptions list
-      consumes:
-        - application/json
-      parameters:
-        - in: body
-          name: email
-          required: true
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
       responses:
-        '200':
+        "200":
           description: successful operation
-
-  '/contexts/{context_id}/download':
+  "/contexts/{context_id}/download":
     get:
       tags:
         - context
-      summary: 'Download selected flow attributes as csv / json'
-      produces:
-        - text/csv
-        - application/json
+      summary: Download selected flow attributes as csv / json
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: years
-          description: 'Years'
+          description: Years
           in: query
-          type: array
-          items:
-            type: integer
-        - name: e_ids
-          description: 'Exporters ids'
-          in: query
-          type: array
-          items:
-            type: integer
-        - name: i_ids
-          description: 'Importers ids'
-          in: query
-          type: array
-          items:
-            type: integer
-        - name: c_ids
-          description: 'Countries ids'
-          in: query
-          type: array
-          items:
-            type: integer
-        - name: filters
-          description: 'Filters, e.g. filters[][name]=FOB&filters[][op]=lt&filters[][val]=2'
-          in: query
-          type: array
-          items:
+          schema:
             type: array
             items:
-              type: string
+              type: integer
+        - name: e_ids
+          description: Exporters ids
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: i_ids
+          description: Importers ids
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: c_ids
+          description: Countries ids
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: filters
+          description: Filters, e.g. filters[][name]=FOB&filters[][op]=lt&filters[][val]=2
+          in: query
+          schema:
+            type: array
+            items:
+              type: array
+              items:
+                type: string
       responses:
-        '200':
+        "200":
           description: successful operation
-  '/contexts/{context_id}/top_nodes':
+  "/contexts/{context_id}/top_nodes":
     get:
       tags:
         - flow
-      summary: 'Top nodes of given node type per context'
-      description: ''
-      consumes:
-        - application/json
-      produces:
-        - application/json
+      summary: Top nodes of given node type per context
+      description: ""
       parameters:
         - name: context_id
           in: path
-          description: ''
+          description: ""
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: column_id
           in: query
           description: Node type id
           required: true
-          type: integer
+          schema:
+            type: integer
         - name: start_year
           in: query
           description: Start year (defaults to context default year)
           required: false
-          type: integer
+          schema:
+            type: integer
         - name: end_year
           in: query
           description: End year (defaults to start year)
           required: false
-          type: integer
+          schema:
+            type: integer
         - name: n_nodes
           in: query
           description: Number of top nodes (defaults to 10)
           required: false
-          type: integer
-      responses:
-        '200':
-          description: successful operation
           schema:
-            type: object
-            properties:
-              data:
-                type: object
-                $ref: '#/definitions/TopNodes'
-  '/dashboards/commodities':
-    get:
-      tags:
-        - dashboards
-      summary: 'Commodities matching selected filters'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsCommodity'
-
-  '/dashboards/commodities/search':
-    get:
-      tags:
-        - dashboards
-      summary: 'Commodities matching selected filters with full text search'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/query"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsCommodity'
-
-  '/dashboards/countries':
-    get:
-      tags:
-        - dashboards
-      summary: 'Countries matching selected filters'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsCountry'
-              meta:
-                type: object
-                properties:
-                  context_node_types:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                        context_id:
-                          type: integer
-                        node_type_id:
-                          type: integer
-                        column_position:
-                          type: integer
-                        country_id:
-                          type: integer
-                        commodity_id:
-                          type: integer
-                        node_type_name:
-                          type: string
-
-  '/dashboards/countries/search':
-    get:
-      tags:
-        - dashboards
-      summary: 'Countries matching selected filters with full text search'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/query"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsCountry'
-
-  '/dashboards/sources':
-    get:
-      tags:
-        - dashboards
-      summary: 'Sources matching selected filters'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_node_type_ids"
-        - $ref: "#/parameters/page"
-        - $ref: "#/parameters/per_page"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsSource'
-
-  '/dashboards/sources/search':
-    get:
-      tags:
-        - dashboards
-      summary: 'Sources matching selected filters with full text search'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/query"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_node_type_ids"
-        - $ref: "#/parameters/page"
-        - $ref: "#/parameters/per_page"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsSearchNode'
-
-  '/dashboards/companies':
-    get:
-      tags:
-        - dashboards
-      summary: 'Companies matching selected filters'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_node_type_ids"
-        - $ref: "#/parameters/page"
-        - $ref: "#/parameters/per_page"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsCompany'
-
-  '/dashboards/companies/search':
-    get:
-      tags:
-        - dashboards
-      summary: 'Companies matching selected filters with full text search'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/query"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_node_type_ids"
-        - $ref: "#/parameters/page"
-        - $ref: "#/parameters/per_page"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsSearchNode'
-
-  '/dashboards/destinations':
-    get:
-      tags:
-        - dashboards
-      summary: 'Destinations matching selected filters'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_node_type_ids"
-        - $ref: "#/parameters/page"
-        - $ref: "#/parameters/per_page"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsDestination'
-
-  '/dashboards/destinations/search':
-    get:
-      tags:
-        - dashboards
-      summary: 'Destinations matching selected filters with full text search'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/query"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_node_type_ids"
-        - $ref: "#/parameters/page"
-        - $ref: "#/parameters/per_page"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsSearchNode'
-
-  '/dashboards/attributes':
-    get:
-      tags:
-        - dashboards
-      summary: 'Attributes matching selected filters'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/DashboardsAttribute'
-              meta:
-                type: object
-                properties:
-                  groups:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                        name:
-                          type: string
-
-  '/dashboards/chart_data':
-    get:
-      tags:
-        - dashboards
-      summary: 'Data formatted for display in charts'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_countries_ids"
-        - $ref: "#/parameters/dashboards_commodities_ids"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_attribute_id"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    x:
-                      description: "Type defined in meta"
-                    y1:
-                      description: "Type defined in meta"
-              meta:
-                type: object
-                properties:
-                  xAxis:
-                    $ref: "#/definitions/DashboardsChartAxis"
-                  yAxis:
-                    $ref: "#/definitions/DashboardsChartAxis"
-                  x:
-                    $ref: "#/definitions/DashboardsChartValue"
-                  y1:
-                    $ref: "#/definitions/DashboardsChartValue"
-
-  '/dashboards/parametrised_charts':
-    get:
-      tags:
-        - dashboards
-      summary: 'Dynamic chart types matching selected filters'
-      consumes:
-        - application/json
-      produces:
-        - application/json
-      parameters:
-        - $ref: "#/parameters/dashboards_country_id"
-        - $ref: "#/parameters/dashboards_commodity_id"
-        - $ref: "#/parameters/dashboards_cont_attribute_id"
-        - $ref: "#/parameters/dashboards_ncont_attribute_id"
-        - $ref: "#/parameters/dashboards_sources_ids"
-        - $ref: "#/parameters/dashboards_companies_ids"
-        - $ref: "#/parameters/dashboards_destinations_ids"
-        - $ref: "#/parameters/dashboards_start_year"
-        - $ref: "#/parameters/dashboards_end_year"
-      responses:
-        '200':
-          description: successful operation
-          schema:
-            type: object
-            properties:
-              data:
-                type: array
-                items:
-                  $ref: '#/definitions/ParametrisedChart'
-
-parameters:
-  dashboards_country_id:
-    name: country_id
-    in: query
-    type: integer
-    required: true
-  dashboards_countries_ids:
-    name: countries_ids
-    in: query
-    description: 'String with comma-separated numeric ids'
-    required: false
-    type: string
-  dashboards_commodity_id:
-    name: commodity_id
-    in: query
-    type: integer
-    required: true
-  dashboards_commodities_ids:
-    name: commodities_ids
-    in: query
-    description: 'String with comma-separated numeric ids'
-    required: false
-    type: string 
-  dashboards_sources_ids:
-    name: sources_ids
-    in: query
-    description: 'String with comma-separated numeric ids'
-    required: false
-    type: string
-  dashboards_companies_ids:
-    name: companies_ids
-    in: query
-    description: 'String with comma-separated numeric ids'
-    required: false
-    type: string
-  dashboards_destinations_ids:
-    name: destinations_ids
-    in: query
-    description: 'String with comma-separated numeric ids'
-    required: false
-    type: string
-  dashboards_node_type_ids:
-    name: node_types_ids
-    in: query
-    description: 'String with comma-separated numeric ids'
-    required: false
-    type: string
-  dashboards_attribute_id:
-    name: attribute_id
-    in: query
-    description: 'Attribute id'
-    required: false
-    type: integer
-  dashboards_cont_attribute_id:
-    name: cont_attribute_id
-    in: query
-    description: 'Continuous attribute id'
-    required: true
-    type: integer
-  dashboards_ncont_attribute_id:
-    name: ncont_attribute_id
-    in: query
-    description: 'Non-continuous attribute id'
-    required: false
-    type: integer
-  dashboards_start_year:
-    name: start_year
-    in: query
-    description: 'Start year'
-    required: true
-    type: integer
-  dashboards_end_year:
-    name: end_year
-    in: query
-    description: 'End year (not required for single year selection)'
-    required: false
-    type: integer
-  page:
-    name: page
-    in: query
-    description: 'Number of page for paginated responses'
-    required: false
-    type: integer
-  per_page:
-    name: per_page
-    in: query
-    description: 'Number of iterms per page'
-    required: false
-    type: integer
-  query:
-    name: q
-    in: query
-    description: 'String with comma-separated numeric ids'
-    required: true
-    type: string
-
-definitions:
-  DashboardsChartAxis:
-    type: object
-    properties:
-      label:
-        type: string
-      prefix:
-        type: string
-      format:
-        type: string
-      suffix:
-        type: string
-  DashboardsChartValue:
-    type: object
-    properties:
-      type:
-        type: string
-        example: "numeric,date,categoric"
-      label:
-        type: string
-      tooltip:
-        type: object
-        properties:
-          prefix:
-            type: string
-            description: "not used"
-          format:
-            type: string
-            description: "not used"
-          suffix:
-            type: string
-  DashboardsCommodity:
-    type: object
-    properties:
-      id:
-        type: integer
-      name:
-        type: string
-  DashboardsCountry:
-    type: object
-    properties:
-      id:
-        type: integer
-      name:
-        type: string
-  DashboardsSource:
-    type: object
-    properties:
-      id:
-        type: integer
-      name:
-        type: string
-      nodeType:
-        type: string
-  DashboardsCompany:
-    type: object
-    properties:
-      id:
-        type: integer
-      name:
-        type: string
-      nodeType:
-        type: string
-      countryId:
-        type: integer
-  DashboardsDestination:
-    type: object
-    properties:
-      id:
-        type: integer
-      name:
-        type: string
-      nodeType:
-        type: string
-  DashboardsSearchNode:
-    type: object
-    properties:
-      id:
-        type: integer
-      name:
-        type: string
-      nodeTypeId:
-        type: integer
-      nodeType:
-        type: string
-      countryId:
-        type: integer
-  DashboardsAttribute:
-    type: object
-    properties:
-      id:
-        type: integer
-      displayName:
-        type: string
-      tooltipText:
-        type: string
-      groupId:
-        type: integer
-      chartType:
-        type: string
-        example: 'line, pie, bar, stacked_bar'
-      isDisabled:
-        type: boolean
-      url:
-        type: string
-  Context:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-      isDefault:
-        type: boolean
-      isDisabled:
-        type: boolean
-      years:
-        type: array
-        items:
-          type: integer
-      defaultYear:
-        type: integer
-      countryId:
-        type: integer
-      commodityId:
-        type: integer
-      countryName:
-        type: string
-      commodityName:
-        type: string
-      defaultBasemap:
-        type: string
-      defaultContextLayers:
-        type: array
-        items:
-          type: string
-      map:
-        type: object
-        properties:
-          latitude:
-            type: number
-          longitude:
-            type: number
-          zoom:
             type: integer
-      worldMap:
-        type: object
-        properties:
-          mapColumnId:
-            type: integer
-            description: 'Id of column to use as parameter to top nodes for top destination countries (world map)'
-          listColumnId:
-            type: integer
-            description: 'Id of column to use as parameter to top nodes for top exporters (world map - list)'
-      recolorBy:
-        type: array
-        items:
-          $ref: '#/definitions/RecolorBy'
-      resizeBy:
-        type: array
-        items:
-          $ref: '#/definitions/ResizeBy'
-      filterBy:
-        type: array
-        items:
-          $ref: '#/definitions/FilterBy'
-  RecolorBy:
-    type: object
-    properties:
-      isDefault:
-        type: boolean
-      isDisabled:
-        type: boolean
-      groupNumber:
-        type: integer
-      position:
-        type: integer
-      legendType:
-        type: string
-      legendColorTheme:
-        type: string
-      intervalCount":
-        type: integer
-      minValue:
-        type: string
-      maxValue:
-        type: string
-      divisor:
-        type: number
-      type:
-        type: string
-        enum:
-          - ind
-          - qual
-          - quant
-      name:
-        type: string
-      years:
-        type: array
-        items:
-          type: integer
-      label:
-        type: string
-      description:
-        type: string
-      nodes:
-        type: array
-        items:
-          type: string
-  ResizeBy:
-    type: object
-    properties:
-      isDefault:
-        type: boolean
-      isDisabled:
-        type: boolean
-      groupNumber:
-        type: integer
-      position:
-        type: integer
-      name:
-        type: string
-      years:
-        type: array
-        items:
-          type: integer
-      label:
-        type: string
-      description:
-        type: string
-  DownloadAttribute:
-    type: object
-    properties:
-      name:
-        type: string
-      unit:
-        type: string
-      unitType:
-        type: string
-      frontendName:
-        type: string
-      indicatorType:
-        type: string
-        enum:
-          - Ind
-          - Qual
-          - Quant
-      years:
-        type: array
-        items:
-          type: integer
-        description: null when all years
-      filterOptions:
-        type: object
-        properties:
-          ops:
-            type: array
-            items:
-              type: string
-              enum:
-                - eq
-                - gt
-                - lt
-            description: Operators available for advanced filter
-          values:
-            type: array
-            items:
-              type: string
-            description: For quals, enumeration of possible values
-  FilterBy:
-    type: object
-    properties:
-      name:
-        type: string
-      nodes:
-        type: array
-        items:
-          type: object
-          properties:
-            nodeId:
-              type: integer
-            name:
-              type: string
-  FlowResult:
-    type: object
-    properties:
-      data:
-        type: array
-        items:
-          type: object
-          properties:
-            path:
-              type: array
-              description: Array of node ids
-              items:
-                type: integer
-            quant:
-              type: number
-            ind:
-              type: number
-            qual:
-              type: string
-            height:
-              type: number
-      include:
-        type: object
-        properties:
-          nodeHeights:
-            type: array
-            items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                height:
-                  type: number
-                quant:
-                  type: number
-          quant:
-            type: object
-            properties:
-              id:
-                type: integer
-              name:
-                type: string
-              unit:
-                type: string
-          ind:
-            type: object
-            properties:
-              id:
-                type: integer
-              name:
-                type: string
-              unit:
-                type: string
-          qual:
-            type: object
-            properties:
-              id:
-                type: integer
-              name:
-                type: string
-  Node:
-    type: object
-    properties:
-      id:
-        type: integer
-      mainNodeId:
-        type: integer
-      name:
-        type: string
-      type:
-        type: string
-        description: 'e.g. BIOME'
-      columnId:
-        type: integer
-        description: 'node type id'
-      geoId:
-        type: string
-        description: 'e.g. BR for Brazil (country), BR1 for Amazonia (biome), BR5107925 for Sorriso (municipality), can be null'
-      isDomesticConsumption:
-        type: boolean
-      isUnknown:
-        type: boolean
-      profileType:
-        type: string
-        description: 'actor or place'
-      isAggregated:
-        type: boolean
-        description: "true for OTHER nodes"
-  LinkedNode:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-  NodeAttribute:
-    type: object
-    properties:
-      node_id:
-        type: integer
-        format: int64
-      attribute_id:
-        type: integer
-        format: int64
-      attribute_type:
-        type: string
-        enum:
-          - ind
-          - qual
-          - quant
-      value:
-        type: number
-      dual_layer_bucket:
-        type: integer
-      single_layer_bucket:
-        type: integer
-  Column:
-    type: object
-    properties:
-      data:
-        type: array
-        items:
-          type: object
-          properties:
-            id:
-              type: integer
-            name:
-              type: string
-            position:
-              type: string
-            group:
-              type: string
-            isDefault:
-              type: boolean
-            isGeo:
-              type: boolean
-            isChoroplethDisabled:
-              type: boolean
-            profileType:
-              type: string
-  MapGroup:
-    type: object
-    properties:
-      dimensionGroups:
-        type: array
-        items:
-          type: object
-          properties:
-            id:
-              type: integer
-              format: int64
-            name:
-              type: string
-      dimensions:
-        type: array
-        items:
-          $ref: '#/definitions/Dimension'
-      contextualLayers:
-        type: array
-        items:
-          type: object
-          properties:
-            id:
-              type: integer
-            title:
-              type: string
-            identifier:
-              type: string
-              example: 'landcover'
-            tooltipText:
-              type: string
-            isDefault:
-              type: boolean
-            legend:
-             type: string
-            cartoLayers:
-              type: array
-              items:
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
                 type: object
                 properties:
-                  identifier:
-                    type: string
-                    example: 'landcover2015'
-                  years:
+                  data:
+                    $ref: "#/components/schemas/TopNodes"
+  /dashboards/commodities:
+    get:
+      tags:
+        - dashboards
+      summary: Commodities matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
                     type: array
                     items:
-                      type: integer
-                  rasterUrl:
-                    type: string
-  Attribute:
-    type: object
-    properties:
-      id:
-        type: integer
-        format: int64
-      name:
-        type: string
-      type:
-        type: string
-  NewsletterSubscription:
-    type: object
-    properties:
-      email:
-        type: string
-  Dimension:
-    type: object
-    properties:
-      aggregateMethod:
-        type: string
-      dual_layer_buckets:
-        type: array
-        items:
-          type: number
-          format: float
-      single_layer_buckets:
-        type: array
-        items:
-          type: number
-          format: float
-      colorScale:
-        type: string
-      description:
-        type: string
-      id:
-        type: integer
-        format: int64
-      is_default:
-        type: boolean
-      layerAttributeId:
-        type: integer
-        format: int64
-      name:
-        type: string
-      unit:
-        type: string
-      years:
-        type: array
-        items:
-          type: integer
-
-  PlaceNode:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          column_name:
-            type: string
-            description: 'e.g. MUNICIPALITY'
-          country_name:
-            type: string
-          country_geo_id:
-            type: string
-            description: 'e.g. BR'
-          summary:
-            type: string
-          municipality_name:
-            type: string
-          municipality_geo_id:
-            type: string
-          state_name:
-            type: string
-          state_geo_id:
-            type: string
-          biome_name:
-            type: string
-          biome_geo_id:
-            type: string
-          area:
-            type: number
-          soy_production:
-            type: number
-          soy_area:
-            type: string
-          soy_farmland:
-            type: number
-          top_consumer_actors:
-            type: object
-            properties:
-              name:
-                type: string
-              indicators:
-                type: string
-              unit:
-                type: string
-              targetNodes:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: integer
-                    name:
-                      type: string
-                    height:
-                      type: number
-                    value:
-                      type: number
-                    is_domestic_consumption:
-                      type: boolean
-          top_consumer_countries:
-            type: object
-            properties:
-              name:
-                type: string
-              indicators:
-                type: string
-              unit:
-                type: string
-              targetNodes:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: integer
-                    name:
-                      type: string
-                    height:
-                      type: number
-                    value:
-                      type: number
-                    is_domestic_consumption:
-                      type: boolean
-          indicators:
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                included_columns:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      unit:
-                        type: string
-                      tooltip:
-                        type: string
-                rows:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      have_unit:
-                        type: boolean
-                      values:
-                        type: array
-                        items:
-                          type: number
-          trajectory_deforestation:
-            type: object
-            properties:
-              included_years:
-                type: array
-                items:
-                  type: integer
-              unit:
-                type: string
-              lines:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    legend_name:
-                      type: string
-                    legend_tooltip:
-                      type: string
-                    type:
-                      type: string
-                    style:
-                      type: string
-                    values:
-                      type: array
-                      items:
-                        type: number
-
-  PlaceBasicAttributes:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          column_name:
-            type: string
-            description: 'e.g. MUNICIPALITY'
-          country_name:
-            type: string
-          country_geo_id:
-            type: string
-            description: 'e.g. BR'
-          summary:
-            type: string
-          municipality_name:
-            type: string
-          municipality_geo_id:
-            type: string
-          state_name:
-            type: string
-          state_geo_id:
-            type: string
-          biome_name:
-            type: string
-          biome_geo_id:
-            type: string
-          area:
-            type: number
-          soy_production:
-            type: number
-          soy_area:
-            type: string
-          soy_farmland:
-            type: number
-
-  PlaceTopConsumerActors:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          name:
-            type: string
-          indicators:
-            type: string
-          unit:
-            type: string
-          targetNodes:
-            type: array
-            items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                name:
-                  type: string
-                height:
-                  type: number
-                value:
-                  type: number
-                is_domestic_consumption:
-                  type: boolean
-
-  PlaceTopConsumerCountries:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          name:
-            type: string
-          indicators:
-            type: string
-          unit:
-            type: string
-          targetNodes:
-            type: array
-            items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                name:
-                  type: string
-                height:
-                  type: number
-                value:
-                  type: number
-                is_domestic_consumption:
-                  type: boolean
-
-  PlaceIndicators:
-    type: object
-    properties:
-      data:
-        type: array
-        items:
-          type: object
-          properties:
-            name:
-              type: string
-            included_columns:
-              type: array
-              items:
+                      $ref: "#/components/schemas/DashboardsCommodity"
+  /dashboards/commodities/search:
+    get:
+      tags:
+        - dashboards
+      summary: Commodities matching selected filters with full text search
+      parameters:
+        - $ref: "#/components/parameters/query"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
                 type: object
                 properties:
-                  name:
-                    type: string
-                  unit:
-                    type: string
-                  tooltip:
-                    type: string
-            rows:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  have_unit:
-                    type: boolean
-                  values:
+                  data:
                     type: array
                     items:
-                      type: number
-
-  PlaceTrajectoryDeforestation:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          included_years:
-            type: array
-            items:
-              type: integer
-          unit:
-            type: string
-          lines:
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                legend_name:
-                  type: string
-                legend_tooltip:
-                  type: string
-                type:
-                  type: string
-                style:
-                  type: string
-                values:
-                  type: array
-                  items:
-                    type: number
-
-  ActorNode:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          node_name:
-            type: string
-          column_name:
-            type: string
-          country_name:
-            type: string
-          country_geo_id:
-            type: string
-          zero_deforestation_link:
-            type: string
-          supply_change_link:
-            type: string
-          rtrs_member:
-            type: string
-          zero_deforestation:
-            type: string
-          supply_change:
-            type: string
-          soy_:
-            type: number
-          forest_500:
-            type: number
-          summary:
-            type: string
-          top_countries:
-            type: object
-            properties:
-              included_years:
-                type: array
-                items:
-                  type: integer
-              buckets:
-                type: array
-                items:
-                  type: integer
-              lines:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    geo_id:
-                      type: string
-                    values:
-                      type: array
-                      items:
-                        type: number
-                    value9:
-                      type: number
-              unit:
-                type: string
-              style:
+                      $ref: "#/components/schemas/DashboardsCommodity"
+  /dashboards/countries:
+    get:
+      tags:
+        - dashboards
+      summary: Countries matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
                 type: object
                 properties:
-                  type:
-                    type: string
-                  style:
-                    type: string
-          top_sources:
-            type: object
-            properties:
-              included_years:
-                type: array
-                items:
-                  type: integer
-              buckets:
-                type: array
-                items:
-                  type: integer
-              municipality:
-                type: object
-                properties:
-                  lines:
+                  data:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                        geo_id:
-                          type: string
-                        values:
-                          type: array
-                          items:
-                            type: number
-                        value9:
-                          type: number
-                  unit:
-                    type: string
-                  style:
+                      $ref: "#/components/schemas/DashboardsCountry"
+                  meta:
                     type: object
                     properties:
-                      type:
-                        type: string
-                      style:
-                        type: string
-              biome:
-                type: object
-                properties:
-                  lines:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                        geo_id:
-                          type: string
-                        values:
-                          type: array
-                          items:
-                            type: number
-                        value9:
-                          type: number
-                  unit:
-                    type: string
-                  style:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                      style:
-                        type: string
-              state:
-                type: object
-                properties:
-                  lines:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                        geo_id:
-                          type: string
-                        values:
-                          type: array
-                          items:
-                            type: number
-                        value9:
-                          type: number
-                  unit:
-                    type: string
-                  style:
-                    type: object
-                    properties:
-                      type:
-                        type: string
-                      style:
-                        type: string
-          sustainability:
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                included_columns:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      name:
-                        type: string
-                      unit:
-                        type: string
-                      tooltip:
-                        type: string
-                rows:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      values:
+                      context_node_types:
                         type: array
                         items:
                           type: object
                           properties:
                             id:
                               type: integer
-                            value:
+                            context_id:
+                              type: integer
+                            node_type_id:
+                              type: integer
+                            column_position:
+                              type: integer
+                            country_id:
+                              type: integer
+                            commodity_id:
+                              type: integer
+                            node_type_name:
                               type: string
-          companies_sourcing:
+  /dashboards/countries/search:
+    get:
+      tags:
+        - dashboards
+      summary: Countries matching selected filters with full text search
+      parameters:
+        - $ref: "#/components/parameters/query"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsCountry"
+  /dashboards/sources:
+    get:
+      tags:
+        - dashboards
+      summary: Sources matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsSource"
+  /dashboards/sources/search:
+    get:
+      tags:
+        - dashboards
+      summary: Sources matching selected filters with full text search
+      parameters:
+        - $ref: "#/components/parameters/query"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsSearchNode"
+  /dashboards/companies:
+    get:
+      tags:
+        - dashboards
+      summary: Companies matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsCompany"
+  /dashboards/companies/search:
+    get:
+      tags:
+        - dashboards
+      summary: Companies matching selected filters with full text search
+      parameters:
+        - $ref: "#/components/parameters/query"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsSearchNode"
+  /dashboards/destinations:
+    get:
+      tags:
+        - dashboards
+      summary: Destinations matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsDestination"
+  /dashboards/destinations/search:
+    get:
+      tags:
+        - dashboards
+      summary: Destinations matching selected filters with full text search
+      parameters:
+        - $ref: "#/components/parameters/query"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsSearchNode"
+  /dashboards/attributes:
+    get:
+      tags:
+        - dashboards
+      summary: Attributes matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsAttribute"
+                  meta:
+                    type: object
+                    properties:
+                      groups:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                            name:
+                              type: string
+  /dashboards/chart_data:
+    get:
+      tags:
+        - dashboards
+      summary: Data formatted for display in charts
+      parameters:
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_attribute_id"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        x:
+                          description: Type defined in meta
+                        y1:
+                          description: Type defined in meta
+                  meta:
+                    type: object
+                    properties:
+                      xAxis:
+                        $ref: "#/components/schemas/DashboardsChartAxis"
+                      yAxis:
+                        $ref: "#/components/schemas/DashboardsChartAxis"
+                      x:
+                        $ref: "#/components/schemas/DashboardsChartValue"
+                      y1:
+                        $ref: "#/components/schemas/DashboardsChartValue"
+  /dashboards/parametrised_charts:
+    get:
+      tags:
+        - dashboards
+      summary: Dynamic chart types matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_country_id"
+        - $ref: "#/components/parameters/dashboards_commodity_id"
+        - $ref: "#/components/parameters/dashboards_cont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_ncont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_start_year"
+        - $ref: "#/components/parameters/dashboards_end_year"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ParametrisedChart"
+  /dashboards/charts/single_year_no_ncont_overview:
+    get:
+      tags:
+        - dashboards
+        - charts
+      summary: Data formatted for display in the overview chart for single year, no
+        non-continuous attribute selection (dynamic sentence)
+      parameters:
+        - $ref: "#/components/parameters/dashboards_country_id"
+        - $ref: "#/components/parameters/dashboards_commodity_id"
+        - $ref: "#/components/parameters/dashboards_cont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_start_year"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        y0:
+                          type: number
+                          example: 97464935.9917641
+                  meta:
+                    type: object
+                    properties:
+                      xAxis:
+                        $ref: "#/components/schemas/DashboardsEmptyXAxis"
+                      yAxis:
+                        $ref: "#/components/schemas/DashboardsYAxis"
+                      x:
+                        $ref: "#/components/schemas/DashboardsEmptyXLegend"
+                      y0:
+                        $ref: "#/components/schemas/DashboardsYLegend"
+  /dashboards/charts/single_year_ncont_overview:
+    get:
+      tags:
+        - dashboards
+        - charts
+      summary: Data formatted for display in the overview chart for single year,
+        non-continuous attribute selection (donut chart per value of non-continuous indicator)
+      parameters:
+        - $ref: "#/components/parameters/dashboards_country_id"
+        - $ref: "#/components/parameters/dashboards_commodity_id"
+        - $ref: "#/components/parameters/dashboards_cont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_mandatory_ncont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_start_year"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        x:
+                          example: 1
+                          description: Type defined in meta
+                        y0:
+                          example: 6913271.774814
+                          description: Type defined in meta
+                  meta:
+                    type: object
+                    properties:
+                      xAxis:
+                        $ref: "#/components/schemas/DashboardsNcontXAxis"
+                      yAxis:
+                        $ref: "#/components/schemas/DashboardsYAxis"
+                      x:
+                        $ref: "#/components/schemas/DashboardsNcontXLegend"
+                      y0:
+                        $ref: "#/components/schemas/DashboardsYLegend"
+  /dashboards/charts/multi_year_no_ncont_overview:
+    get:
+      tags:
+        - dashboards
+        - charts
+      summary: Data formatted for display in the overview chart for multi year, no
+        non-continuous attribute selection (bar chart per year)
+      parameters:
+        - $ref: "#/components/parameters/dashboards_country_id"
+        - $ref: "#/components/parameters/dashboards_commodity_id"
+        - $ref: "#/components/parameters/dashboards_cont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_start_year"
+        - $ref: "#/components/parameters/dashboards_mandatory_end_year"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        x:
+                          example: 2014
+                          description: Type defined in meta
+                        y0:
+                          example: 86760519.9871819
+                          description: Type defined in meta
+                  meta:
+                    type: object
+                    properties:
+                      xAxis:
+                        $ref: "#/components/schemas/DashboardsYearXAxis"
+                      yAxis:
+                        $ref: "#/components/schemas/DashboardsYAxis"
+                      x:
+                        $ref: "#/components/schemas/DashboardsYearXLegend"
+                      y0:
+                        $ref: "#/components/schemas/DashboardsYLegend"
+  /dashboards/charts/multi_year_ncont_overview:
+    get:
+      tags:
+        - dashboards
+        - charts
+      summary: Data formatted for display in the overview chart for multi year,
+        non-continuous attribute selection (stacked bar chart per year per value of non-continuous indicator
+      parameters:
+        - $ref: "#/components/parameters/dashboards_country_id"
+        - $ref: "#/components/parameters/dashboards_commodity_id"
+        - $ref: "#/components/parameters/dashboards_cont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_mandatory_ncont_attribute_id"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/dashboards_start_year"
+        - $ref: "#/components/parameters/dashboards_mandatory_end_year"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        x:
+                          example: 2015
+                          description: Type defined in meta
+                        y0:
+                          example: 6913271.774814
+                          description: Type defined in meta
+                        y1:
+                          example: 7170873.080941
+                        y2:
+                          example: 10910119.85475
+                        y3:
+                          example: 20003570.43905
+                  meta:
+                    type: object
+                    properties:
+                      xAxis:
+                        $ref: "#/components/schemas/DashboardsNcontXAxis"
+                      yAxis:
+                        $ref: "#/components/schemas/DashboardsYAxis"
+                      x:
+                        $ref: "#/components/schemas/DashboardsNcontXLegend"
+                      y0:
+                        $ref: "#/components/schemas/DashboardsNcontYLegend"
+                      y1:
+                        allOf:
+                          - $ref: "#/components/schemas/DashboardsNcontYLegend"
+                          - type: object
+                            properties:
+                              label:
+                                type: string
+                                example: '2.0'
+                      y2:
+                        allOf:
+                          - $ref: "#/components/schemas/DashboardsNcontYLegend"
+                          - type: object
+                            properties:
+                              label:
+                                type: string
+                                example: '3.0'
+                      y3:
+                        allOf:
+                          - $ref: "#/components/schemas/DashboardsNcontYLegend"
+                          - type: object
+                            properties:
+                              label:
+                                type: string
+                                example: '4.0'
+                      y4:
+                        allOf:
+                          - $ref: "#/components/schemas/DashboardsNcontYLegend"
+                          - type: object
+                            properties:
+                              label:
+                                type: string
+                                example: '5.0'
+servers:
+  - url: https://trase.earth/api/v3
+components:
+  parameters:
+    dashboards_country_id:
+      name: country_id
+      in: query
+      required: true
+      schema:
+        type: integer
+    dashboards_countries_ids:
+      name: countries_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_commodity_id:
+      name: commodity_id
+      in: query
+      required: true
+      schema:
+        type: integer
+    dashboards_commodities_ids:
+      name: commodities_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_sources_ids:
+      name: sources_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_companies_ids:
+      name: companies_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_destinations_ids:
+      name: destinations_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_node_type_ids:
+      name: node_types_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_attribute_id:
+      name: attribute_id
+      in: query
+      description: Attribute id
+      required: false
+      schema:
+        type: integer
+    dashboards_cont_attribute_id:
+      name: cont_attribute_id
+      in: query
+      description: Continuous attribute id
+      required: true
+      schema:
+        type: integer
+    dashboards_ncont_attribute_id:
+      name: ncont_attribute_id
+      in: query
+      description: Non-continuous attribute id
+      required: false
+      schema:
+        type: integer
+    dashboards_mandatory_ncont_attribute_id:
+      name: ncont_attribute_id
+      in: query
+      description: Non-continuous attribute id
+      required: true
+      schema:
+        type: integer
+    dashboards_start_year:
+      name: start_year
+      in: query
+      description: Start year
+      required: true
+      schema:
+        type: integer
+    dashboards_end_year:
+      name: end_year
+      in: query
+      description: End year (not required for single year selection)
+      required: false
+      schema:
+        type: integer
+    dashboards_mandatory_end_year:
+      name: end_year
+      in: query
+      description: End year (not required for single year selection)
+      required: true
+      schema:
+        type: integer
+    page:
+      name: page
+      in: query
+      description: Number of page for paginated responses
+      required: false
+      schema:
+        type: integer
+    per_page:
+      name: per_page
+      in: query
+      description: Number of iterms per page
+      required: false
+      schema:
+        type: integer
+    query:
+      name: q
+      in: query
+      description: String with comma-separated numeric ids
+      required: true
+      schema:
+        type: string
+  schemas:
+    DashboardsEmptyXAxis:
+      type: object
+    DashboardsNcontXAxis:
+      type: object
+      properties:
+        label:
+          type: string
+          example: Forest 500 score
+        prefix:
+          type: string
+          example: ""
+          description: not used
+        format:
+          type: string
+          example: ""
+          description: not used
+        suffix:
+          type: string
+          example: /5
+    DashboardsYearXAxis:
+      type: object
+      properties:
+        label:
+          type: string
+          example: Year
+        prefix:
+          type: string
+          example: ""
+          description: not used
+        format:
+          type: string
+          example: ""
+          description: not used
+        suffix:
+          type: string
+          example: ""
+          description: not used
+    DashboardsYAxis:
+      type: object
+      properties:
+        label:
+          type: string
+          example: Trade Volume
+        prefix:
+          type: string
+          example: ""
+          description: not used
+        format:
+          type: string
+          example: ""
+          description: not used
+        suffix:
+          type: string
+          example: t
+    DashboardsChartAxis:
+      type: object
+      properties:
+        label:
+          type: string
+        prefix:
+          type: string
+        format:
+          type: string
+        suffix:
+          type: string
+    DashboardsEmptyXLegend:
+      type: object
+    DashboardsNcontXLegend:
+      type: object
+      properties:
+        type:
+          type: string
+          example: category
+        label:
+          type: string
+          example: Forest 500 score
+        tooltip:
+          type: object
+          properties:
+            prefix:
+              type: string
+              example: ""
+              description: not used
+            format:
+              type: string
+              example: ""
+              description: not used
+            suffix:
+              example: /5
+              type: string
+    DashboardsYearXLegend:
+      type: object
+      properties:
+        type:
+          type: string
+          example: category
+        label:
+          type: string
+          example: Year
+        tooltip:
+          type: object
+          properties:
+            prefix:
+              type: string
+              example: ""
+              description: not used
+            format:
+              type: string
+              example: ""
+              description: not used
+            suffix:
+              example: ""
+              type: string
+              description: not used
+    DashboardsYLegend:
+      type: object
+      properties:
+        type:
+          type: string
+          example: numeric
+        label:
+          type: string
+          example: Trade Volume
+        tooltip:
+          type: object
+          properties:
+            prefix:
+              type: string
+              example: ""
+              description: not used
+            format:
+              type: string
+              example: ""
+              description: not used
+            suffix:
+              example: t
+              type: string
+    DashboardsNcontYLegend:
+      type: object
+      properties:
+        type:
+          type: string
+          example: category
+        label:
+          type: string
+          example: "1.0"
+        tooltip:
+          type: object
+          properties:
+            prefix:
+              type: string
+              example: ""
+              description: not used
+            format:
+              type: string
+              example: ""
+              description: not used
+            suffix:
+              type: string
+              example: ""
+              description: not used
+    DashboardsChartValue:
+      type: object
+      properties:
+        type:
+          type: string
+          example: numeric,date,categoric
+        label:
+          type: string
+        tooltip:
+          type: object
+          properties:
+            prefix:
+              type: string
+              description: not used
+            format:
+              type: string
+              description: not used
+            suffix:
+              type: string
+    DashboardsCommodity:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    DashboardsCountry:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+    DashboardsSource:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        nodeType:
+          type: string
+    DashboardsCompany:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        nodeType:
+          type: string
+        countryId:
+          type: integer
+    DashboardsDestination:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        nodeType:
+          type: string
+    DashboardsSearchNode:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        nodeTypeId:
+          type: integer
+        nodeType:
+          type: string
+        countryId:
+          type: integer
+    DashboardsAttribute:
+      type: object
+      properties:
+        id:
+          type: integer
+        displayName:
+          type: string
+        tooltipText:
+          type: string
+        groupId:
+          type: integer
+        chartType:
+          type: string
+          example: line, pie, bar, stacked_bar
+        isDisabled:
+          type: boolean
+        url:
+          type: string
+    Context:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        isDefault:
+          type: boolean
+        isDisabled:
+          type: boolean
+        years:
+          type: array
+          items:
+            type: integer
+        defaultYear:
+          type: integer
+        countryId:
+          type: integer
+        commodityId:
+          type: integer
+        countryName:
+          type: string
+        commodityName:
+          type: string
+        defaultBasemap:
+          type: string
+        defaultContextLayers:
+          type: array
+          items:
+            type: string
+        map:
+          type: object
+          properties:
+            latitude:
+              type: number
+            longitude:
+              type: number
+            zoom:
+              type: integer
+        worldMap:
+          type: object
+          properties:
+            mapColumnId:
+              type: integer
+              description: Id of column to use as parameter to top nodes for top
+                destination countries (world map)
+            listColumnId:
+              type: integer
+              description: Id of column to use as parameter to top nodes for top exporters
+                (world map - list)
+        recolorBy:
+          type: array
+          items:
+            $ref: "#/components/schemas/RecolorBy"
+        resizeBy:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResizeBy"
+        filterBy:
+          type: array
+          items:
+            $ref: "#/components/schemas/FilterBy"
+    RecolorBy:
+      type: object
+      properties:
+        isDefault:
+          type: boolean
+        isDisabled:
+          type: boolean
+        groupNumber:
+          type: integer
+        position:
+          type: integer
+        legendType:
+          type: string
+        legendColorTheme:
+          type: string
+        intervalCount":
+          type: integer
+        minValue:
+          type: string
+        maxValue:
+          type: string
+        divisor:
+          type: number
+        type:
+          type: string
+          enum:
+            - ind
+            - qual
+            - quant
+        name:
+          type: string
+        years:
+          type: array
+          items:
+            type: integer
+        label:
+          type: string
+        description:
+          type: string
+        nodes:
+          type: array
+          items:
+            type: string
+    ResizeBy:
+      type: object
+      properties:
+        isDefault:
+          type: boolean
+        isDisabled:
+          type: boolean
+        groupNumber:
+          type: integer
+        position:
+          type: integer
+        name:
+          type: string
+        years:
+          type: array
+          items:
+            type: integer
+        label:
+          type: string
+        description:
+          type: string
+    DownloadAttribute:
+      type: object
+      properties:
+        name:
+          type: string
+        unit:
+          type: string
+        unitType:
+          type: string
+        frontendName:
+          type: string
+        indicatorType:
+          type: string
+          enum:
+            - Ind
+            - Qual
+            - Quant
+        years:
+          type: array
+          items:
+            type: integer
+          description: null when all years
+        filterOptions:
+          type: object
+          properties:
+            ops:
+              type: array
+              items:
+                type: string
+                enum:
+                  - eq
+                  - gt
+                  - lt
+              description: Operators available for advanced filter
+            values:
+              type: array
+              items:
+                type: string
+              description: For quals, enumeration of possible values
+    FilterBy:
+      type: object
+      properties:
+        name:
+          type: string
+        nodes:
+          type: array
+          items:
             type: object
             properties:
-              dimension_y:
+              nodeId:
+                type: integer
+              name:
+                type: string
+    FlowResult:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              path:
+                type: array
+                description: Array of node ids
+                items:
+                  type: integer
+              quant:
+                type: number
+              ind:
+                type: number
+              qual:
+                type: string
+              height:
+                type: number
+        include:
+          type: object
+          properties:
+            nodeHeights:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  height:
+                    type: number
+                  quant:
+                    type: number
+            quant:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                unit:
+                  type: string
+            ind:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+                unit:
+                  type: string
+            qual:
+              type: object
+              properties:
+                id:
+                  type: integer
+                name:
+                  type: string
+    Node:
+      type: object
+      properties:
+        id:
+          type: integer
+        mainNodeId:
+          type: integer
+        name:
+          type: string
+        type:
+          type: string
+          description: e.g. BIOME
+        columnId:
+          type: integer
+          description: node type id
+        geoId:
+          type: string
+          description: e.g. BR for Brazil (country), BR1 for Amazonia (biome), BR5107925
+            for Sorriso (municipality), can be null
+        isDomesticConsumption:
+          type: boolean
+        isUnknown:
+          type: boolean
+        profileType:
+          type: string
+          description: actor or place
+        isAggregated:
+          type: boolean
+          description: true for OTHER nodes
+    LinkedNode:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+    NodeAttribute:
+      type: object
+      properties:
+        node_id:
+          type: integer
+          format: int64
+        attribute_id:
+          type: integer
+          format: int64
+        attribute_type:
+          type: string
+          enum:
+            - ind
+            - qual
+            - quant
+        value:
+          type: number
+        dual_layer_bucket:
+          type: integer
+        single_layer_bucket:
+          type: integer
+    Column:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              name:
+                type: string
+              position:
+                type: string
+              group:
+                type: string
+              isDefault:
+                type: boolean
+              isGeo:
+                type: boolean
+              isChoroplethDisabled:
+                type: boolean
+              profileType:
+                type: string
+    MapGroup:
+      type: object
+      properties:
+        dimensionGroups:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+        dimensions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Dimension"
+        contextualLayers:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              title:
+                type: string
+              identifier:
+                type: string
+                example: landcover
+              tooltipText:
+                type: string
+              isDefault:
+                type: boolean
+              legend:
+                type: string
+              cartoLayers:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    identifier:
+                      type: string
+                      example: landcover2015
+                    years:
+                      type: array
+                      items:
+                        type: integer
+                    rasterUrl:
+                      type: string
+    Attribute:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        type:
+          type: string
+    NewsletterSubscription:
+      type: object
+      properties:
+        email:
+          type: string
+    Dimension:
+      type: object
+      properties:
+        aggregateMethod:
+          type: string
+        dual_layer_buckets:
+          type: array
+          items:
+            type: number
+            format: float
+        single_layer_buckets:
+          type: array
+          items:
+            type: number
+            format: float
+        colorScale:
+          type: string
+        description:
+          type: string
+        id:
+          type: integer
+          format: int64
+        is_default:
+          type: boolean
+        layerAttributeId:
+          type: integer
+          format: int64
+        name:
+          type: string
+        unit:
+          type: string
+        years:
+          type: array
+          items:
+            type: integer
+    PlaceNode:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            column_name:
+              type: string
+              description: e.g. MUNICIPALITY
+            country_name:
+              type: string
+            country_geo_id:
+              type: string
+              description: e.g. BR
+            summary:
+              type: string
+            municipality_name:
+              type: string
+            municipality_geo_id:
+              type: string
+            state_name:
+              type: string
+            state_geo_id:
+              type: string
+            biome_name:
+              type: string
+            biome_geo_id:
+              type: string
+            area:
+              type: number
+            soy_production:
+              type: number
+            soy_area:
+              type: string
+            soy_farmland:
+              type: number
+            top_consumer_actors:
+              type: object
+              properties:
+                name:
+                  type: string
+                indicators:
+                  type: string
+                unit:
+                  type: string
+                targetNodes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                      height:
+                        type: number
+                      value:
+                        type: number
+                      is_domestic_consumption:
+                        type: boolean
+            top_consumer_countries:
+              type: object
+              properties:
+                name:
+                  type: string
+                indicators:
+                  type: string
+                unit:
+                  type: string
+                targetNodes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      name:
+                        type: string
+                      height:
+                        type: number
+                      value:
+                        type: number
+                      is_domestic_consumption:
+                        type: boolean
+            indicators:
+              type: array
+              items:
                 type: object
                 properties:
                   name:
                     type: string
-                  unit:
+                  included_columns:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        unit:
+                          type: string
+                        tooltip:
+                          type: string
+                  rows:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        have_unit:
+                          type: boolean
+                        values:
+                          type: array
+                          items:
+                            type: number
+            trajectory_deforestation:
+              type: object
+              properties:
+                included_years:
+                  type: array
+                  items:
+                    type: integer
+                unit:
+                  type: string
+                lines:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      legend_name:
+                        type: string
+                      legend_tooltip:
+                        type: string
+                      type:
+                        type: string
+                      style:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: number
+    PlaceBasicAttributes:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            column_name:
+              type: string
+              description: e.g. MUNICIPALITY
+            country_name:
+              type: string
+            country_geo_id:
+              type: string
+              description: e.g. BR
+            summary:
+              type: string
+            municipality_name:
+              type: string
+            municipality_geo_id:
+              type: string
+            state_name:
+              type: string
+            state_geo_id:
+              type: string
+            biome_name:
+              type: string
+            biome_geo_id:
+              type: string
+            area:
+              type: number
+            soy_production:
+              type: number
+            soy_area:
+              type: string
+            soy_farmland:
+              type: number
+    PlaceTopConsumerActors:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            name:
+              type: string
+            indicators:
+              type: string
+            unit:
+              type: string
+            targetNodes:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
                     type: string
-              dimensions_x:
+                  height:
+                    type: number
+                  value:
+                    type: number
+                  is_domestic_consumption:
+                    type: boolean
+    PlaceTopConsumerCountries:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            name:
+              type: string
+            indicators:
+              type: string
+            unit:
+              type: string
+            targetNodes:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  height:
+                    type: number
+                  value:
+                    type: number
+                  is_domestic_consumption:
+                    type: boolean
+    PlaceIndicators:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              included_columns:
                 type: array
                 items:
                   type: object
@@ -2427,201 +2537,489 @@ definitions:
                       type: string
                     unit:
                       type: string
-              companies:
+                    tooltip:
+                      type: string
+              rows:
                 type: array
                 items:
                   type: object
                   properties:
                     name:
                       type: string
-                    id:
-                      type: integer
-                    y:
-                      type: number
-                    x:
+                    have_unit:
+                      type: boolean
+                    values:
                       type: array
                       items:
                         type: number
-
-  ActorBasicAttributes:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          node_name:
-            type: string
-          column_name:
-            type: string
-          country_name:
-            type: string
-          country_geo_id:
-            type: string
-          zero_deforestation_link:
-            type: string
-          supply_change_link:
-            type: string
-          rtrs_member:
-            type: string
-          zero_deforestation:
-            type: string
-          supply_change:
-            type: string
-          soy_:
-            type: number
-          forest_500:
-            type: number
-          summary:
-            type: string
-
-  ActorTopCountries:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          included_years:
-            type: array
-            items:
-              type: integer
-          buckets:
-            type: array
-            items:
-              type: integer
-          lines:
-            type: array
-            items:
+    PlaceTrajectoryDeforestation:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            included_years:
+              type: array
+              items:
+                type: integer
+            unit:
+              type: string
+            lines:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  legend_name:
+                    type: string
+                  legend_tooltip:
+                    type: string
+                  type:
+                    type: string
+                  style:
+                    type: string
+                  values:
+                    type: array
+                    items:
+                      type: number
+    ActorNode:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            node_name:
+              type: string
+            column_name:
+              type: string
+            country_name:
+              type: string
+            country_geo_id:
+              type: string
+            zero_deforestation_link:
+              type: string
+            supply_change_link:
+              type: string
+            rtrs_member:
+              type: string
+            zero_deforestation:
+              type: string
+            supply_change:
+              type: string
+            soy_:
+              type: number
+            forest_500:
+              type: number
+            summary:
+              type: string
+            top_countries:
+              type: object
+              properties:
+                included_years:
+                  type: array
+                  items:
+                    type: integer
+                buckets:
+                  type: array
+                  items:
+                    type: integer
+                lines:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      geo_id:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: number
+                      value9:
+                        type: number
+                unit:
+                  type: string
+                style:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    style:
+                      type: string
+            top_sources:
+              type: object
+              properties:
+                included_years:
+                  type: array
+                  items:
+                    type: integer
+                buckets:
+                  type: array
+                  items:
+                    type: integer
+                municipality:
+                  type: object
+                  properties:
+                    lines:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          geo_id:
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: number
+                          value9:
+                            type: number
+                    unit:
+                      type: string
+                    style:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        style:
+                          type: string
+                biome:
+                  type: object
+                  properties:
+                    lines:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          geo_id:
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: number
+                          value9:
+                            type: number
+                    unit:
+                      type: string
+                    style:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        style:
+                          type: string
+                state:
+                  type: object
+                  properties:
+                    lines:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          geo_id:
+                            type: string
+                          values:
+                            type: array
+                            items:
+                              type: number
+                          value9:
+                            type: number
+                    unit:
+                      type: string
+                    style:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        style:
+                          type: string
+            sustainability:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  included_columns:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        unit:
+                          type: string
+                        tooltip:
+                          type: string
+                  rows:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        values:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: integer
+                              value:
+                                type: string
+            companies_sourcing:
+              type: object
+              properties:
+                dimension_y:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    unit:
+                      type: string
+                dimensions_x:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      unit:
+                        type: string
+                companies:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      id:
+                        type: integer
+                      y:
+                        type: number
+                      x:
+                        type: array
+                        items:
+                          type: number
+    ActorBasicAttributes:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            node_name:
+              type: string
+            column_name:
+              type: string
+            country_name:
+              type: string
+            country_geo_id:
+              type: string
+            zero_deforestation_link:
+              type: string
+            supply_change_link:
+              type: string
+            rtrs_member:
+              type: string
+            zero_deforestation:
+              type: string
+            supply_change:
+              type: string
+            soy_:
+              type: number
+            forest_500:
+              type: number
+            summary:
+              type: string
+    ActorTopCountries:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            included_years:
+              type: array
+              items:
+                type: integer
+            buckets:
+              type: array
+              items:
+                type: integer
+            lines:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  geo_id:
+                    type: string
+                  values:
+                    type: array
+                    items:
+                      type: number
+                  value9:
+                    type: number
+            unit:
+              type: string
+            style:
+              type: object
+              properties:
+                type:
+                  type: string
+                style:
+                  type: string
+    ActorTopSources:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            included_years:
+              type: array
+              items:
+                type: integer
+            buckets:
+              type: array
+              items:
+                type: integer
+            municipality:
+              type: object
+              properties:
+                lines:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      geo_id:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: number
+                      value9:
+                        type: number
+                unit:
+                  type: string
+                style:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    style:
+                      type: string
+            biome:
+              type: object
+              properties:
+                lines:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      geo_id:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: number
+                      value9:
+                        type: number
+                unit:
+                  type: string
+                style:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    style:
+                      type: string
+            state:
+              type: object
+              properties:
+                lines:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      geo_id:
+                        type: string
+                      values:
+                        type: array
+                        items:
+                          type: number
+                      value9:
+                        type: number
+                unit:
+                  type: string
+                style:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                    style:
+                      type: string
+    ActorSustainability:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              profile:
+                type: boolean
+              included_columns:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    unit:
+                      type: string
+                    tooltip:
+                      type: string
+              rows:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    values:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                          value:
+                            type: string
+    ActorExportingCompanies:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            dimension_y:
               type: object
               properties:
                 name:
                   type: string
-                geo_id:
+                unit:
                   type: string
-                values:
-                  type: array
-                  items:
-                    type: number
-                value9:
-                  type: number
-          unit:
-            type: string
-          style:
-            type: object
-            properties:
-              type:
-                type: string
-              style:
-                type: string
-
-  ActorTopSources:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          included_years:
-            type: array
-            items:
-              type: integer
-          buckets:
-            type: array
-            items:
-              type: integer
-          municipality:
-            type: object
-            properties:
-              lines:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    geo_id:
-                      type: string
-                    values:
-                      type: array
-                      items:
-                        type: number
-                    value9:
-                      type: number
-              unit:
-                type: string
-              style:
-                type: object
-                properties:
-                  type:
-                    type: string
-                  style:
-                    type: string
-          biome:
-            type: object
-            properties:
-              lines:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    geo_id:
-                      type: string
-                    values:
-                      type: array
-                      items:
-                        type: number
-                    value9:
-                      type: number
-              unit:
-                type: string
-              style:
-                type: object
-                properties:
-                  type:
-                    type: string
-                  style:
-                    type: string
-          state:
-            type: object
-            properties:
-              lines:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    geo_id:
-                      type: string
-                    values:
-                      type: array
-                      items:
-                        type: number
-                    value9:
-                      type: number
-              unit:
-                type: string
-              style:
-                type: object
-                properties:
-                  type:
-                    type: string
-                  style:
-                    type: string
-
-  ActorSustainability:
-    type: object
-    properties:
-      data:
-        type: array
-        items:
-          type: object
-          properties:
-            name:
-              type: string
-            profile:
-              type: boolean
-            included_columns:
+            dimensions_x:
               type: array
               items:
                 type: object
@@ -2630,145 +3028,102 @@ definitions:
                     type: string
                   unit:
                     type: string
-                  tooltip:
-                    type: string
-            rows:
+            companies:
               type: array
               items:
                 type: object
                 properties:
-                  values:
+                  name:
+                    type: string
+                  id:
+                    type: integer
+                  y:
+                    type: number
+                  x:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        id:
-                          type: integer
-                        value:
-                          type: string
-
-  ActorExportingCompanies:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          dimension_y:
-            type: object
-            properties:
-              name:
-                type: string
-              unit:
-                type: string
-          dimensions_x:
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                unit:
-                  type: string
-          companies:
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  type: string
-                id:
-                  type: integer
-                y:
-                  type: number
-                x:
-                  type: array
-                  items:
+                      type: number
+    TopNodes:
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            context_id:
+              type: integer
+            indicator:
+              type: string
+              description: e.g. Trade volume
+            unit:
+              type: string
+              description: e.g. Tn
+            target_nods:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  height:
                     type: number
-
-  TopNodes:
-    type: object
-    properties:
-      data:
-        type: object
-        properties:
-          context_id:
-            type: integer
-          indicator:
-            type: string
-            description: 'e.g. Trade volume'
-          unit:
-            type: string
-            description: 'e.g. Tn'
-          target_nods:
-            type: array
-            items:
-              type: object
-              properties:
-                id:
-                  type: integer
-                name:
-                  type: string
-                height:
-                  type: number
-                value:
-                  type: number
-
-  ProfileMetadata:
-    type: object
-    properties:
-      id:
-        type: integer
-      context_node_type_id:
-        type: integer
-      name:
-        type: string
-      main_topojson_path:
-        type: string
-      main_topojson_root:
-        type: string
-      adm_1_name:
-        type: string
-      adm_1_topojson_path:
-        type: string
-      adm_1_topojson_root:
-        type: string
-      adm_2_name:
-        type: string
-      adm_2_topojson_path:
-        type: string
-      adm_2_topojson_root:
-        type: string
-      charts:
-        type: array
-        items:
-          $ref: '#/definitions/Chart'
-
-  Chart:
-    type: object
-    properties:
-      id:
-        type: integer
-      chart_type:
-        type: string
-        example: 'tabs_table'
-      identifier:
-        type: string
-        example: 'actor_sustainability_table'
-      title:
-        type: string
-        example: 'Deforestation risk associated with top sourcing regions'
-      position:
-        type: integer
-      charts:
-        type: array
-        items:
-          $ref: '#/definitions/Chart'
-
-  ParametrisedChart:
-    type: object
-    properties:
-      type:
-        type: string
-        example: 'stacked_bar_chart'
-      url:
-        type: string
+                  value:
+                    type: number
+    ProfileMetadata:
+      type: object
+      properties:
+        id:
+          type: integer
+        context_node_type_id:
+          type: integer
+        name:
+          type: string
+        main_topojson_path:
+          type: string
+        main_topojson_root:
+          type: string
+        adm_1_name:
+          type: string
+        adm_1_topojson_path:
+          type: string
+        adm_1_topojson_root:
+          type: string
+        adm_2_name:
+          type: string
+        adm_2_topojson_path:
+          type: string
+        adm_2_topojson_root:
+          type: string
+        charts:
+          type: array
+          items:
+            $ref: "#/components/schemas/Chart"
+    Chart:
+      type: object
+      properties:
+        id:
+          type: integer
+        chart_type:
+          type: string
+          example: tabs_table
+        identifier:
+          type: string
+          example: actor_sustainability_table
+        title:
+          type: string
+          example: Deforestation risk associated with top sourcing regions
+        position:
+          type: integer
+        charts:
+          type: array
+          items:
+            $ref: "#/components/schemas/Chart"
+    ParametrisedChart:
+      type: object
+      properties:
+        type:
+          type: string
+          example: stacked_bar_chart
+        url:
+          type: string

--- a/spec/models/api/v3/resize_by_attribute_spec.rb
+++ b/spec/models/api/v3/resize_by_attribute_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Api::V3::ResizeByAttribute, type: :model do
       FactoryBot.build(
         :api_v3_resize_by_attribute,
         context: api_v3_context,
-        group_number: api_v3_area_resize_by_attribute.group_number,
-        position: api_v3_area_resize_by_attribute.position
+        group_number: api_v3_volume_resize_by_attribute.group_number,
+        position: api_v3_volume_resize_by_attribute.position
       )
     }
     it 'fails when context missing' do

--- a/spec/responses/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
+++ b/spec/responses/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+require 'responses/api/v3/dashboards/charts/required_chart_parameters_examples.rb'
+
+RSpec.describe 'Charts::MultiYearNcontOverview', type: :request do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 brazil flows inds'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+  let(:ncont_attribute) { api_v3_forest_500.readonly_attribute }
+
+  describe 'GET /api/v3/dashboards/charts/multi_year_ncont_overview' do
+    let(:url) { '/api/v3/dashboards/charts/multi_year_ncont_overview' }
+    let(:filter_params) {
+      {
+        country_id: api_v3_brazil.id,
+        commodity_id: api_v3_soy.id,
+        cont_attribute_id: cont_attribute.id,
+        ncont_attribute_id: ncont_attribute.id,
+        sources_ids: api_v3_municipality_node.id,
+        companies_ids: [api_v3_exporter1_node.id, api_v3_exporter1_node.id].join(','),
+        destinations_ids: api_v3_country_of_destination1_node.id,
+        start_year: 2015,
+        end_year: 2016
+      }
+    }
+    include_examples 'required chart parameters'
+
+    it 'requires ncont_attribute_id' do
+      get url, params: filter_params.except(:ncont_attribute_id)
+      expect(@response).to have_http_status(:bad_request)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param ncont_attribute_id missing'
+      )
+    end
+
+    it 'requires end_year' do
+      get url, params: filter_params.except(:end_year)
+      expect(@response).to have_http_status(:bad_request)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param end_year missing'
+      )
+    end
+
+    it 'has the correct response structure' do
+      get url, params: filter_params
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_charts_multi_year_ncont_overview')
+    end
+  end
+end

--- a/spec/responses/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
+++ b/spec/responses/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require 'responses/api/v3/dashboards/charts/required_chart_parameters_examples.rb'
+
+RSpec.describe 'Charts::MultiYearNoNcontOverview', type: :request do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+
+  describe 'GET /api/v3/dashboards/charts/multi_year_no_ncont_overview' do
+    let(:url) { '/api/v3/dashboards/charts/multi_year_no_ncont_overview' }
+    let(:filter_params) {
+      {
+        country_id: api_v3_brazil.id,
+        commodity_id: api_v3_soy.id,
+        cont_attribute_id: cont_attribute.id,
+        sources_ids: api_v3_municipality_node.id,
+        companies_ids: [api_v3_exporter1_node.id, api_v3_exporter1_node.id].join(','),
+        destinations_ids: api_v3_country_of_destination1_node.id,
+        start_year: 2015,
+        end_year: 2016
+      }
+    }
+    include_examples 'required chart parameters'
+
+    it 'requires end_year' do
+      get url, params: filter_params.except(:end_year)
+      expect(@response).to have_http_status(:bad_request)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param end_year missing'
+      )
+    end
+
+    it 'has the correct response structure' do
+      get url, params: filter_params
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_charts_multi_year_no_ncont_overview')
+    end
+  end
+end

--- a/spec/responses/api/v3/dashboards/charts/required_chart_parameters_examples.rb
+++ b/spec/responses/api/v3/dashboards/charts/required_chart_parameters_examples.rb
@@ -1,0 +1,30 @@
+RSpec.shared_examples 'required chart parameters' do
+  it 'requires country_id' do
+    get url, params: filter_params.except(:country_id)
+    expect(@response).to have_http_status(:bad_request)
+    expect(JSON.parse(@response.body)).to eq(
+      'error' => 'param is missing or the value is empty: Required param country_id missing'
+    )
+  end
+  it 'requires commodity_id' do
+    get url, params: filter_params.except(:commodity_id)
+    expect(@response).to have_http_status(:bad_request)
+    expect(JSON.parse(@response.body)).to eq(
+      'error' => 'param is missing or the value is empty: Required param commodity_id missing'
+    )
+  end
+  it 'requires cont_attribute_id' do
+    get url, params: filter_params.except(:cont_attribute_id)
+    expect(@response).to have_http_status(:bad_request)
+    expect(JSON.parse(@response.body)).to eq(
+      'error' => 'param is missing or the value is empty: Required param cont_attribute_id missing'
+    )
+  end
+  it 'requires start_year' do
+    get url, params: filter_params.except(:start_year)
+    expect(@response).to have_http_status(:bad_request)
+    expect(JSON.parse(@response.body)).to eq(
+      'error' => 'param is missing or the value is empty: Required param start_year missing'
+    )
+  end
+end

--- a/spec/responses/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
+++ b/spec/responses/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'responses/api/v3/dashboards/charts/required_chart_parameters_examples.rb'
+
+RSpec.describe 'Charts::SingleYearNcontOverview', type: :request do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 brazil flows inds'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+  let(:ncont_attribute) { api_v3_forest_500.readonly_attribute }
+
+  describe 'GET /api/v3/dashboards/charts/single_year_ncont_overview' do
+    let(:url) { '/api/v3/dashboards/charts/single_year_ncont_overview' }
+    let(:filter_params) {
+      {
+        country_id: api_v3_brazil.id,
+        commodity_id: api_v3_soy.id,
+        cont_attribute_id: cont_attribute.id,
+        ncont_attribute_id: ncont_attribute.id,
+        sources_ids: api_v3_municipality_node.id,
+        companies_ids: [api_v3_exporter1_node.id, api_v3_exporter1_node.id].join(','),
+        destinations_ids: api_v3_country_of_destination1_node.id,
+        start_year: 2015
+      }
+    }
+    include_examples 'required chart parameters'
+
+    it 'requires ncont_attribute_id' do
+      get url, params: filter_params.except(:ncont_attribute_id)
+      expect(@response).to have_http_status(:bad_request)
+      expect(JSON.parse(@response.body)).to eq(
+        'error' => 'param is missing or the value is empty: Required param ncont_attribute_id missing'
+      )
+    end
+
+    it 'has the correct response structure' do
+      get url, params: filter_params
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_charts_single_year_ncont_overview')
+    end
+  end
+end

--- a/spec/responses/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
+++ b/spec/responses/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require 'responses/api/v3/dashboards/charts/required_chart_parameters_examples.rb'
+
+RSpec.describe 'Charts::SingleYearNoNcontOverview', type: :request do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+
+  describe 'GET /api/v3/dashboards/charts/single_year_no_ncont_overview' do
+    let(:url) { '/api/v3/dashboards/charts/single_year_no_ncont_overview' }
+    let(:filter_params) {
+      {
+        country_id: api_v3_brazil.id,
+        commodity_id: api_v3_soy.id,
+        cont_attribute_id: cont_attribute.id,
+        sources_ids: api_v3_municipality_node.id,
+        companies_ids: [api_v3_exporter1_node.id, api_v3_exporter1_node.id].join(','),
+        destinations_ids: api_v3_country_of_destination1_node.id,
+        start_year: 2015
+      }
+    }
+    include_examples 'required chart parameters'
+
+    it 'has the correct response structure' do
+      get url, params: filter_params
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_charts_single_year_no_ncont_overview')
+    end
+  end
+end

--- a/spec/responses/api/v3/dashboards/parametrised_charts_spec.rb
+++ b/spec/responses/api/v3/dashboards/parametrised_charts_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'ParametrisedCharts', type: :request do
+  include_context 'api v3 brazil context node types'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil resize by attributes'
+
+  describe 'GET /api/v3/dashboards/parametrised_charts' do
+    before(:each) do
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+    end
+
+    it 'has the correct response structure' do
+      get '/api/v3/dashboards/parametrised_charts', params: {
+        country_id: api_v3_brazil.id,
+        commodity_id: api_v3_soy.id,
+        cont_attribute_id: api_v3_volume.readonly_attribute.id
+      }
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_parametrised_charts')
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::Charts::MultiYearNcontOverview do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 brazil flows inds'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+  let(:ncont_attribute) { api_v3_forest_500.readonly_attribute }
+
+  let(:shared_parameters_hash) {
+    {
+      country_id: api_v3_brazil.id,
+      commodity_id: api_v3_soy.id,
+      cont_attribute_id: cont_attribute.id,
+      ncont_attribute_id: ncont_attribute.id,
+      start_year: 2015,
+      end_year: 2016
+    }
+  }
+
+  let(:chart_parameters) {
+    Api::V3::Dashboards::ChartParameters.new(parameters_hash)
+  }
+
+  let(:result) {
+    Api::V3::Dashboards::Charts::MultiYearNcontOverview.new(
+      chart_parameters
+    ).call
+  }
+
+  let(:data) { result[:data] }
+  let(:meta) { result[:meta] }
+
+  describe :call do
+    context 'when no flow path filters' do
+      let(:parameters_hash) { shared_parameters_hash }
+      it 'summarized all flows per year' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(10)
+        expect(meta[:y0][:label]).to eq(1)
+      end
+    end
+
+    context 'when filtered by 1 exporter' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+      }
+      it 'summarized flows matching exporter per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(nil)
+      end
+    end
+
+    context 'when filtered by 2 exporters' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(10)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 importer' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching exporter AND importer per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y3]).to eq(25)
+      end
+    end
+
+    context 'when filtered by 2 exporters and 2 importers' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id,
+            api_v3_other_exporter_node.id,
+            api_v3_importer1_node.id,
+            api_v3_other_importer_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter AND either importer per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontOverview do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+
+  let(:shared_parameters_hash) {
+    {
+      country_id: api_v3_brazil.id,
+      commodity_id: api_v3_soy.id,
+      cont_attribute_id: cont_attribute.id,
+      start_year: 2015,
+      end_year: 2016
+    }
+  }
+
+  let(:chart_parameters) {
+    Api::V3::Dashboards::ChartParameters.new(parameters_hash)
+  }
+
+  let(:result) {
+    Api::V3::Dashboards::Charts::MultiYearNoNcontOverview.new(
+      chart_parameters
+    ).call
+  }
+
+  let(:data) { result[:data] }
+
+  describe :call do
+    context 'when no flow path filters' do
+      let(:parameters_hash) { shared_parameters_hash }
+      it 'summarized all flows per year' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(100)
+      end
+    end
+
+    context 'when filtered by 1 exporter' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+      }
+      it 'summarized flows matching exporter per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(25)
+      end
+    end
+
+    context 'when filtered by 2 exporters' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(100)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 importer' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching exporter AND importer per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(25)
+      end
+    end
+
+    context 'when filtered by 2 exporters and 2 importers' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id,
+            api_v3_other_exporter_node.id,
+            api_v3_importer1_node.id,
+            api_v3_other_importer_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter AND either importer per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(100)
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontOverview do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 brazil flows inds'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+  let(:ncont_attribute) { api_v3_forest_500.readonly_attribute }
+
+  let(:shared_parameters_hash) {
+    {
+      country_id: api_v3_brazil.id,
+      commodity_id: api_v3_soy.id,
+      cont_attribute_id: cont_attribute.id,
+      ncont_attribute_id: ncont_attribute.id,
+      start_year: 2015
+    }
+  }
+
+  let(:chart_parameters) {
+    Api::V3::Dashboards::ChartParameters.new(parameters_hash)
+  }
+
+  let(:result) {
+    Api::V3::Dashboards::Charts::SingleYearNcontOverview.new(
+      chart_parameters
+    ).call
+  }
+
+  let(:data) { result[:data] }
+
+  describe :call do
+    context 'when no flow path filters' do
+      let(:parameters_hash) { shared_parameters_hash }
+      it 'summarized all flows per ncont' do
+        expect(data.size).to eq(5)
+        expect(data[0][:x]).to eq(1)
+        expect(data[0][:y0]).to eq(10)
+      end
+    end
+
+    context 'when filtered by 1 exporter' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+      }
+      it 'summarized flows matching exporter per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(4)
+        expect(data[0][:y0]).to eq(25)
+      end
+    end
+
+    context 'when filtered by 2 exporters' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter per ncont' do
+        expect(data.size).to eq(5)
+        expect(data[2][:x]).to eq(3)
+        expect(data[2][:y0]).to eq(20)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 importer' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching exporter AND importer per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(4)
+        expect(data[0][:y0]).to eq(25)
+      end
+    end
+
+    context 'when filtered by 2 exporters and 2 importers' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id,
+            api_v3_other_exporter_node.id,
+            api_v3_importer1_node.id,
+            api_v3_other_importer_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter AND either importer per ncont' do
+        expect(data.size).to eq(5)
+        expect(data[0][:x]).to eq(1)
+        expect(data[0][:y0]).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontOverview do
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+
+  let(:shared_parameters_hash) {
+    {
+      country_id: api_v3_brazil.id,
+      commodity_id: api_v3_soy.id,
+      cont_attribute_id: cont_attribute.id,
+      start_year: 2015
+    }
+  }
+
+  let(:chart_parameters) {
+    Api::V3::Dashboards::ChartParameters.new(parameters_hash)
+  }
+
+  let(:result) {
+    Api::V3::Dashboards::Charts::SingleYearNoNcontOverview.new(
+      chart_parameters
+    ).call
+  }
+
+  let(:data) { result[:data] }
+
+  describe :call do
+    context 'when no flow path filters' do
+      let(:parameters_hash) { shared_parameters_hash }
+      it 'returns total value' do
+        expect(data[0][:y0]).to eq(100)
+      end
+    end
+
+    context 'when filtered by 1 exporter' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+      }
+      it 'it summarized flows matching exporter' do
+        expect(data[0][:y0]).to eq(25)
+      end
+    end
+
+    context 'when filtered by 2 exporters' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter' do
+        expect(data[0][:y0]).to eq(100)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 importer' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching exporter AND importer' do
+        expect(data[0][:y0]).to eq(25)
+      end
+    end
+
+    context 'when filtered by 2 exporters and 2 importers' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [
+            api_v3_exporter1_node.id,
+            api_v3_other_exporter_node.id,
+            api_v3_importer1_node.id,
+            api_v3_other_importer_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching either exporter AND either importer' do
+        expect(data[0][:y0]).to eq(100)
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
+++ b/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
@@ -1,0 +1,151 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
+  include_context 'api v3 node types'
+
+  let(:context) { FactoryBot.create(:api_v3_context) }
+
+  let!(:exporter_node_type) {
+    cnt = FactoryBot.create(
+      :api_v3_context_node_type, context: context, node_type: api_v3_exporter_node_type
+    )
+    FactoryBot.create(
+      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 1
+    )
+  }
+
+  let!(:destination_node_type) {
+    cnt = FactoryBot.create(
+      :api_v3_context_node_type, context: context, node_type: api_v3_country_node_type
+    )
+    FactoryBot.create(
+      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 3
+    )
+  }
+
+  describe 'call' do
+    context 'when subnational context with importer node' do
+      let!(:source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_biome_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+      let!(:another_source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_state_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+
+      let!(:importer_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_importer_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2
+        )
+      }
+
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [api_v3_biome_node_type.id],
+          [api_v3_exporter_node_type.id, api_v3_importer_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_biome_node_type,
+          api_v3_exporter_node_type,
+          api_v3_importer_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+
+    context 'when national context with importer node' do
+      let!(:importer_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_importer_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2
+        )
+      }
+
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [],
+          [api_v3_exporter_node_type.id, api_v3_importer_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_exporter_node_type,
+          api_v3_importer_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+
+    context 'when subnational context without importer node' do
+      let!(:source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_biome_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+      let!(:another_source_node_type) {
+        cnt = FactoryBot.create(
+          :api_v3_context_node_type, context: context, node_type: api_v3_state_node_type
+        )
+        FactoryBot.create(
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+        )
+      }
+
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [api_v3_biome_node_type.id],
+          [api_v3_exporter_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_biome_node_type,
+          api_v3_exporter_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+
+    context 'when national context without importer node' do
+      let(:node_types_to_break_by) {
+        Api::V3::Dashboards::NodeTypesToBreakBy.new(
+          context,
+          [],
+          [api_v3_exporter_node_type.id],
+          [api_v3_country_node_type.id]
+        )
+      }
+      it 'returns available node types to break by' do
+        expect(node_types_to_break_by.call).to eq([
+          api_v3_exporter_node_type,
+          api_v3_country_node_type
+        ])
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/parametrised_charts_spec.rb
+++ b/spec/services/api/v3/dashboards/parametrised_charts_spec.rb
@@ -1,0 +1,193 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
+  include_context 'api v3 brazil context node types'
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 brazil resize by attributes'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:cont_attribute) { api_v3_volume.readonly_attribute }
+  let(:ncont_attribute) { api_v3_forest_500.readonly_attribute }
+  let(:mandatory_parameters) {
+    {
+      country_id: api_v3_context.country_id,
+      commodity_id: api_v3_context.commodity_id,
+      cont_attribute_id: cont_attribute.id
+    }
+  }
+  let(:no_flow_path_filters) {
+    {
+      sources_ids: [],
+      companies_ids: [],
+      destinations_ids: []
+    }
+  }
+  let(:single_year) { {start_year: 2017, end_year: 2017} }
+  let(:multi_year) { {start_year: 2016, end_year: 2017} }
+
+  let(:chart_types) {
+    Api::V3::Dashboards::ParametrisedCharts.new(
+      Api::V3::Dashboards::ChartParameters.new(parameters)
+    ).call
+  }
+
+  let(:expected_chart_types) {
+    simplified_expected_chart_types.map do |chart_type|
+      chart_type.merge(parameters)
+    end
+  }
+
+  context 'when single year, no non-cont indicator, no flow-path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(single_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: nil
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :single_year_no_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::DYNAMIC_SENTENCE,
+          x: nil
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :single_year_no_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::HORIZONTAL_BAR_CHART,
+          x: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+
+  context 'when multiple years, no non-cont indicator, no flow path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(multi_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: nil
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_no_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::BAR_CHART,
+          x: :year
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+
+  context 'when single year, non-cont indicator, no flow path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(single_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :single_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::DONUT_CHART,
+          x: :ncont_attribute
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :single_year_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::HORIZONTAL_STACKED_BAR_CHART,
+          x: :node_type,
+          break_by: :ncont_attribute,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+
+  context 'when multiple years, non-cont indicator, no flow path filters' do
+    let(:parameters) {
+      mandatory_parameters.merge(multi_year).merge(no_flow_path_filters).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_ncont_by_node_type,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          filter_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+    it 'returns expected chart types' do
+      expect(chart_types).to eq(expected_chart_types)
+    end
+  end
+end

--- a/spec/support/contexts/api/v3/brazil/brazil_flows_inds.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows_inds.rb
@@ -1,0 +1,45 @@
+shared_context 'api v3 brazil flows inds' do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 inds'
+
+  let!(:api_v3_flow1_forest_500) do
+    FactoryBot.create(
+      :api_v3_flow_ind,
+      flow: api_v3_flow1,
+      ind: api_v3_forest_500,
+      value: 1
+    )
+  end
+  let!(:api_v3_flow2_forest_500) do
+    FactoryBot.create(
+      :api_v3_flow_ind,
+      flow: api_v3_flow2,
+      ind: api_v3_forest_500,
+      value: 2
+    )
+  end
+  let!(:api_v3_flow3_forest_500) do
+    FactoryBot.create(
+      :api_v3_flow_ind,
+      flow: api_v3_flow3,
+      ind: api_v3_forest_500,
+      value: 3
+    )
+  end
+  let!(:api_v3_flow4_forest_500) do
+    FactoryBot.create(
+      :api_v3_flow_ind,
+      flow: api_v3_flow4,
+      ind: api_v3_forest_500,
+      value: 4
+    )
+  end
+  let!(:api_v3_flow5_forest_500) do
+    FactoryBot.create(
+      :api_v3_flow_ind,
+      flow: api_v3_flow5,
+      ind: api_v3_forest_500,
+      value: 5
+    )
+  end
+end

--- a/spec/support/contexts/api/v3/brazil/brazil_resize_by_attributes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_resize_by_attributes.rb
@@ -2,17 +2,17 @@ shared_context 'api v3 brazil resize by attributes' do
   include_context 'api v3 brazil contexts'
   include_context 'api v3 quants'
 
-  let!(:api_v3_area_resize_by_attribute) do
+  let!(:api_v3_volume_resize_by_attribute) do
     resize_by_attribute = Api::V3::ResizeByQuant.
       includes(:resize_by_attribute).
       where(
         'resize_by_attributes.context_id' => api_v3_context.id,
-        quant_id: api_v3_area.id
+        quant_id: api_v3_volume.id
       ).first&.resize_by_attribute
     unless resize_by_attribute
       resize_by_attribute = FactoryBot.create(
         :api_v3_resize_by_attribute,
-        tooltip_text: 'area tooltip text',
+        tooltip_text: 'Amount of the traded commodity (tonnes)',
         context: api_v3_context,
         position: 1,
         years: [],
@@ -23,23 +23,23 @@ shared_context 'api v3 brazil resize by attributes' do
       FactoryBot.create(
         :api_v3_resize_by_quant,
         resize_by_attribute: resize_by_attribute,
-        quant: api_v3_area
+        quant: api_v3_volume
       )
     end
     resize_by_attribute
   end
 
-  let!(:api_v3_land_conflict_resize_by_attribute) do
+  let!(:api_v3_fob_resize_by_attribute) do
     resize_by_attribute = Api::V3::ResizeByQuant.
       includes(:resize_by_attribute).
       where(
         'resize_by_attributes.context_id' => api_v3_context.id,
-        quant_id: api_v3_land_conflicts.id
+        quant_id: api_v3_fob.id
       ).first&.resize_by_attribute
     unless resize_by_attribute
       resize_by_attribute = FactoryBot.create(
         :api_v3_resize_by_attribute,
-        tooltip_text: 'land conflict tooltip text',
+        tooltip_text: 'Value of the traded product in US dollars',
         context: api_v3_context,
         position: 2,
         years: [],
@@ -50,7 +50,7 @@ shared_context 'api v3 brazil resize by attributes' do
       FactoryBot.create(
         :api_v3_resize_by_quant,
         resize_by_attribute: resize_by_attribute,
-        quant: api_v3_land_conflicts
+        quant: api_v3_fob
       )
     end
     resize_by_attribute

--- a/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
@@ -1,0 +1,638 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "$id": "#/properties/data",
+      "type": "array",
+      "title": "The Data Schema",
+      "items": {
+        "$id": "#/properties/data/items",
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "x",
+          "y0",
+          "y1",
+          "y4"
+        ],
+        "properties": {
+          "y0": {
+            "$id": "#/properties/data/items/properties/y0",
+            "type": "number",
+            "title": "The Y0 Schema",
+            "default": 0.0,
+            "examples": [
+              6913271.774814
+            ]
+          },
+          "y1": {
+            "$id": "#/properties/data/items/properties/y1",
+            "type": "number",
+            "title": "The Y1 Schema",
+            "default": 0.0,
+            "examples": [
+              7170873.080941
+            ]
+          },
+          "y2": {
+            "$id": "#/properties/data/items/properties/y2",
+            "type": "number",
+            "title": "The Y2 Schema",
+            "default": 0.0,
+            "examples": [
+              10910119.85475
+            ]
+          },
+          "y3": {
+            "$id": "#/properties/data/items/properties/y3",
+            "type": "number",
+            "title": "The Y3 Schema",
+            "default": 0.0,
+            "examples": [
+              20003570.43905
+            ]
+          },
+          "x": {
+            "$id": "#/properties/data/items/properties/x",
+            "type": "integer",
+            "title": "The X Schema",
+            "default": 0,
+            "examples": [
+              2015
+            ]
+          }
+        }
+      }
+    },
+    "meta": {
+      "$id": "#/properties/meta",
+      "type": "object",
+      "title": "The Meta Schema",
+      "required": [
+        "xAxis",
+        "yAxis",
+        "x",
+        "y0",
+        "y1",
+        "y2",
+        "y3",
+        "y4"
+      ],
+      "properties": {
+        "xAxis": {
+          "$id": "#/properties/meta/properties/xAxis",
+          "type": "object",
+          "title": "The Xaxis Schema",
+          "required": [
+            "label",
+            "prefix",
+            "format",
+            "suffix"
+          ],
+          "properties": {
+            "label": {
+              "$id": "#/properties/meta/properties/xAxis/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Year"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "prefix": {
+              "$id": "#/properties/meta/properties/xAxis/properties/prefix",
+              "type": "string",
+              "title": "The Prefix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "format": {
+              "$id": "#/properties/meta/properties/xAxis/properties/format",
+              "type": "string",
+              "title": "The Format Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "suffix": {
+              "$id": "#/properties/meta/properties/xAxis/properties/suffix",
+              "type": "string",
+              "title": "The Suffix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "yAxis": {
+          "$id": "#/properties/meta/properties/yAxis",
+          "type": "object",
+          "title": "The Yaxis Schema",
+          "required": [
+            "label",
+            "prefix",
+            "format",
+            "suffix"
+          ],
+          "properties": {
+            "label": {
+              "$id": "#/properties/meta/properties/yAxis/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Trade volume"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "prefix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/prefix",
+              "type": "string",
+              "title": "The Prefix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "format": {
+              "$id": "#/properties/meta/properties/yAxis/properties/format",
+              "type": "string",
+              "title": "The Format Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "suffix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/suffix",
+              "type": "string",
+              "title": "The Suffix Schema",
+              "default": "",
+              "examples": [
+                "t"
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "x": {
+          "$id": "#/properties/meta/properties/x",
+          "type": "object",
+          "title": "The X Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/x/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/x/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Year"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/x/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "y0": {
+          "$id": "#/properties/meta/properties/y0",
+          "type": "object",
+          "title": "The Y0 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y0/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y0/properties/label",
+              "type": ["integer", "number", "string"],
+              "title": "The Label Schema",
+              "default": 0,
+              "examples": [
+                1
+              ]
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y0/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "y1": {
+          "$id": "#/properties/meta/properties/y1",
+          "type": "object",
+          "title": "The Y1 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y1/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y1/properties/label",
+              "type": ["integer", "number", "string"],
+              "title": "The Label Schema",
+              "default": 0,
+              "examples": [
+                2
+              ]
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y1/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "y2": {
+          "$id": "#/properties/meta/properties/y2",
+          "type": "object",
+          "title": "The Y2 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y2/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y2/properties/label",
+              "type": ["integer", "number", "string"],
+              "title": "The Label Schema",
+              "default": 0,
+              "examples": [
+                3
+              ]
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y2/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "y3": {
+          "$id": "#/properties/meta/properties/y3",
+          "type": "object",
+          "title": "The Y3 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y3/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y3/properties/label",
+              "type": ["integer", "number", "string"],
+              "title": "The Label Schema",
+              "default": 0,
+              "examples": [
+                4
+              ]
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y3/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "y4": {
+          "$id": "#/properties/meta/properties/y4",
+          "type": "object",
+          "title": "The Y4 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y4/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y4/properties/label",
+              "type": ["integer", "number", "string"],
+              "title": "The Label Schema",
+              "default": 0,
+              "examples": [
+                5
+              ]
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y4/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
@@ -3,7 +3,6 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "data",
     "meta"
@@ -12,11 +11,9 @@
     "data": {
       "$id": "#/properties/data",
       "type": "array",
-      "title": "The Data Schema",
       "items": {
         "$id": "#/properties/data/items",
         "type": "object",
-        "title": "The Items Schema",
         "required": [
           "x",
           "y0",
@@ -26,48 +23,23 @@
         "properties": {
           "y0": {
             "$id": "#/properties/data/items/properties/y0",
-            "type": "number",
-            "title": "The Y0 Schema",
-            "default": 0.0,
-            "examples": [
-              6913271.774814
-            ]
+            "type": "number"
           },
           "y1": {
             "$id": "#/properties/data/items/properties/y1",
-            "type": "number",
-            "title": "The Y1 Schema",
-            "default": 0.0,
-            "examples": [
-              7170873.080941
-            ]
+            "type": "number"
           },
           "y2": {
             "$id": "#/properties/data/items/properties/y2",
-            "type": "number",
-            "title": "The Y2 Schema",
-            "default": 0.0,
-            "examples": [
-              10910119.85475
-            ]
+            "type": "number"
           },
           "y3": {
             "$id": "#/properties/data/items/properties/y3",
-            "type": "number",
-            "title": "The Y3 Schema",
-            "default": 0.0,
-            "examples": [
-              20003570.43905
-            ]
+            "type": "number"
           },
           "x": {
             "$id": "#/properties/data/items/properties/x",
-            "type": "integer",
-            "title": "The X Schema",
-            "default": 0,
-            "examples": [
-              2015
-            ]
+            "type": "integer"
           }
         }
       }
@@ -75,7 +47,6 @@
     "meta": {
       "$id": "#/properties/meta",
       "type": "object",
-      "title": "The Meta Schema",
       "required": [
         "xAxis",
         "yAxis",
@@ -90,52 +61,37 @@
         "xAxis": {
           "$id": "#/properties/meta/properties/xAxis",
           "type": "object",
-          "title": "The Xaxis Schema",
           "required": [
+            "type",
             "label",
             "prefix",
             "format",
             "suffix"
           ],
           "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/xAxis/properties/type",
+              "type": "string",
+              "pattern": "^(.*)$"
+            },
             "label": {
               "$id": "#/properties/meta/properties/xAxis/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Year"
-              ],
               "pattern": "^(.*)$"
             },
             "prefix": {
               "$id": "#/properties/meta/properties/xAxis/properties/prefix",
               "type": "string",
-              "title": "The Prefix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "format": {
               "$id": "#/properties/meta/properties/xAxis/properties/format",
               "type": "string",
-              "title": "The Format Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "suffix": {
               "$id": "#/properties/meta/properties/xAxis/properties/suffix",
               "type": "string",
-              "title": "The Suffix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             }
           }
@@ -143,52 +99,46 @@
         "yAxis": {
           "$id": "#/properties/meta/properties/yAxis",
           "type": "object",
-          "title": "The Yaxis Schema",
           "required": [
+            "type",
             "label",
             "prefix",
             "format",
             "suffix"
           ],
           "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/yAxis/properties/type",
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "$id": "#/properties/meta/properties/yAxis/properties/type/properties/type",
+                  "type": "string",
+                  "pattern": "^(.*)$"
+                }
+              }
+            },
             "label": {
               "$id": "#/properties/meta/properties/yAxis/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Trade volume"
-              ],
               "pattern": "^(.*)$"
             },
             "prefix": {
               "$id": "#/properties/meta/properties/yAxis/properties/prefix",
               "type": "string",
-              "title": "The Prefix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "format": {
               "$id": "#/properties/meta/properties/yAxis/properties/format",
               "type": "string",
-              "title": "The Format Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "suffix": {
               "$id": "#/properties/meta/properties/yAxis/properties/suffix",
               "type": "string",
-              "title": "The Suffix Schema",
-              "default": "",
-              "examples": [
-                "t"
-              ],
               "pattern": "^(.*)$"
             }
           }
@@ -196,37 +146,19 @@
         "x": {
           "$id": "#/properties/meta/properties/x",
           "type": "object",
-          "title": "The X Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/x/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/x/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Year"
-              ],
               "pattern": "^(.*)$"
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/x/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -236,31 +168,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }
@@ -270,36 +187,18 @@
         "y0": {
           "$id": "#/properties/meta/properties/y0",
           "type": "object",
-          "title": "The Y0 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y0/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y0/properties/label",
-              "type": ["integer", "number", "string"],
-              "title": "The Label Schema",
-              "default": 0,
-              "examples": [
-                1
-              ]
+              "type": ["integer", "number", "string"]
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y0/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -309,31 +208,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }
@@ -343,36 +227,18 @@
         "y1": {
           "$id": "#/properties/meta/properties/y1",
           "type": "object",
-          "title": "The Y1 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y1/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y1/properties/label",
-              "type": ["integer", "number", "string"],
-              "title": "The Label Schema",
-              "default": 0,
-              "examples": [
-                2
-              ]
+              "type": ["integer", "number", "string"]
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y1/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -382,31 +248,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }
@@ -416,36 +267,18 @@
         "y2": {
           "$id": "#/properties/meta/properties/y2",
           "type": "object",
-          "title": "The Y2 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y2/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y2/properties/label",
-              "type": ["integer", "number", "string"],
-              "title": "The Label Schema",
-              "default": 0,
-              "examples": [
-                3
-              ]
+              "type": ["integer", "number", "string"]
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y2/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -455,31 +288,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }
@@ -489,36 +307,18 @@
         "y3": {
           "$id": "#/properties/meta/properties/y3",
           "type": "object",
-          "title": "The Y3 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y3/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y3/properties/label",
-              "type": ["integer", "number", "string"],
-              "title": "The Label Schema",
-              "default": 0,
-              "examples": [
-                4
-              ]
+              "type": ["integer", "number", "string"]
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y3/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -528,31 +328,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }
@@ -562,36 +347,18 @@
         "y4": {
           "$id": "#/properties/meta/properties/y4",
           "type": "object",
-          "title": "The Y4 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y4/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y4/properties/label",
-              "type": ["integer", "number", "string"],
-              "title": "The Label Schema",
-              "default": 0,
-              "examples": [
-                5
-              ]
+              "type": ["integer", "number", "string"]
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y4/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -601,31 +368,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
@@ -3,7 +3,6 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "data",
     "meta"
@@ -12,11 +11,9 @@
     "data": {
       "$id": "#/properties/data",
       "type": "array",
-      "title": "The Data Schema",
       "items": {
         "$id": "#/properties/data/items",
         "type": "object",
-        "title": "The Items Schema",
         "required": [
           "x",
           "y0"
@@ -24,21 +21,11 @@
         "properties": {
           "x": {
             "$id": "#/properties/data/items/properties/x",
-            "type": "integer",
-            "title": "The X Schema",
-            "default": 0,
-            "examples": [
-              2014
-            ]
+            "type": "integer"
           },
           "y0": {
             "$id": "#/properties/data/items/properties/y0",
-            "type": "number",
-            "title": "The Y0 Schema",
-            "default": 0.0,
-            "examples": [
-              86760519.9871819
-            ]
+            "type": "number"
           }
         }
       }
@@ -46,7 +33,6 @@
     "meta": {
       "$id": "#/properties/meta",
       "type": "object",
-      "title": "The Meta Schema",
       "required": [
         "xAxis",
         "yAxis",
@@ -57,52 +43,37 @@
         "xAxis": {
           "$id": "#/properties/meta/properties/xAxis",
           "type": "object",
-          "title": "The Xaxis Schema",
           "required": [
+            "type",
             "label",
             "prefix",
             "format",
             "suffix"
           ],
           "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/xAxis/properties/type",
+              "type": "string",
+              "pattern": "^(.*)$"
+            },
             "label": {
               "$id": "#/properties/meta/properties/xAxis/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Year"
-              ],
               "pattern": "^(.*)$"
             },
             "prefix": {
               "$id": "#/properties/meta/properties/xAxis/properties/prefix",
               "type": "string",
-              "title": "The Prefix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "format": {
               "$id": "#/properties/meta/properties/xAxis/properties/format",
               "type": "string",
-              "title": "The Format Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "suffix": {
               "$id": "#/properties/meta/properties/xAxis/properties/suffix",
               "type": "string",
-              "title": "The Suffix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             }
           }
@@ -110,52 +81,37 @@
         "yAxis": {
           "$id": "#/properties/meta/properties/yAxis",
           "type": "object",
-          "title": "The Yaxis Schema",
           "required": [
+            "type",
             "label",
             "prefix",
             "format",
             "suffix"
           ],
           "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/yAxis/properties/type",
+              "type": "string",
+              "pattern": "^(.*)$"
+            },
             "label": {
               "$id": "#/properties/meta/properties/yAxis/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Trade volume"
-              ],
               "pattern": "^(.*)$"
             },
             "prefix": {
               "$id": "#/properties/meta/properties/yAxis/properties/prefix",
               "type": "string",
-              "title": "The Prefix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "format": {
               "$id": "#/properties/meta/properties/yAxis/properties/format",
               "type": "string",
-              "title": "The Format Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "suffix": {
               "$id": "#/properties/meta/properties/yAxis/properties/suffix",
               "type": "string",
-              "title": "The Suffix Schema",
-              "default": "",
-              "examples": [
-                "t"
-              ],
               "pattern": "^(.*)$"
             }
           }
@@ -163,37 +119,19 @@
         "x": {
           "$id": "#/properties/meta/properties/x",
           "type": "object",
-          "title": "The X Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/x/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/x/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Year"
-              ],
               "pattern": "^(.*)$"
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/x/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -203,31 +141,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }
@@ -237,37 +160,19 @@
         "y0": {
           "$id": "#/properties/meta/properties/y0",
           "type": "object",
-          "title": "The Y0 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y0/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "number"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y0/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y0/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -277,31 +182,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
@@ -1,0 +1,314 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "$id": "#/properties/data",
+      "type": "array",
+      "title": "The Data Schema",
+      "items": {
+        "$id": "#/properties/data/items",
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "x",
+          "y0"
+        ],
+        "properties": {
+          "x": {
+            "$id": "#/properties/data/items/properties/x",
+            "type": "integer",
+            "title": "The X Schema",
+            "default": 0,
+            "examples": [
+              2014
+            ]
+          },
+          "y0": {
+            "$id": "#/properties/data/items/properties/y0",
+            "type": "number",
+            "title": "The Y0 Schema",
+            "default": 0.0,
+            "examples": [
+              86760519.9871819
+            ]
+          }
+        }
+      }
+    },
+    "meta": {
+      "$id": "#/properties/meta",
+      "type": "object",
+      "title": "The Meta Schema",
+      "required": [
+        "xAxis",
+        "yAxis",
+        "x",
+        "y0"
+      ],
+      "properties": {
+        "xAxis": {
+          "$id": "#/properties/meta/properties/xAxis",
+          "type": "object",
+          "title": "The Xaxis Schema",
+          "required": [
+            "label",
+            "prefix",
+            "format",
+            "suffix"
+          ],
+          "properties": {
+            "label": {
+              "$id": "#/properties/meta/properties/xAxis/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Year"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "prefix": {
+              "$id": "#/properties/meta/properties/xAxis/properties/prefix",
+              "type": "string",
+              "title": "The Prefix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "format": {
+              "$id": "#/properties/meta/properties/xAxis/properties/format",
+              "type": "string",
+              "title": "The Format Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "suffix": {
+              "$id": "#/properties/meta/properties/xAxis/properties/suffix",
+              "type": "string",
+              "title": "The Suffix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "yAxis": {
+          "$id": "#/properties/meta/properties/yAxis",
+          "type": "object",
+          "title": "The Yaxis Schema",
+          "required": [
+            "label",
+            "prefix",
+            "format",
+            "suffix"
+          ],
+          "properties": {
+            "label": {
+              "$id": "#/properties/meta/properties/yAxis/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Trade volume"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "prefix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/prefix",
+              "type": "string",
+              "title": "The Prefix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "format": {
+              "$id": "#/properties/meta/properties/yAxis/properties/format",
+              "type": "string",
+              "title": "The Format Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "suffix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/suffix",
+              "type": "string",
+              "title": "The Suffix Schema",
+              "default": "",
+              "examples": [
+                "t"
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "x": {
+          "$id": "#/properties/meta/properties/x",
+          "type": "object",
+          "title": "The X Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/x/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/x/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Year"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/x/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "y0": {
+          "$id": "#/properties/meta/properties/y0",
+          "type": "object",
+          "title": "The Y0 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y0/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "number"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y0/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y0/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
@@ -1,0 +1,314 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "$id": "#/properties/data",
+      "type": "array",
+      "title": "The Data Schema",
+      "items": {
+        "$id": "#/properties/data/items",
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "x",
+          "y0"
+        ],
+        "properties": {
+          "x": {
+            "$id": "#/properties/data/items/properties/x",
+            "type": "number",
+            "title": "The X Schema",
+            "default": 0,
+            "examples": [
+              1
+            ]
+          },
+          "y0": {
+            "$id": "#/properties/data/items/properties/y0",
+            "type": "number",
+            "title": "The Y0 Schema",
+            "default": 0.0,
+            "examples": [
+              6913271.77481399
+            ]
+          }
+        }
+      }
+    },
+    "meta": {
+      "$id": "#/properties/meta",
+      "type": "object",
+      "title": "The Meta Schema",
+      "required": [
+        "xAxis",
+        "yAxis",
+        "x",
+        "y0"
+      ],
+      "properties": {
+        "xAxis": {
+          "$id": "#/properties/meta/properties/xAxis",
+          "type": "object",
+          "title": "The Xaxis Schema",
+          "required": [
+            "label",
+            "prefix",
+            "format",
+            "suffix"
+          ],
+          "properties": {
+            "label": {
+              "$id": "#/properties/meta/properties/xAxis/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Forest 500 score"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "prefix": {
+              "$id": "#/properties/meta/properties/xAxis/properties/prefix",
+              "type": "string",
+              "title": "The Prefix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "format": {
+              "$id": "#/properties/meta/properties/xAxis/properties/format",
+              "type": "string",
+              "title": "The Format Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "suffix": {
+              "$id": "#/properties/meta/properties/xAxis/properties/suffix",
+              "type": "string",
+              "title": "The Suffix Schema",
+              "default": "",
+              "examples": [
+                "/5"
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "yAxis": {
+          "$id": "#/properties/meta/properties/yAxis",
+          "type": "object",
+          "title": "The Yaxis Schema",
+          "required": [
+            "label",
+            "prefix",
+            "format",
+            "suffix"
+          ],
+          "properties": {
+            "label": {
+              "$id": "#/properties/meta/properties/yAxis/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Trade volume"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "prefix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/prefix",
+              "type": "string",
+              "title": "The Prefix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "format": {
+              "$id": "#/properties/meta/properties/yAxis/properties/format",
+              "type": "string",
+              "title": "The Format Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "suffix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/suffix",
+              "type": "string",
+              "title": "The Suffix Schema",
+              "default": "",
+              "examples": [
+                "t"
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "x": {
+          "$id": "#/properties/meta/properties/x",
+          "type": "object",
+          "title": "The X Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/x/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "category"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/x/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Forest 500 score"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/x/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/x/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "y0": {
+          "$id": "#/properties/meta/properties/y0",
+          "type": "object",
+          "title": "The Y0 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y0/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "number"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y0/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Trade volume"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y0/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
@@ -3,7 +3,6 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "data",
     "meta"
@@ -12,11 +11,9 @@
     "data": {
       "$id": "#/properties/data",
       "type": "array",
-      "title": "The Data Schema",
       "items": {
         "$id": "#/properties/data/items",
         "type": "object",
-        "title": "The Items Schema",
         "required": [
           "x",
           "y0"
@@ -24,21 +21,11 @@
         "properties": {
           "x": {
             "$id": "#/properties/data/items/properties/x",
-            "type": "number",
-            "title": "The X Schema",
-            "default": 0,
-            "examples": [
-              1
-            ]
+            "type": "number"
           },
           "y0": {
             "$id": "#/properties/data/items/properties/y0",
-            "type": "number",
-            "title": "The Y0 Schema",
-            "default": 0.0,
-            "examples": [
-              6913271.77481399
-            ]
+            "type": "number"
           }
         }
       }
@@ -46,7 +33,6 @@
     "meta": {
       "$id": "#/properties/meta",
       "type": "object",
-      "title": "The Meta Schema",
       "required": [
         "xAxis",
         "yAxis",
@@ -57,52 +43,37 @@
         "xAxis": {
           "$id": "#/properties/meta/properties/xAxis",
           "type": "object",
-          "title": "The Xaxis Schema",
           "required": [
+            "type",
             "label",
             "prefix",
             "format",
             "suffix"
           ],
           "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/xAxis/properties/type",
+              "type": "string",
+              "pattern": "^(.*)$"
+            },
             "label": {
               "$id": "#/properties/meta/properties/xAxis/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Forest 500 score"
-              ],
               "pattern": "^(.*)$"
             },
             "prefix": {
               "$id": "#/properties/meta/properties/xAxis/properties/prefix",
               "type": "string",
-              "title": "The Prefix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "format": {
               "$id": "#/properties/meta/properties/xAxis/properties/format",
               "type": "string",
-              "title": "The Format Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "suffix": {
               "$id": "#/properties/meta/properties/xAxis/properties/suffix",
               "type": "string",
-              "title": "The Suffix Schema",
-              "default": "",
-              "examples": [
-                "/5"
-              ],
               "pattern": "^(.*)$"
             }
           }
@@ -110,52 +81,37 @@
         "yAxis": {
           "$id": "#/properties/meta/properties/yAxis",
           "type": "object",
-          "title": "The Yaxis Schema",
           "required": [
+            "type",
             "label",
             "prefix",
             "format",
             "suffix"
           ],
           "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/yAxis/properties/type",
+              "type": "string",
+              "pattern": "^(.*)$"
+            },
             "label": {
               "$id": "#/properties/meta/properties/yAxis/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Trade volume"
-              ],
               "pattern": "^(.*)$"
             },
             "prefix": {
               "$id": "#/properties/meta/properties/yAxis/properties/prefix",
               "type": "string",
-              "title": "The Prefix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "format": {
               "$id": "#/properties/meta/properties/yAxis/properties/format",
               "type": "string",
-              "title": "The Format Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "suffix": {
               "$id": "#/properties/meta/properties/yAxis/properties/suffix",
               "type": "string",
-              "title": "The Suffix Schema",
-              "default": "",
-              "examples": [
-                "t"
-              ],
               "pattern": "^(.*)$"
             }
           }
@@ -163,37 +119,19 @@
         "x": {
           "$id": "#/properties/meta/properties/x",
           "type": "object",
-          "title": "The X Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/x/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "category"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/x/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Forest 500 score"
-              ],
               "pattern": "^(.*)$"
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/x/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -203,31 +141,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/x/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }
@@ -237,37 +160,19 @@
         "y0": {
           "$id": "#/properties/meta/properties/y0",
           "type": "object",
-          "title": "The Y0 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y0/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "number"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y0/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Trade volume"
-              ],
               "pattern": "^(.*)$"
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y0/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -277,31 +182,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
@@ -1,0 +1,187 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "required": [
+    "data",
+    "meta"
+  ],
+  "properties": {
+    "data": {
+      "$id": "#/properties/data",
+      "type": "array",
+      "title": "The Data Schema",
+      "items": {
+        "$id": "#/properties/data/items",
+        "type": "object",
+        "title": "The Items Schema",
+        "required": [
+          "y0"
+        ],
+        "properties": {
+          "y0": {
+            "$id": "#/properties/data/items/properties/y0",
+            "type": "number",
+            "title": "The Y1 Schema",
+            "default": 0.0,
+            "examples": [
+              97464935.9917643
+            ]
+          }
+        }
+      }
+    },
+    "meta": {
+      "$id": "#/properties/meta",
+      "type": "object",
+      "title": "The Meta Schema",
+      "required": [
+        "xAxis",
+        "yAxis",
+        "x",
+        "y0"
+      ],
+      "properties": {
+        "xAxis": {
+          "$id": "#/properties/meta/properties/xAxis",
+          "type": "object",
+          "title": "The Xaxis Schema"
+        },
+        "yAxis": {
+          "$id": "#/properties/meta/properties/yAxis",
+          "type": "object",
+          "title": "The Yaxis Schema",
+          "required": [
+            "label",
+            "prefix",
+            "format",
+            "suffix"
+          ],
+          "properties": {
+            "label": {
+              "$id": "#/properties/meta/properties/yAxis/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                "Trade volume"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "prefix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/prefix",
+              "type": "string",
+              "title": "The Prefix Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "format": {
+              "$id": "#/properties/meta/properties/yAxis/properties/format",
+              "type": "string",
+              "title": "The Format Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "suffix": {
+              "$id": "#/properties/meta/properties/yAxis/properties/suffix",
+              "type": "string",
+              "title": "The Suffix Schema",
+              "default": "",
+              "examples": [
+                "t"
+              ],
+              "pattern": "^(.*)$"
+            }
+          }
+        },
+        "x": {
+          "$id": "#/properties/meta/properties/x",
+          "type": "object",
+          "title": "The X Schema"
+        },
+        "y0": {
+          "$id": "#/properties/meta/properties/y0",
+          "type": "object",
+          "title": "The Y1 Schema",
+          "required": [
+            "type",
+            "label",
+            "tooltip"
+          ],
+          "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/y0/properties/type",
+              "type": "string",
+              "title": "The Type Schema",
+              "default": "",
+              "examples": [
+                "number"
+              ],
+              "pattern": "^(.*)$"
+            },
+            "label": {
+              "$id": "#/properties/meta/properties/y0/properties/label",
+              "type": "string",
+              "title": "The Label Schema",
+              "default": "",
+              "examples": [
+                ""
+              ],
+              "pattern": "^(.*)$"
+            },
+            "tooltip": {
+              "$id": "#/properties/meta/properties/y0/properties/tooltip",
+              "type": "object",
+              "title": "The Tooltip Schema",
+              "required": [
+                "prefix",
+                "format",
+                "suffix"
+              ],
+              "properties": {
+                "prefix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
+                  "type": "string",
+                  "title": "The Prefix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "format": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
+                  "type": "string",
+                  "title": "The Format Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                },
+                "suffix": {
+                  "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
+                  "type": "string",
+                  "title": "The Suffix Schema",
+                  "default": "",
+                  "examples": [
+                    ""
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
@@ -3,7 +3,6 @@
   "$schema": "http://json-schema.org/draft-06/schema#",
   "$id": "http://example.com/root.json",
   "type": "object",
-  "title": "The Root Schema",
   "required": [
     "data",
     "meta"
@@ -12,23 +11,16 @@
     "data": {
       "$id": "#/properties/data",
       "type": "array",
-      "title": "The Data Schema",
       "items": {
         "$id": "#/properties/data/items",
         "type": "object",
-        "title": "The Items Schema",
         "required": [
           "y0"
         ],
         "properties": {
           "y0": {
             "$id": "#/properties/data/items/properties/y0",
-            "type": "number",
-            "title": "The Y1 Schema",
-            "default": 0.0,
-            "examples": [
-              97464935.9917643
-            ]
+            "type": "number"
           }
         }
       }
@@ -36,7 +28,6 @@
     "meta": {
       "$id": "#/properties/meta",
       "type": "object",
-      "title": "The Meta Schema",
       "required": [
         "xAxis",
         "yAxis",
@@ -46,101 +37,66 @@
       "properties": {
         "xAxis": {
           "$id": "#/properties/meta/properties/xAxis",
-          "type": "object",
-          "title": "The Xaxis Schema"
+          "type": "object"
         },
         "yAxis": {
           "$id": "#/properties/meta/properties/yAxis",
           "type": "object",
-          "title": "The Yaxis Schema",
           "required": [
+            "type",
             "label",
             "prefix",
             "format",
             "suffix"
           ],
           "properties": {
+            "type": {
+              "$id": "#/properties/meta/properties/yAxis/properties/type",
+              "type": "string",
+              "pattern": "^(.*)$"
+            },
             "label": {
               "$id": "#/properties/meta/properties/yAxis/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                "Trade volume"
-              ],
               "pattern": "^(.*)$"
             },
             "prefix": {
               "$id": "#/properties/meta/properties/yAxis/properties/prefix",
               "type": "string",
-              "title": "The Prefix Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "format": {
               "$id": "#/properties/meta/properties/yAxis/properties/format",
               "type": "string",
-              "title": "The Format Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "suffix": {
               "$id": "#/properties/meta/properties/yAxis/properties/suffix",
               "type": "string",
-              "title": "The Suffix Schema",
-              "default": "",
-              "examples": [
-                "t"
-              ],
               "pattern": "^(.*)$"
             }
           }
         },
         "x": {
           "$id": "#/properties/meta/properties/x",
-          "type": "object",
-          "title": "The X Schema"
+          "type": "object"
         },
         "y0": {
           "$id": "#/properties/meta/properties/y0",
           "type": "object",
-          "title": "The Y1 Schema",
           "required": [
-            "type",
             "label",
             "tooltip"
           ],
           "properties": {
-            "type": {
-              "$id": "#/properties/meta/properties/y0/properties/type",
-              "type": "string",
-              "title": "The Type Schema",
-              "default": "",
-              "examples": [
-                "number"
-              ],
-              "pattern": "^(.*)$"
-            },
             "label": {
               "$id": "#/properties/meta/properties/y0/properties/label",
               "type": "string",
-              "title": "The Label Schema",
-              "default": "",
-              "examples": [
-                ""
-              ],
               "pattern": "^(.*)$"
             },
             "tooltip": {
               "$id": "#/properties/meta/properties/y0/properties/tooltip",
               "type": "object",
-              "title": "The Tooltip Schema",
               "required": [
                 "prefix",
                 "format",
@@ -150,31 +106,16 @@
                 "prefix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/prefix",
                   "type": "string",
-                  "title": "The Prefix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "format": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/format",
                   "type": "string",
-                  "title": "The Format Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
                   "type": "string",
-                  "title": "The Suffix Schema",
-                  "default": "",
-                  "examples": [
-                    ""
-                  ],
                   "pattern": "^(.*)$"
                 }
               }

--- a/spec/support/schemas/dashboards_parametrised_charts.json
+++ b/spec/support/schemas/dashboards_parametrised_charts.json
@@ -1,0 +1,44 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.com/root.json",
+  "type": "object",
+  "required": [
+    "data"
+  ],
+  "properties": {
+    "data": {
+      "$id": "#/properties/data",
+      "type": "array",
+      "title": "The Data Schema",
+      "items": {
+        "$id": "#/properties/data/items",
+        "type": "object",
+        "required": [
+          "type",
+          "url"
+        ],
+        "properties": {
+          "type": {
+            "$id": "#/properties/data/items/properties/type",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "bar_chart"
+            ],
+            "pattern": "^(.*)$"
+          },
+          "url": {
+            "$id": "#/properties/data/items/properties/url",
+            "type": "string",
+            "default": "",
+            "examples": [
+              "http://localhost:3000/api/v3/dashboards/chart_data?chart_type=bar_chart&commodity_id=1&cont_attribute_id=1&country_id=27&start_year=2015&x=year&y=cont_attribute&y_id=1"
+            ],
+            "pattern": "^(.*)$"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds 4 "overview" chart endpoints, which return data for different types of charts, one per each of the 4 broad types of dashboards parameters selections:
1. when single year selected and no non-continuous indicator selected - dynamic sentence
2. when single year selected and a non-continous indicator selected - donut chart
3. when multiple years selected and no non-continuous indicator selected - vertical bar chart
4. when multiple years selected and a non-continuous indicator selected - vertical stacked bar chart

This corresponds to the [spec](https://docs.google.com/document/d/1jBMhDs4_51cW4xC3fSH2AboGj934OPh-DEMFPFyY7b0/edit?usp=sharing). Responses described in the swagger file.