### PR TITLE
Fix uniqueness on materialized views

### DIFF
--- a/app/models/api/v3/ind_commodity_property.rb
+++ b/app/models/api/v3/ind_commodity_property.rb
@@ -3,9 +3,9 @@
 # Table name: ind_commodity_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  commodity_id :bigint(8)
-#  ind_id       :bigint(8)
+#  tooltip_text :text             not null
+#  commodity_id :bigint(8)        not null
+#  ind_id       :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (commodity_id => commodities.id)
-#  fk_rails_...  (ind_id => inds.id)
+#  fk_rails_...  (commodity_id => commodities.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (ind_id => inds.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/ind_context_property.rb
+++ b/app/models/api/v3/ind_context_property.rb
@@ -3,9 +3,9 @@
 # Table name: ind_context_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  context_id   :bigint(8)
-#  ind_id       :bigint(8)
+#  tooltip_text :text             not null
+#  context_id   :bigint(8)        not null
+#  ind_id       :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (context_id => contexts.id)
-#  fk_rails_...  (ind_id => inds.id)
+#  fk_rails_...  (context_id => contexts.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (ind_id => inds.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/ind_country_property.rb
+++ b/app/models/api/v3/ind_country_property.rb
@@ -3,9 +3,9 @@
 # Table name: ind_country_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  country_id   :bigint(8)
-#  ind_id       :bigint(8)
+#  tooltip_text :text             not null
+#  country_id   :bigint(8)        not null
+#  ind_id       :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (country_id => countries.id)
-#  fk_rails_...  (ind_id => inds.id)
+#  fk_rails_...  (country_id => countries.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (ind_id => inds.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/qual_commodity_property.rb
+++ b/app/models/api/v3/qual_commodity_property.rb
@@ -3,9 +3,9 @@
 # Table name: qual_commodity_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  commodity_id :bigint(8)
-#  qual_id      :bigint(8)
+#  tooltip_text :text             not null
+#  commodity_id :bigint(8)        not null
+#  qual_id      :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (commodity_id => commodities.id)
-#  fk_rails_...  (qual_id => quals.id)
+#  fk_rails_...  (commodity_id => commodities.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (qual_id => quals.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/qual_context_property.rb
+++ b/app/models/api/v3/qual_context_property.rb
@@ -3,9 +3,9 @@
 # Table name: qual_context_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  context_id   :bigint(8)
-#  qual_id      :bigint(8)
+#  tooltip_text :text             not null
+#  context_id   :bigint(8)        not null
+#  qual_id      :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (context_id => contexts.id)
-#  fk_rails_...  (qual_id => quals.id)
+#  fk_rails_...  (context_id => contexts.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (qual_id => quals.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/qual_country_property.rb
+++ b/app/models/api/v3/qual_country_property.rb
@@ -3,9 +3,9 @@
 # Table name: qual_country_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  country_id   :bigint(8)
-#  qual_id      :bigint(8)
+#  tooltip_text :text             not null
+#  country_id   :bigint(8)        not null
+#  qual_id      :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (country_id => countries.id)
-#  fk_rails_...  (qual_id => quals.id)
+#  fk_rails_...  (country_id => countries.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (qual_id => quals.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/quant_commodity_property.rb
+++ b/app/models/api/v3/quant_commodity_property.rb
@@ -3,9 +3,9 @@
 # Table name: quant_commodity_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  commodity_id :bigint(8)
-#  quant_id     :bigint(8)
+#  tooltip_text :text             not null
+#  commodity_id :bigint(8)        not null
+#  quant_id     :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (commodity_id => commodities.id)
-#  fk_rails_...  (quant_id => quants.id)
+#  fk_rails_...  (commodity_id => commodities.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (quant_id => quants.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/quant_context_property.rb
+++ b/app/models/api/v3/quant_context_property.rb
@@ -3,9 +3,9 @@
 # Table name: quant_context_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  context_id   :bigint(8)
-#  quant_id     :bigint(8)
+#  tooltip_text :text             not null
+#  context_id   :bigint(8)        not null
+#  quant_id     :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (context_id => contexts.id)
-#  fk_rails_...  (quant_id => quants.id)
+#  fk_rails_...  (context_id => contexts.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (quant_id => quants.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/quant_country_property.rb
+++ b/app/models/api/v3/quant_country_property.rb
@@ -3,9 +3,9 @@
 # Table name: quant_country_properties
 #
 #  id           :bigint(8)        not null, primary key
-#  tooltip_text :text
-#  country_id   :bigint(8)
-#  quant_id     :bigint(8)
+#  tooltip_text :text             not null
+#  country_id   :bigint(8)        not null
+#  quant_id     :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
@@ -16,8 +16,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (country_id => countries.id)
-#  fk_rails_...  (quant_id => quants.id)
+#  fk_rails_...  (country_id => countries.id) ON DELETE => cascade ON UPDATE => cascade
+#  fk_rails_...  (quant_id => quants.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api

--- a/app/models/api/v3/readonly/commodity_attribute_property.rb
+++ b/app/models/api/v3/readonly/commodity_attribute_property.rb
@@ -11,7 +11,9 @@
 #
 # Indexes
 #
-#  index_commodity_attribute_properties_mv_id_idx  (id) UNIQUE
+#  index_commodity_ind_attribute_properties_mv_id    (id,commodity_id,ind_id) UNIQUE
+#  index_commodity_qual_attribute_properties_mv_id   (id,commodity_id,qual_id) UNIQUE
+#  index_commodity_quant_attribute_properties_mv_id  (id,commodity_id,quant_id) UNIQUE
 #
 
 module Api

--- a/app/models/api/v3/readonly/context_attribute_property.rb
+++ b/app/models/api/v3/readonly/context_attribute_property.rb
@@ -11,7 +11,9 @@
 #
 # Indexes
 #
-#  index_context_attribute_properties_mv_id_idx  (id) UNIQUE
+#  index_context_ind_attribute_properties_mv_id    (id,context_id,ind_id) UNIQUE
+#  index_context_qual_attribute_properties_mv_id   (id,context_id,qual_id) UNIQUE
+#  index_context_quant_attribute_properties_mv_id  (id,context_id,quant_id) UNIQUE
 #
 
 module Api

--- a/app/models/api/v3/readonly/country_attribute_property.rb
+++ b/app/models/api/v3/readonly/country_attribute_property.rb
@@ -11,7 +11,9 @@
 #
 # Indexes
 #
-#  index_country_attribute_properties_mv_id_idx  (id) UNIQUE
+#  index_country_ind_attribute_properties_mv_id    (id,country_id,ind_id) UNIQUE
+#  index_country_qual_attribute_properties_mv_id   (id,country_id,qual_id) UNIQUE
+#  index_country_quant_attribute_properties_mv_id  (id,country_id,quant_id) UNIQUE
 #
 
 module Api

--- a/db/migrate/20190320122547_remove_uniqueness_id_constraint_from_m_vs.rb
+++ b/db/migrate/20190320122547_remove_uniqueness_id_constraint_from_m_vs.rb
@@ -1,0 +1,27 @@
+class RemoveUniquenessIdConstraintFromMVs < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :context_attribute_properties_mv, :id
+    add_index :context_attribute_properties_mv, [:id, :context_id, :qual_id], unique: true,
+      name: 'index_context_qual_attribute_properties_mv_id'
+    add_index :context_attribute_properties_mv, [:id, :context_id, :quant_id], unique: true,
+      name: 'index_context_quant_attribute_properties_mv_id'
+    add_index :context_attribute_properties_mv, [:id, :context_id, :ind_id], unique: true,
+      name: 'index_context_ind_attribute_properties_mv_id'
+    
+    remove_index :country_attribute_properties_mv, :id
+    add_index :country_attribute_properties_mv, [:id, :country_id, :qual_id], unique: true,
+      name: 'index_country_qual_attribute_properties_mv_id'
+    add_index :country_attribute_properties_mv, [:id, :country_id, :quant_id], unique: true,
+      name: 'index_country_quant_attribute_properties_mv_id'
+    add_index :country_attribute_properties_mv, [:id, :country_id, :ind_id], unique: true,
+      name: 'index_country_ind_attribute_properties_mv_id'
+    
+    remove_index :commodity_attribute_properties_mv, :id
+    add_index :commodity_attribute_properties_mv, [:id, :commodity_id, :qual_id], unique: true,
+      name: 'index_commodity_qual_attribute_properties_mv_id'
+    add_index :commodity_attribute_properties_mv, [:id, :commodity_id, :quant_id], unique: true,
+      name: 'index_commodity_quant_attribute_properties_mv_id'
+    add_index :commodity_attribute_properties_mv, [:id, :commodity_id, :ind_id], unique: true,
+      name: 'index_commodity_ind_attribute_properties_mv_id'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7140,17 +7140,31 @@ CREATE INDEX index_charts_on_profile_id ON public.charts USING btree (profile_id
 
 
 --
--- Name: index_commodity_attribute_properties_mv_id_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: index_commodity_ind_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commodity_attribute_properties_mv_id_idx ON public.commodity_attribute_properties_mv USING btree (id);
+CREATE UNIQUE INDEX index_commodity_ind_attribute_properties_mv_id ON public.commodity_attribute_properties_mv USING btree (id, commodity_id, ind_id);
 
 
 --
--- Name: index_context_attribute_properties_mv_id_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: index_commodity_qual_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_context_attribute_properties_mv_id_idx ON public.context_attribute_properties_mv USING btree (id);
+CREATE UNIQUE INDEX index_commodity_qual_attribute_properties_mv_id ON public.commodity_attribute_properties_mv USING btree (id, commodity_id, qual_id);
+
+
+--
+-- Name: index_commodity_quant_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_commodity_quant_attribute_properties_mv_id ON public.commodity_attribute_properties_mv USING btree (id, commodity_id, quant_id);
+
+
+--
+-- Name: index_context_ind_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_context_ind_attribute_properties_mv_id ON public.context_attribute_properties_mv USING btree (id, context_id, ind_id);
 
 
 --
@@ -7182,6 +7196,20 @@ CREATE INDEX index_context_properties_on_context_id ON public.context_properties
 
 
 --
+-- Name: index_context_qual_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_context_qual_attribute_properties_mv_id ON public.context_attribute_properties_mv USING btree (id, context_id, qual_id);
+
+
+--
+-- Name: index_context_quant_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_context_quant_attribute_properties_mv_id ON public.context_attribute_properties_mv USING btree (id, context_id, quant_id);
+
+
+--
 -- Name: index_contexts_on_commodity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7203,10 +7231,10 @@ CREATE INDEX index_contextual_layers_on_context_id ON public.contextual_layers U
 
 
 --
--- Name: index_country_attribute_properties_mv_id_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: index_country_ind_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_country_attribute_properties_mv_id_idx ON public.country_attribute_properties_mv USING btree (id);
+CREATE UNIQUE INDEX index_country_ind_attribute_properties_mv_id ON public.country_attribute_properties_mv USING btree (id, country_id, ind_id);
 
 
 --
@@ -7214,6 +7242,20 @@ CREATE UNIQUE INDEX index_country_attribute_properties_mv_id_idx ON public.count
 --
 
 CREATE INDEX index_country_properties_on_country_id ON public.country_properties USING btree (country_id);
+
+
+--
+-- Name: index_country_qual_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_country_qual_attribute_properties_mv_id ON public.country_attribute_properties_mv USING btree (id, country_id, qual_id);
+
+
+--
+-- Name: index_country_quant_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_country_quant_attribute_properties_mv_id ON public.country_attribute_properties_mv USING btree (id, country_id, quant_id);
 
 
 --
@@ -8582,6 +8624,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190301173748'),
 ('20190301173808'),
 ('20190301173824'),
-('20190308163938');
+('20190308163938'),
+('20190320122547');
 
 


### PR DESCRIPTION
Remove all unique indexes from context/commodity/country attributes properties materialized views (uniqueness only on `:id` which was causing an error -> https://www.pivotaltracker.com/n/projects/1637931/stories/164764230) and instead add uniqueness keys on more than one column.