### PR TITLE
Fix/filter recolor by options by context

### DIFF
--- a/app/models/api/v3/readonly/recolor_by_attribute.rb
+++ b/app/models/api/v3/readonly/recolor_by_attribute.rb
@@ -19,6 +19,7 @@
 #  created_at         :datetime
 #  updated_at         :datetime
 #  attribute_id       :bigint(8)
+#  legend             :text             is an Array
 #
 # Indexes
 #

--- a/app/models/api/v3/recolor_by_attribute.rb
+++ b/app/models/api/v3/recolor_by_attribute.rb
@@ -54,6 +54,9 @@ module Api
       belongs_to :context
       has_one :recolor_by_ind, autosave: true
       has_one :recolor_by_qual, autosave: true
+      has_one :readonly_recolor_by_attribute,
+              class_name: 'Api::V3::Readonly::RecolorByAttribute',
+              foreign_key: :id
 
       validates :context, presence: true
       validates :group_number, presence: true

--- a/app/serializers/api/v3/contexts/recolor_by_attribute_serializer.rb
+++ b/app/serializers/api/v3/contexts/recolor_by_attribute_serializer.rb
@@ -13,17 +13,9 @@ module Api
         end
 
         attribute :nodes do
-          flows = []
-          if object.legend_type.eql? 'qual'
-            FlowQual.distinct.select('value').
-              where(
-                'qual_id = ? AND value NOT LIKE \'UNKNOWN%\'',
-                object.original_id
-              ).each do |flow|
-              flows.push(flow.value)
-            end
-          end
-          flows
+          next [] unless object.legend_type.eql? 'qual'
+
+          object.legend
         end
       end
     end

--- a/db/migrate/20190320172713_add_legend_to_recolor_by_attributes_mv.rb
+++ b/db/migrate/20190320172713_add_legend_to_recolor_by_attributes_mv.rb
@@ -1,0 +1,8 @@
+class AddLegendToRecolorByAttributesMv < ActiveRecord::Migration[5.2]
+  def change
+    update_view :recolor_by_attributes_mv,
+            version: 3,
+            revert_to_version: 2,
+            materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -485,7 +485,7 @@ COMMENT ON COLUMN public.ind_properties.unit_type IS 'Type of unit, e.g. score. 
 -- Name: COLUMN ind_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.ind_properties.tooltip_text IS 'Tooltip text';
+COMMENT ON COLUMN public.ind_properties.tooltip_text IS 'Generic tooltip text (lowest precedence)';
 
 
 --
@@ -578,7 +578,7 @@ COMMENT ON COLUMN public.qual_properties.display_name IS 'Name of attribute for 
 -- Name: COLUMN qual_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.qual_properties.tooltip_text IS 'Tooltip text';
+COMMENT ON COLUMN public.qual_properties.tooltip_text IS 'Generic tooltip text (lowest precedence)';
 
 
 --
@@ -658,7 +658,7 @@ COMMENT ON COLUMN public.quant_properties.unit_type IS 'Type of unit, e.g. count
 -- Name: COLUMN quant_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.quant_properties.tooltip_text IS 'Tooltip text';
+COMMENT ON COLUMN public.quant_properties.tooltip_text IS 'Generic tooltip text (lowest precedence)';
 
 
 --
@@ -1376,6 +1376,34 @@ CREATE TABLE public.ind_commodity_properties (
 
 
 --
+-- Name: TABLE ind_commodity_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.ind_commodity_properties IS 'Commodity specific properties for ind';
+
+
+--
+-- Name: COLUMN ind_commodity_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_commodity_properties.tooltip_text IS 'Commodity-specific tooltips are the third-most specific tooltips that can be defined after context and country-specific tooltips; in absence of a commodity-specific tooltip, a generic tooltip will be used.';
+
+
+--
+-- Name: COLUMN ind_commodity_properties.commodity_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_commodity_properties.commodity_id IS 'Reference to commodity';
+
+
+--
+-- Name: COLUMN ind_commodity_properties.ind_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_commodity_properties.ind_id IS 'Reference to ind';
+
+
+--
 -- Name: qual_commodity_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1390,6 +1418,34 @@ CREATE TABLE public.qual_commodity_properties (
 
 
 --
+-- Name: TABLE qual_commodity_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.qual_commodity_properties IS 'Commodity specific properties for qual';
+
+
+--
+-- Name: COLUMN qual_commodity_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_commodity_properties.tooltip_text IS 'Commodity-specific tooltips are the third-most specific tooltips that can be defined after context and country-specific tooltips; in absence of a commodity-specific tooltip, a generic tooltip will be used.';
+
+
+--
+-- Name: COLUMN qual_commodity_properties.commodity_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_commodity_properties.commodity_id IS 'Reference to commodity';
+
+
+--
+-- Name: COLUMN qual_commodity_properties.qual_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_commodity_properties.qual_id IS 'Reference to qual';
+
+
+--
 -- Name: quant_commodity_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1401,6 +1457,34 @@ CREATE TABLE public.quant_commodity_properties (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
+
+
+--
+-- Name: TABLE quant_commodity_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.quant_commodity_properties IS 'Commodity specific properties for quant';
+
+
+--
+-- Name: COLUMN quant_commodity_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_commodity_properties.tooltip_text IS 'Commodity-specific tooltips are the third-most specific tooltips that can be defined after context and country-specific tooltips; in absence of a commodity-specific tooltip, a generic tooltip will be used.';
+
+
+--
+-- Name: COLUMN quant_commodity_properties.commodity_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_commodity_properties.commodity_id IS 'Reference to commodity';
+
+
+--
+-- Name: COLUMN quant_commodity_properties.quant_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_commodity_properties.quant_id IS 'Reference to quant';
 
 
 --
@@ -1435,6 +1519,48 @@ UNION ALL
 
 
 --
+-- Name: MATERIALIZED VIEW commodity_attribute_properties_mv; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON MATERIALIZED VIEW public.commodity_attribute_properties_mv IS 'Materialized view combining commodity specific properties for inds, quals and quants.';
+
+
+--
+-- Name: COLUMN commodity_attribute_properties_mv.commodity_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.commodity_attribute_properties_mv.commodity_id IS 'Reference to commodity';
+
+
+--
+-- Name: COLUMN commodity_attribute_properties_mv.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.commodity_attribute_properties_mv.tooltip_text IS 'Tooltip text';
+
+
+--
+-- Name: COLUMN commodity_attribute_properties_mv.qual_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.commodity_attribute_properties_mv.qual_id IS 'Reference to qual';
+
+
+--
+-- Name: COLUMN commodity_attribute_properties_mv.ind_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.commodity_attribute_properties_mv.ind_id IS 'Reference to ind';
+
+
+--
+-- Name: COLUMN commodity_attribute_properties_mv.quant_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.commodity_attribute_properties_mv.quant_id IS 'Reference to quant';
+
+
+--
 -- Name: ind_context_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1446,6 +1572,34 @@ CREATE TABLE public.ind_context_properties (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
+
+
+--
+-- Name: TABLE ind_context_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.ind_context_properties IS 'Context specific properties for ind (like tooltip text)';
+
+
+--
+-- Name: COLUMN ind_context_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_context_properties.tooltip_text IS 'Context-specific tooltips are the most specific tooltips that can be defined; in absence of a context-specific tooltip, a country-specific tooltip will be used (if any).';
+
+
+--
+-- Name: COLUMN ind_context_properties.context_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_context_properties.context_id IS 'Reference to context';
+
+
+--
+-- Name: COLUMN ind_context_properties.ind_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_context_properties.ind_id IS 'Reference to ind';
 
 
 --
@@ -1463,6 +1617,34 @@ CREATE TABLE public.qual_context_properties (
 
 
 --
+-- Name: TABLE qual_context_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.qual_context_properties IS 'Context specific properties for qual (like tooltip text)';
+
+
+--
+-- Name: COLUMN qual_context_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_context_properties.tooltip_text IS 'Context-specific tooltips are the most specific tooltips that can be defined; in absence of a context-specific tooltip, a country-specific tooltip will be used (if any).';
+
+
+--
+-- Name: COLUMN qual_context_properties.context_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_context_properties.context_id IS 'Reference to context';
+
+
+--
+-- Name: COLUMN qual_context_properties.qual_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_context_properties.qual_id IS 'Reference to qual';
+
+
+--
 -- Name: quant_context_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1474,6 +1656,34 @@ CREATE TABLE public.quant_context_properties (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
+
+
+--
+-- Name: TABLE quant_context_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.quant_context_properties IS 'Context specific properties for quant (like tooltip text)';
+
+
+--
+-- Name: COLUMN quant_context_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_context_properties.tooltip_text IS 'Context-specific tooltips are the most specific tooltips that can be defined; in absence of a context-specific tooltip, a country-specific tooltip will be used (if any).';
+
+
+--
+-- Name: COLUMN quant_context_properties.context_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_context_properties.context_id IS 'Reference to context';
+
+
+--
+-- Name: COLUMN quant_context_properties.quant_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_context_properties.quant_id IS 'Reference to quant';
 
 
 --
@@ -1505,6 +1715,48 @@ UNION ALL
     '-1'::integer AS quant_id
    FROM public.ind_context_properties
   WITH DATA;
+
+
+--
+-- Name: MATERIALIZED VIEW context_attribute_properties_mv; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON MATERIALIZED VIEW public.context_attribute_properties_mv IS 'Materialized view combining context specific properties for inds, quals and quants.';
+
+
+--
+-- Name: COLUMN context_attribute_properties_mv.context_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_attribute_properties_mv.context_id IS 'Reference to context';
+
+
+--
+-- Name: COLUMN context_attribute_properties_mv.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_attribute_properties_mv.tooltip_text IS 'Tooltip text';
+
+
+--
+-- Name: COLUMN context_attribute_properties_mv.qual_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_attribute_properties_mv.qual_id IS 'Reference to qual';
+
+
+--
+-- Name: COLUMN context_attribute_properties_mv.ind_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_attribute_properties_mv.ind_id IS 'Reference to ind';
+
+
+--
+-- Name: COLUMN context_attribute_properties_mv.quant_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_attribute_properties_mv.quant_id IS 'Reference to quant';
 
 
 --
@@ -1963,6 +2215,34 @@ CREATE TABLE public.ind_country_properties (
 
 
 --
+-- Name: TABLE ind_country_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.ind_country_properties IS 'Country specific properties for ind';
+
+
+--
+-- Name: COLUMN ind_country_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_country_properties.tooltip_text IS 'Country-specific tooltips are the second-most specific tooltips that can be defined after context-specific tooltips; in absence of a country-specific tooltip, a commodity-specific tooltip will be used (if any).';
+
+
+--
+-- Name: COLUMN ind_country_properties.country_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_country_properties.country_id IS 'Reference to country';
+
+
+--
+-- Name: COLUMN ind_country_properties.ind_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.ind_country_properties.ind_id IS 'Reference to ind';
+
+
+--
 -- Name: qual_country_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1977,6 +2257,34 @@ CREATE TABLE public.qual_country_properties (
 
 
 --
+-- Name: TABLE qual_country_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.qual_country_properties IS 'Country specific properties for qual';
+
+
+--
+-- Name: COLUMN qual_country_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_country_properties.tooltip_text IS 'Country-specific tooltips are the second-most specific tooltips that can be defined after context-specific tooltips; in absence of a country-specific tooltip, a commodity-specific tooltip will be used (if any).';
+
+
+--
+-- Name: COLUMN qual_country_properties.country_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_country_properties.country_id IS 'Reference to country';
+
+
+--
+-- Name: COLUMN qual_country_properties.qual_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.qual_country_properties.qual_id IS 'Reference to qual';
+
+
+--
 -- Name: quant_country_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1988,6 +2296,34 @@ CREATE TABLE public.quant_country_properties (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
+
+
+--
+-- Name: TABLE quant_country_properties; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.quant_country_properties IS 'Country specific properties for quant';
+
+
+--
+-- Name: COLUMN quant_country_properties.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_country_properties.tooltip_text IS 'Country-specific tooltips are the second-most specific tooltips that can be defined after context-specific tooltips; in absence of a country-specific tooltip, a commodity-specific tooltip will be used (if any).';
+
+
+--
+-- Name: COLUMN quant_country_properties.country_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_country_properties.country_id IS 'Reference to country';
+
+
+--
+-- Name: COLUMN quant_country_properties.quant_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.quant_country_properties.quant_id IS 'Reference to quant';
 
 
 --
@@ -2019,6 +2355,48 @@ UNION ALL
     '-1'::integer AS quant_id
    FROM public.ind_country_properties
   WITH DATA;
+
+
+--
+-- Name: MATERIALIZED VIEW country_attribute_properties_mv; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON MATERIALIZED VIEW public.country_attribute_properties_mv IS 'Materialized view combining country specific properties for inds, quals and quants.';
+
+
+--
+-- Name: COLUMN country_attribute_properties_mv.country_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.country_attribute_properties_mv.country_id IS 'Reference to country';
+
+
+--
+-- Name: COLUMN country_attribute_properties_mv.tooltip_text; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.country_attribute_properties_mv.tooltip_text IS 'Tooltip text';
+
+
+--
+-- Name: COLUMN country_attribute_properties_mv.qual_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.country_attribute_properties_mv.qual_id IS 'Reference to qual';
+
+
+--
+-- Name: COLUMN country_attribute_properties_mv.ind_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.country_attribute_properties_mv.ind_id IS 'Reference to ind';
+
+
+--
+-- Name: COLUMN country_attribute_properties_mv.quant_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.country_attribute_properties_mv.quant_id IS 'Reference to quant';
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -770,7 +770,7 @@ CREATE MATERIALIZED VIEW public.attributes_mv AS
             NULL::text AS text
            FROM (public.quals
              LEFT JOIN public.qual_properties qp ON ((qp.qual_id = quals.id)))) s
-  WITH DATA;
+  WITH NO DATA;
 
 
 --
@@ -1102,7 +1102,7 @@ UNION ALL
    FROM ((public.chart_inds chi
      JOIN public.chart_attributes cha ON ((cha.id = chi.chart_attribute_id)))
      JOIN public.attributes_mv a ON (((a.original_id = chi.ind_id) AND (a.original_type = 'Ind'::text))))
-  WITH DATA;
+  WITH NO DATA;
 
 
 --
@@ -1515,7 +1515,7 @@ UNION ALL
     ind_commodity_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_commodity_properties
-  WITH DATA;
+  WITH NO DATA;
 
 
 --
@@ -1714,7 +1714,7 @@ UNION ALL
     ind_context_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_context_properties
-  WITH DATA;
+  WITH NO DATA;
 
 
 --
@@ -2354,7 +2354,7 @@ UNION ALL
     ind_country_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_country_properties
-  WITH DATA;
+  WITH NO DATA;
 
 
 --
@@ -5174,6 +5174,25 @@ COMMENT ON TABLE public.recolor_by_inds IS 'Inds available for recoloring (see r
 
 
 --
+-- Name: recolor_by_inds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.recolor_by_inds_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: recolor_by_inds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.recolor_by_inds_id_seq OWNED BY public.recolor_by_inds.id;
+
+
+--
 -- Name: recolor_by_quals; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5191,88 +5210,6 @@ CREATE TABLE public.recolor_by_quals (
 --
 
 COMMENT ON TABLE public.recolor_by_quals IS 'Quals available for recoloring (see recolor_by_attributes.)';
-
-
---
--- Name: recolor_by_attributes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW public.recolor_by_attributes_mv AS
- SELECT ra.id,
-    ra.context_id,
-    ra.group_number,
-    ra."position",
-    ra.legend_type,
-    ra.legend_color_theme,
-    ra.interval_count,
-    ra.min_value,
-    ra.max_value,
-    ra.divisor,
-    ra.tooltip_text,
-    ra.years,
-    ra.is_disabled,
-    ra.is_default,
-    ra.created_at,
-    ra.updated_at,
-    a.id AS attribute_id
-   FROM ((public.recolor_by_inds rai
-     JOIN public.recolor_by_attributes ra ON ((ra.id = rai.recolor_by_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = rai.ind_id) AND (a.original_type = 'Ind'::text))))
-UNION ALL
- SELECT ra.id,
-    ra.context_id,
-    ra.group_number,
-    ra."position",
-    ra.legend_type,
-    ra.legend_color_theme,
-    ra.interval_count,
-    ra.min_value,
-    ra.max_value,
-    ra.divisor,
-    ra.tooltip_text,
-    ra.years,
-    ra.is_disabled,
-    ra.is_default,
-    ra.created_at,
-    ra.updated_at,
-    a.id AS attribute_id
-   FROM ((public.recolor_by_quals raq
-     JOIN public.recolor_by_attributes ra ON ((ra.id = raq.recolor_by_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = raq.qual_id) AND (a.original_type = 'Qual'::text))))
-  WITH NO DATA;
-
-
---
--- Name: MATERIALIZED VIEW recolor_by_attributes_mv; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON MATERIALIZED VIEW public.recolor_by_attributes_mv IS 'Materialized view which merges recolor_by_inds and recolor_by_quals with recolor_by_attributes.';
-
-
---
--- Name: COLUMN recolor_by_attributes_mv.attribute_id; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.recolor_by_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
-
-
---
--- Name: recolor_by_inds_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.recolor_by_inds_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: recolor_by_inds_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.recolor_by_inds_id_seq OWNED BY public.recolor_by_inds.id;
 
 
 --
@@ -5987,6 +5924,83 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: recolor_by_attributes recolor_by_attributes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recolor_by_attributes
+    ADD CONSTRAINT recolor_by_attributes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recolor_by_attributes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.recolor_by_attributes_mv AS
+ SELECT ra.id,
+    ra.context_id,
+    ra.group_number,
+    ra."position",
+    ra.legend_type,
+    ra.legend_color_theme,
+    ra.interval_count,
+    ra.min_value,
+    ra.max_value,
+    ra.divisor,
+    ra.tooltip_text,
+    ra.years,
+    ra.is_disabled,
+    ra.is_default,
+    ra.created_at,
+    ra.updated_at,
+    a.id AS attribute_id,
+    ARRAY[]::text[] AS legend
+   FROM ((public.recolor_by_inds rai
+     JOIN public.recolor_by_attributes ra ON ((ra.id = rai.recolor_by_attribute_id)))
+     JOIN public.attributes_mv a ON (((a.original_id = rai.ind_id) AND (a.original_type = 'Ind'::text))))
+UNION ALL
+ SELECT ra.id,
+    ra.context_id,
+    ra.group_number,
+    ra."position",
+    ra.legend_type,
+    ra.legend_color_theme,
+    ra.interval_count,
+    ra.min_value,
+    ra.max_value,
+    ra.divisor,
+    ra.tooltip_text,
+    ra.years,
+    ra.is_disabled,
+    ra.is_default,
+    ra.created_at,
+    ra.updated_at,
+    a.id AS attribute_id,
+    array_agg(DISTINCT flow_quals.value) AS legend
+   FROM ((((public.recolor_by_quals raq
+     JOIN public.recolor_by_attributes ra ON ((ra.id = raq.recolor_by_attribute_id)))
+     JOIN public.attributes_mv a ON (((a.original_id = raq.qual_id) AND (a.original_type = 'Qual'::text))))
+     JOIN public.flow_quals ON ((flow_quals.qual_id = raq.qual_id)))
+     JOIN public.flows ON (((flow_quals.flow_id = flows.id) AND (flows.context_id = ra.context_id))))
+  WHERE (flow_quals.value !~~ 'UNKNOWN%'::text)
+  GROUP BY ra.id, a.id
+  WITH NO DATA;
+
+
+--
+-- Name: MATERIALIZED VIEW recolor_by_attributes_mv; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON MATERIALIZED VIEW public.recolor_by_attributes_mv IS 'Materialized view which merges recolor_by_inds and recolor_by_quals with recolor_by_attributes.';
+
+
+--
+-- Name: COLUMN recolor_by_attributes_mv.attribute_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.recolor_by_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
 
 
 --
@@ -6931,14 +6945,6 @@ ALTER TABLE ONLY public.quants
 
 ALTER TABLE ONLY public.recolor_by_attributes
     ADD CONSTRAINT recolor_by_attributes_context_id_group_number_position_key UNIQUE (context_id, group_number, "position");
-
-
---
--- Name: recolor_by_attributes recolor_by_attributes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.recolor_by_attributes
-    ADD CONSTRAINT recolor_by_attributes_pkey PRIMARY KEY (id);
 
 
 --
@@ -9003,6 +9009,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190301173808'),
 ('20190301173824'),
 ('20190308163938'),
-('20190320122547');
+('20190320122547'),
+('20190320172713');
 
 

--- a/db/views/recolor_by_attributes_mv_v03.sql
+++ b/db/views/recolor_by_attributes_mv_v03.sql
@@ -1,0 +1,15 @@
+SELECT ra.*, a.id AS attribute_id, ARRAY[]::TEXT[] AS legend
+FROM recolor_by_inds rai
+JOIN recolor_by_attributes ra ON ra.id = rai.recolor_by_attribute_id
+JOIN attributes_mv a ON a.original_id = rai.ind_id AND a.original_type = 'Ind'
+
+UNION ALL
+
+SELECT ra.*, a.id AS attribute_id, ARRAY_AGG(DISTINCT flow_quals.value)
+FROM recolor_by_quals raq
+JOIN recolor_by_attributes ra ON ra.id = raq.recolor_by_attribute_id
+JOIN attributes_mv a ON a.original_id = raq.qual_id AND a.original_type = 'Qual'
+JOIN flow_quals ON flow_quals.qual_id = raq.qual_id
+JOIN flows ON flow_quals.flow_id = flows.id AND flows.context_id = ra.context_id
+WHERE value NOT LIKE 'UNKNOWN%'
+GROUP BY ra.id, a.id

--- a/spec/models/api/v3/readonly/recolor_by_attribute_spec.rb
+++ b/spec/models/api/v3/readonly/recolor_by_attribute_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Readonly::RecolorByAttribute, type: :model do
+  include_context 'api v3 brazil recolor by attributes'
+  include_context 'api v3 paraguay recolor by attributes'
+  include_context 'api v3 brazil flows quals'
+  include_context 'api v3 paraguay flows quals'
+
+  before(:each) do
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependencies: false)
+  end
+
+  describe :legend do
+    context 'when Paraguay' do
+      let(:recolor_by_attribute) {
+        api_v3_paraguay_biome_recolor_by_attribute.readonly_recolor_by_attribute
+      }
+
+      it 'only returns Paraguay values' do
+        expect(recolor_by_attribute.legend).to eq(['Chaco seco'])
+      end
+    end
+  end
+end

--- a/spec/responses/api/v3/exporter_profile_spec.rb
+++ b/spec/responses/api/v3/exporter_profile_spec.rb
@@ -94,8 +94,11 @@ RSpec.describe 'Exporter profile', type: :request do
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/sustainability' do
     before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::ChartAttribute.refresh
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
     end
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_exporter1_node.id}/sustainability", params: summary_params
@@ -107,8 +110,11 @@ RSpec.describe 'Exporter profile', type: :request do
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/exporting_companies' do
     before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::ChartAttribute.refresh
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
     end
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_exporter1_node.id}/exporting_companies", params: summary_params

--- a/spec/responses/api/v3/importer_profile_spec.rb
+++ b/spec/responses/api/v3/importer_profile_spec.rb
@@ -94,8 +94,11 @@ RSpec.describe 'Importer profile', type: :request do
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/sustainability' do
     before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::ChartAttribute.refresh
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
     end
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/sustainability", params: summary_params
@@ -107,8 +110,11 @@ RSpec.describe 'Importer profile', type: :request do
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/exporting_companies' do
     before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::ChartAttribute.refresh
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
     end
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/exporting_companies", params: summary_params

--- a/spec/responses/api/v3/map_layers_spec.rb
+++ b/spec/responses/api/v3/map_layers_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe 'Map layers', type: :request do
     Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true, skip_dependents: true)
     Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
     Api::V3::Readonly::MapAttribute.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
   end
 
   describe 'GET /api/v3/contexts/:context_id/map_layers' do

--- a/spec/responses/api/v3/place_profile_spec.rb
+++ b/spec/responses/api/v3/place_profile_spec.rb
@@ -60,8 +60,11 @@ RSpec.describe 'Place profile', type: :request do
 
   describe 'GET /api/v3/contexts/:context_id/places/:id/indicators' do
     before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::ChartAttribute.refresh
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
     end
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_municipality_node.id}/indicators", params: summary_params
@@ -73,8 +76,11 @@ RSpec.describe 'Place profile', type: :request do
 
   describe 'GET /api/v3/contexts/:context_id/places/:id/trajectory_deforestation' do
     before(:each) do
-      Api::V3::Readonly::Attribute.refresh
-      Api::V3::Readonly::ChartAttribute.refresh
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
     end
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_municipality_node.id}/trajectory_deforestation", params: summary_params

--- a/spec/services/api/v3/map_layers/map_attribute_filter_spec.rb
+++ b/spec/services/api/v3/map_layers/map_attribute_filter_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Api::V3::MapLayers::MapAttributeFilter do
   before(:each) do
     Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
     Api::V3::Readonly::MapAttribute.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
+    Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
   end
 
   context 'when single year' do

--- a/spec/support/contexts/api/v3/brazil/brazil_flows_quals.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows_quals.rb
@@ -1,0 +1,13 @@
+shared_context 'api v3 brazil flows quals' do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 quants'
+
+  let!(:api_v3_brazil_biome) do
+    FactoryBot.create(
+      :api_v3_flow_qual,
+      flow: api_v3_flow1,
+      qual: api_v3_biome,
+      value: 'Amazonia'
+    )
+  end
+end

--- a/spec/support/contexts/api/v3/paraguay/paraguay_flows_quals.rb
+++ b/spec/support/contexts/api/v3/paraguay/paraguay_flows_quals.rb
@@ -1,0 +1,13 @@
+shared_context 'api v3 paraguay flows quals' do
+  include_context 'api v3 paraguay flows'
+  include_context 'api v3 quants'
+
+  let!(:api_v3_paraguay_biome) do
+    FactoryBot.create(
+      :api_v3_flow_qual,
+      flow: api_v3_paraguay_flow,
+      qual: api_v3_biome,
+      value: 'Chaco seco'
+    )
+  end
+end

--- a/spec/support/contexts/api/v3/paraguay/paraguay_recolor_by_attributes.rb
+++ b/spec/support/contexts/api/v3/paraguay/paraguay_recolor_by_attributes.rb
@@ -1,0 +1,33 @@
+shared_context 'api v3 paraguay recolor by attributes' do
+  include_context 'api v3 paraguay context'
+  include_context 'api v3 quals'
+
+  let!(:api_v3_paraguay_biome_recolor_by_attribute) do
+    recolor_by_attribute = Api::V3::RecolorByQual.
+      includes(:recolor_by_attribute).
+      where(
+        'recolor_by_attributes.context_id' => api_v3_paraguay_context.id,
+        qual_id: api_v3_biome.id
+      ).first&.recolor_by_attribute
+    unless recolor_by_attribute
+      recolor_by_attribute = FactoryBot.create(
+        :api_v3_recolor_by_attribute,
+        tooltip_text: 'biome tooltip text',
+        context: api_v3_paraguay_context,
+        position: 3,
+        years: [],
+        group_number: 1,
+        is_disabled: false,
+        is_default: false,
+        legend_type: 'qual',
+        legend_color_theme: 'thematic'
+      )
+      FactoryBot.create(
+        :api_v3_recolor_by_qual,
+        recolor_by_attribute: recolor_by_attribute,
+        qual: api_v3_biome
+      )
+    end
+    recolor_by_attribute
+  end
+end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/164762841

The problem was that the query which returns distinct flow_quals values did not apply the context filter, ending up with mixed up flow_quals from various contexts. Fixing the query itself requires a join with flows, which made it even slower than it was before. Therefore, I moved that logic to the underlying `recolor_by_attributes_mv`, which now also includes an array of distinct values ready to return here.

There are specs which test for this case. To test for real you need either the current sandbox db, or patch your local db to contain 1. flow values of BIOME for another context than Brazil-soy 2. a recolor by attribute defined for BIOME for that context. This might work:

```
WITH contexts_cte AS (
  SELECT contexts.id FROM contexts
  JOIN countries ON countries.id = contexts.country_id AND countries.name = 'PARAGUAY'
  JOIN commodities ON commodities.id = contexts.commodity_id AND commodities.name = 'SOY'
),
flows_cte AS (
  SELECT flows.id AS flow_id FROM flows WHERE year = 2016 AND context_id IN (SELECT id FROM contexts_cte) LIMIT 10
),
quals_cte AS (
  SELECT quals.id AS qual_id FROM quals WHERE name = 'BIOME'
)
INSERT INTO flow_quals (flow_id, qual_id, value, created_at)
SELECT flow_id, qual_id, 'Chaco seco', NOW()
FROM flows_cte, quals_cte;

WITH contexts_cte AS (
  SELECT contexts.id FROM contexts
  JOIN countries ON countries.id = contexts.country_id AND countries.name = 'PARAGUAY'
  JOIN commodities ON commodities.id = contexts.commodity_id AND commodities.name = 'SOY'
),
quals_cte AS (
  SELECT quals.id AS qual_id FROM quals WHERE name = 'BIOME'
),
recolor_by_attributes_cte AS (
  INSERT INTO recolor_by_attributes(context_id, group_number, position, legend_type, legend_color_theme, created_at, updated_at)
  SELECT contexts_cte.id AS context_id, 1 AS group_number, 1 AS position, 'qual' AS legend_type, 'thematic' AS legend_color_theme, NOW(), NOW()
  FROM contexts_cte
  RETURNING *
)
INSERT INTO recolor_by_quals(recolor_by_attribute_id, qual_id, created_at, updated_at)
SELECT recolor_by_attributes_cte.id, quals_cte.qual_id, NOW(), NOW()
FROM recolor_by_attributes_cte, quals_cte;

REFRESH MATERIALIZED VIEW recolor_by_attributes_mv;
```

The idea is, when you're on the sankey looking at Brazil-soy, you shouldn't see "Chaco seco" in the list of biomes (neither in the 'Select biome' dropdown nor in the legend for the recolor by option)