### PR TITLE
Unique indexes on materialized views

### DIFF
--- a/app/admin/api/v3/ind_commodity_property.rb
+++ b/app/admin/api/v3/ind_commodity_property.rb
@@ -47,7 +47,7 @@ ActiveAdmin.register Api::V3::IndCommodityProperty, as: 'IndCommodityProperty' d
       row :created_at
       row :updated_at
     end
-  end  
+  end
 
   filter :ind, collection: -> { Api::V3::Ind.select_options }
   filter :commodity, collection: -> { Api::V3::Commodity.select_options }

--- a/app/admin/api/v3/ind_commodity_property.rb
+++ b/app/admin/api/v3/ind_commodity_property.rb
@@ -39,6 +39,16 @@ ActiveAdmin.register Api::V3::IndCommodityProperty, as: 'IndCommodityProperty' d
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Commodity') { |property| property.commodity&.name }
+      row('Ind') { |property| property.ind&.name }
+      row :created_at
+      row :updated_at
+    end
+  end  
+
   filter :ind, collection: -> { Api::V3::Ind.select_options }
   filter :commodity, collection: -> { Api::V3::Commodity.select_options }
 end

--- a/app/admin/api/v3/ind_context_property.rb
+++ b/app/admin/api/v3/ind_context_property.rb
@@ -37,6 +37,17 @@ ActiveAdmin.register Api::V3::IndContextProperty, as: 'IndContextProperty' do
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Country') { |property| property.context&.country&.name }
+      row('Commodity') { |property| property.context&.commodity&.name }
+      row('Ind') { |property| property.ind&.name }
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :ind, collection: -> { Api::V3::Ind.select_options }
   filter :context, collection: -> { Api::V3::Context.select_options }
 end

--- a/app/admin/api/v3/ind_country_property.rb
+++ b/app/admin/api/v3/ind_country_property.rb
@@ -39,6 +39,16 @@ ActiveAdmin.register Api::V3::IndCountryProperty, as: 'IndCountryProperty' do
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Country') { |property| property.country&.name }
+      row('Ind') { |property| property.ind&.name }
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :ind, collection: -> { Api::V3::Ind.select_options }
   filter :country, collection: -> { Api::V3::Country.select_options }
 end

--- a/app/admin/api/v3/qual_commodity_property.rb
+++ b/app/admin/api/v3/qual_commodity_property.rb
@@ -39,6 +39,16 @@ ActiveAdmin.register Api::V3::QualCommodityProperty, as: 'QualCommodityProperty'
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Commodity') { |property| property.commodity&.name }
+      row('Qual') { |property| property.qual&.name }
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :qual, collection: -> { Api::V3::Qual.select_options }
   filter :commodity, collection: -> { Api::V3::Commodity.select_options }
 end

--- a/app/admin/api/v3/qual_context_property.rb
+++ b/app/admin/api/v3/qual_context_property.rb
@@ -37,6 +37,17 @@ ActiveAdmin.register Api::V3::QualContextProperty, as: 'QualContextProperty' do
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Country') { |property| property.context&.country&.name }
+      row('Commodity') { |property| property.context&.commodity&.name }
+      row('Qual') { |property| property.qual&.name }
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :qual, collection: -> { Api::V3::Qual.select_options }
   filter :context, collection: -> { Api::V3::Context.select_options }
 end

--- a/app/admin/api/v3/qual_country_property.rb
+++ b/app/admin/api/v3/qual_country_property.rb
@@ -38,6 +38,16 @@ ActiveAdmin.register Api::V3::QualCountryProperty, as: 'QualCountryProperty' do
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Country') { |property| property.country&.name }
+      row('Qual') { |property| property.qual&.name }
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :qual, collection: -> { Api::V3::Qual.select_options }
   filter :country, collection: -> { Api::V3::Country.select_options }
 end

--- a/app/admin/api/v3/quant_commodity_property.rb
+++ b/app/admin/api/v3/quant_commodity_property.rb
@@ -39,6 +39,16 @@ ActiveAdmin.register Api::V3::QuantCommodityProperty, as: 'QuantCommodityPropert
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Commodity') { |property| property.commodity&.name }
+      row('Quant') { |property| property.quant&.name }
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :quant, collection: -> { Api::V3::Quant.select_options }
   filter :commodity, collection: -> { Api::V3::Commodity.select_options }
 end

--- a/app/admin/api/v3/quant_context_property.rb
+++ b/app/admin/api/v3/quant_context_property.rb
@@ -37,6 +37,17 @@ ActiveAdmin.register Api::V3::QuantContextProperty, as: 'QuantContextProperty' d
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Country') { |property| property.context&.country&.name }
+      row('Commodity') { |property| property.context&.commodity&.name }
+      row('Quant') { |property| property.quant&.name }
+      row :created_at
+      row :updated_at
+    end
+  end  
+
   filter :quant, collection: -> { Api::V3::Quant.select_options }
   filter :context, collection: -> { Api::V3::Context.select_options }
 end

--- a/app/admin/api/v3/quant_context_property.rb
+++ b/app/admin/api/v3/quant_context_property.rb
@@ -46,7 +46,7 @@ ActiveAdmin.register Api::V3::QuantContextProperty, as: 'QuantContextProperty' d
       row :created_at
       row :updated_at
     end
-  end  
+  end
 
   filter :quant, collection: -> { Api::V3::Quant.select_options }
   filter :context, collection: -> { Api::V3::Context.select_options }

--- a/app/admin/api/v3/quant_country_property.rb
+++ b/app/admin/api/v3/quant_country_property.rb
@@ -38,6 +38,16 @@ ActiveAdmin.register Api::V3::QuantCountryProperty, as: 'QuantCountryProperty' d
     actions
   end
 
+  show do
+    attributes_table do
+      row :tooltip_text
+      row('Country') { |property| property.country&.name }
+      row('Quant') { |property| property.quant&.name }
+      row :created_at
+      row :updated_at
+    end
+  end
+
   filter :quant, collection: -> { Api::V3::Quant.select_options }
   filter :country, collection: -> { Api::V3::Country.select_options }
 end

--- a/app/models/api/v3/readonly/commodity_attribute_property.rb
+++ b/app/models/api/v3/readonly/commodity_attribute_property.rb
@@ -11,9 +11,7 @@
 #
 # Indexes
 #
-#  index_commodity_ind_attribute_properties_mv_id    (id,commodity_id,ind_id) UNIQUE
-#  index_commodity_qual_attribute_properties_mv_id   (id,commodity_id,qual_id) UNIQUE
-#  index_commodity_quant_attribute_properties_mv_id  (id,commodity_id,quant_id) UNIQUE
+#  index_commodity_attribute_properties_mv_id  (id,commodity_id,qual_id,quant_id,ind_id) UNIQUE
 #
 
 module Api

--- a/app/models/api/v3/readonly/context_attribute_property.rb
+++ b/app/models/api/v3/readonly/context_attribute_property.rb
@@ -11,9 +11,7 @@
 #
 # Indexes
 #
-#  index_context_ind_attribute_properties_mv_id    (id,context_id,ind_id) UNIQUE
-#  index_context_qual_attribute_properties_mv_id   (id,context_id,qual_id) UNIQUE
-#  index_context_quant_attribute_properties_mv_id  (id,context_id,quant_id) UNIQUE
+#  index_context_attribute_properties_mv_id  (context_id,qual_id,quant_id,ind_id) UNIQUE
 #
 
 module Api

--- a/app/models/api/v3/readonly/country_attribute_property.rb
+++ b/app/models/api/v3/readonly/country_attribute_property.rb
@@ -11,9 +11,7 @@
 #
 # Indexes
 #
-#  index_country_ind_attribute_properties_mv_id    (id,country_id,ind_id) UNIQUE
-#  index_country_qual_attribute_properties_mv_id   (id,country_id,qual_id) UNIQUE
-#  index_country_quant_attribute_properties_mv_id  (id,country_id,quant_id) UNIQUE
+#  index_country_attribute_properties_mv_id  (id,country_id,qual_id,quant_id,ind_id) UNIQUE
 #
 
 module Api

--- a/db/migrate/20190321122822_add_unique_indexes_on_materialized_views.rb
+++ b/db/migrate/20190321122822_add_unique_indexes_on_materialized_views.rb
@@ -1,0 +1,24 @@
+class AddUniqueIndexesOnMaterializedViews < ActiveRecord::Migration[5.2]
+  def change
+    remove_index :context_attribute_properties_mv, [:id, :context_id, :qual_id]
+    remove_index :context_attribute_properties_mv, [:id, :context_id, :quant_id]
+    remove_index :context_attribute_properties_mv, [:id, :context_id, :ind_id]
+
+    add_index :context_attribute_properties_mv, [:context_id, :qual_id, :quant_id, :ind_id], unique: true,
+      name: 'index_context_attribute_properties_mv_id'
+    
+    remove_index :country_attribute_properties_mv, [:id, :country_id, :qual_id]
+    remove_index :country_attribute_properties_mv, [:id, :country_id, :quant_id]
+    remove_index :country_attribute_properties_mv, [:id, :country_id, :ind_id]
+
+    add_index :country_attribute_properties_mv, [:id, :country_id, :qual_id, :quant_id, :ind_id], unique: true,
+      name: 'index_country_attribute_properties_mv_id'
+    
+    remove_index :commodity_attribute_properties_mv, [:id, :commodity_id, :qual_id]
+    remove_index :commodity_attribute_properties_mv, [:id, :commodity_id, :quant_id]
+    remove_index :commodity_attribute_properties_mv, [:id, :commodity_id, :ind_id]
+    
+    add_index :commodity_attribute_properties_mv, [:id, :commodity_id, :qual_id, :quant_id, :ind_id], unique: true,
+      name: 'index_commodity_attribute_properties_mv_id'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7524,31 +7524,17 @@ CREATE INDEX index_charts_on_profile_id ON public.charts USING btree (profile_id
 
 
 --
--- Name: index_commodity_ind_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_commodity_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commodity_ind_attribute_properties_mv_id ON public.commodity_attribute_properties_mv USING btree (id, commodity_id, ind_id);
-
-
---
--- Name: index_commodity_qual_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_commodity_qual_attribute_properties_mv_id ON public.commodity_attribute_properties_mv USING btree (id, commodity_id, qual_id);
+CREATE UNIQUE INDEX index_commodity_attribute_properties_mv_id ON public.commodity_attribute_properties_mv USING btree (id, commodity_id, qual_id, quant_id, ind_id);
 
 
 --
--- Name: index_commodity_quant_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_context_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_commodity_quant_attribute_properties_mv_id ON public.commodity_attribute_properties_mv USING btree (id, commodity_id, quant_id);
-
-
---
--- Name: index_context_ind_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_context_ind_attribute_properties_mv_id ON public.context_attribute_properties_mv USING btree (id, context_id, ind_id);
+CREATE UNIQUE INDEX index_context_attribute_properties_mv_id ON public.context_attribute_properties_mv USING btree (context_id, qual_id, quant_id, ind_id);
 
 
 --
@@ -7580,20 +7566,6 @@ CREATE INDEX index_context_properties_on_context_id ON public.context_properties
 
 
 --
--- Name: index_context_qual_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_context_qual_attribute_properties_mv_id ON public.context_attribute_properties_mv USING btree (id, context_id, qual_id);
-
-
---
--- Name: index_context_quant_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_context_quant_attribute_properties_mv_id ON public.context_attribute_properties_mv USING btree (id, context_id, quant_id);
-
-
---
 -- Name: index_contexts_on_commodity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7615,10 +7587,10 @@ CREATE INDEX index_contextual_layers_on_context_id ON public.contextual_layers U
 
 
 --
--- Name: index_country_ind_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_country_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_country_ind_attribute_properties_mv_id ON public.country_attribute_properties_mv USING btree (id, country_id, ind_id);
+CREATE UNIQUE INDEX index_country_attribute_properties_mv_id ON public.country_attribute_properties_mv USING btree (id, country_id, qual_id, quant_id, ind_id);
 
 
 --
@@ -7626,20 +7598,6 @@ CREATE UNIQUE INDEX index_country_ind_attribute_properties_mv_id ON public.count
 --
 
 CREATE INDEX index_country_properties_on_country_id ON public.country_properties USING btree (country_id);
-
-
---
--- Name: index_country_qual_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_country_qual_attribute_properties_mv_id ON public.country_attribute_properties_mv USING btree (id, country_id, qual_id);
-
-
---
--- Name: index_country_quant_attribute_properties_mv_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_country_quant_attribute_properties_mv_id ON public.country_attribute_properties_mv USING btree (id, country_id, quant_id);
 
 
 --
@@ -9010,6 +8968,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190301173824'),
 ('20190308163938'),
 ('20190320122547'),
-('20190320172713');
+('20190320172713'),
+('20190321122822');
 
 

--- a/spec/controllers/admin/ind_commodity_properties_controller_spec.rb
+++ b/spec/controllers/admin/ind_commodity_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::IndCommodityPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: ind_commodity_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/ind_context_properties_controller_spec.rb
+++ b/spec/controllers/admin/ind_context_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::IndContextPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: ind_context_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/ind_country_properties_controller_spec.rb
+++ b/spec/controllers/admin/ind_country_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::IndCountryPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: ind_country_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/qual_commodity_properties_controller_spec.rb
+++ b/spec/controllers/admin/qual_commodity_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::QualCommodityPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: qual_commodity_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/qual_context_properties_controller_spec.rb
+++ b/spec/controllers/admin/qual_context_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::QualContextPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: qual_context_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/qual_country_properties_controller_spec.rb
+++ b/spec/controllers/admin/qual_country_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::QualCountryPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: qual_country_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/quant_commodity_properties_controller_spec.rb
+++ b/spec/controllers/admin/quant_commodity_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::QuantCommodityPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: quant_commodity_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/quant_context_properties_controller_spec.rb
+++ b/spec/controllers/admin/quant_context_properties_controller_spec.rb
@@ -98,5 +98,10 @@ RSpec.describe Admin::QuantContextPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: quant_context_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end

--- a/spec/controllers/admin/quant_country_properties_controller_spec.rb
+++ b/spec/controllers/admin/quant_country_properties_controller_spec.rb
@@ -99,5 +99,10 @@ RSpec.describe Admin::QuantCountryPropertiesController, type: :controller do
       get :index
       expect(response).to render_template(:index)
     end
+
+    it 'renders show' do
+      get :show, params: {id: quant_country_property.id}
+      expect(response).to render_template(:show)
+    end
   end
 end


### PR DESCRIPTION
- Another attempt to fix indexes on materialized views
- Display user-friendly names of quals/inds/quants on controller#show action in admin panel for context/commodity/country qual/inds/quants properties. Also, for context-specific attributes, instead of showing context's id in the show page, show commodity and country names as it's more readable.