### PR TITLE
Fixes exception when unknown nodes present

### DIFF
--- a/app/services/api/v3/actors/top_nodes_summary.rb
+++ b/app/services/api/v3/actors/top_nodes_summary.rb
@@ -107,7 +107,10 @@ module Api
               node_id: node['node_id'],
               geo_id: node['geo_id'],
               values: years.map do |year|
-                @top_node_values_by_year_hash[year][node['node_id']]
+                values_for_year = @top_node_values_by_year_hash[year]
+                next nil unless values_for_year
+
+                values_for_year[node['node_id']]
               end
             }
           end

--- a/spec/responses/api/v3/exporter_profile_spec.rb
+++ b/spec/responses/api/v3/exporter_profile_spec.rb
@@ -52,6 +52,38 @@ RSpec.describe 'Exporter profile', type: :request do
   end
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/top_sources' do
+    let(:unknown_municipality) {
+      FactoryBot.create(
+        :api_v3_node,
+        node_type: api_v3_municipality_node_type,
+        is_unknown: true
+      )
+    }
+    let!(:flow_2014) {
+      FactoryBot.create(
+        :api_v3_flow,
+        context: api_v3_context,
+        path: [
+          api_v3_biome_node,
+          api_v3_state_node,
+          unknown_municipality,
+          api_v3_logistics_hub_node,
+          api_v3_port1_node,
+          api_v3_exporter1_node,
+          api_v3_importer1_node,
+          api_v3_country_of_destination1_node
+        ].map(&:id),
+        year: 2014
+      )
+    }
+    let!(:flow_2014_volume) {
+      FactoryBot.create(
+        :api_v3_flow_quant,
+        flow: flow_2014,
+        quant: api_v3_volume,
+        value: 10
+      )
+    }
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_exporter1_node.id}/top_sources", params: summary_params
 

--- a/spec/responses/api/v3/importer_profile_spec.rb
+++ b/spec/responses/api/v3/importer_profile_spec.rb
@@ -52,6 +52,38 @@ RSpec.describe 'Importer profile', type: :request do
   end
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/top_sources' do
+    let(:unknown_municipality) {
+      FactoryBot.create(
+        :api_v3_node,
+        node_type: api_v3_municipality_node_type,
+        is_unknown: true
+      )
+    }
+    let!(:flow_2014) {
+      FactoryBot.create(
+        :api_v3_flow,
+        context: api_v3_context,
+        path: [
+          api_v3_biome_node,
+          api_v3_state_node,
+          unknown_municipality,
+          api_v3_logistics_hub_node,
+          api_v3_port1_node,
+          api_v3_exporter1_node,
+          api_v3_importer1_node,
+          api_v3_country_of_destination1_node
+        ].map(&:id),
+        year: 2014
+      )
+    }
+    let!(:flow_2014_volume) {
+      FactoryBot.create(
+        :api_v3_flow_quant,
+        flow: flow_2014,
+        quant: api_v3_volume,
+        value: 10
+      )
+    }
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/top_sources", params: summary_params
 

--- a/spec/support/schemas/v3_actor_top_sources.json
+++ b/spec/support/schemas/v3_actor_top_sources.json
@@ -64,7 +64,7 @@
                   },
                   "geo_id": {
                     "$id": "/properties/data/properties/municipality/properties/lines/items/properties/geo_id",
-                    "type": "string",
+                    "type": ["string", "null"],
                     "title": "The Geo_id Schema ",
                     "default": "",
                     "examples": [
@@ -76,7 +76,7 @@
                     "type": "array",
                     "items": {
                       "$id": "/properties/data/properties/municipality/properties/lines/items/properties/values/items",
-                      "type": "number",
+                      "type": ["number", "null"],
                       "title": "The 0th Schema ",
                       "default": 0,
                       "examples": [


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/164576161

The problem was due to "unknown" municipalities in the flow path. This is an example of the top sources chart which illustrates what happens:

top states:
<img width="709" alt="Screenshot 2019-03-20 at 08 39 43" src="https://user-images.githubusercontent.com/134055/54670575-d8686100-4aeb-11e9-908c-d6f43370a14e.png">

top municipalities:
<img width="696" alt="Screenshot 2019-03-20 at 08 39 52" src="https://user-images.githubusercontent.com/134055/54670590-e3bb8c80-4aeb-11e9-9b52-80dc82af1856.png">

In year 2003 there is a dot present on the state chart for Rio grande do sul, but no data on the municipality chart. This is because the municipalities involved in the 2003 flows are "unknown" (only state is known), and so were filtered out from the chart. That caused an exception when retrieving municipality data for 2003.

