### PR TITLE
Apply node type role attribute to dashboards filters

### DIFF
--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -29,7 +29,14 @@ module Api
         0, 1, 2, 3
       ].freeze
 
-      ROLES = %w(source exporter importer destination).freeze
+      SOURCE_ROLE = 'source'.freeze
+      EXPORTER_ROLE = 'exporter'.freeze
+      IMPORTER_ROLE = 'importer'.freeze
+      DESTINATION_ROLE = 'destination'.freeze
+
+      ROLES = [
+        SOURCE_ROLE, EXPORTER_ROLE, IMPORTER_ROLE, DESTINATION_ROLE
+      ].freeze
 
       before_save :nilify_role,
                   if: -> { role.blank? }

--- a/app/models/api/v3/readonly/dashboards/country.rb
+++ b/app/models/api/v3/readonly/dashboards/country.rb
@@ -9,15 +9,6 @@
 #  commodity_id  :integer
 #  node_id       :integer
 #
-# Indexes
-#
-#  dashboards_countries_mv_commodity_id_idx   (commodity_id)
-#  dashboards_countries_mv_group_columns_idx  (id,name)
-#  dashboards_countries_mv_name_idx           (name)
-#  dashboards_countries_mv_name_tsvector_idx  (name_tsvector) USING gin
-#  dashboards_countries_mv_node_id_idx        (node_id)
-#  dashboards_countries_mv_unique_idx         (id,node_id,commodity_id) UNIQUE
-#
 
 module Api
   module V3

--- a/app/models/api/v3/readonly/dashboards/country.rb
+++ b/app/models/api/v3/readonly/dashboards/country.rb
@@ -9,6 +9,15 @@
 #  commodity_id  :integer
 #  node_id       :integer
 #
+# Indexes
+#
+#  dashboards_countries_mv_commodity_id_idx   (commodity_id)
+#  dashboards_countries_mv_group_columns_idx  (id,name)
+#  dashboards_countries_mv_name_idx           (name)
+#  dashboards_countries_mv_name_tsvector_idx  (name_tsvector) USING gin
+#  dashboards_countries_mv_node_id_idx        (node_id)
+#  dashboards_countries_mv_unique_idx         (id,node_id,commodity_id) UNIQUE
+#
 
 module Api
   module V3

--- a/app/models/api/v3/readonly/dashboards/flow_path.rb
+++ b/app/models/api/v3/readonly/dashboards/flow_path.rb
@@ -11,8 +11,8 @@
 #  node_type       :text
 #  flow_id         :integer
 #  column_position :integer
-#  column_group    :integer
-#  category        :text
+#  role            :string
+#  category        :string
 #
 # Indexes
 #

--- a/app/services/api/v3/dashboards/filter_meta.rb
+++ b/app/services/api/v3/dashboards/filter_meta.rb
@@ -17,25 +17,24 @@ module Api
               {
                 section: 'SOURCES',
                 tabs: @query.where(
-                  'context_node_type_properties.column_group' => 0
-                ).where(
-                  'node_types.name <> ?', NodeTypeName::COUNTRY_OF_PRODUCTION
+                  'context_node_type_properties.role' =>
+                    ContextNodeTypeProperty::SOURCE_ROLE
                 ).all
               },
               {
                 section: 'COMPANIES',
                 tabs: @query.where(
-                  'node_types.name' => [
-                    NodeTypeName::IMPORTER,
-                    NodeTypeName::EXPORTER,
-                    NodeTypeName::TRADER
+                  'context_node_type_properties.role' => [
+                    ContextNodeTypeProperty::EXPORTER_ROLE,
+                    ContextNodeTypeProperty::IMPORTER_ROLE
                   ]
                 ).all
               },
               {
                 section: 'DESTINATIONS',
                 tabs: @query.where(
-                  'context_node_type_properties.column_group' => 3
+                  'context_node_type_properties.role' =>
+                    ContextNodeTypeProperty::DESTINATION_ROLE
                 ).all
               }
             ].map do |section|

--- a/db/migrate/20190321161913_update_dashboards_flow_paths_mv.rb
+++ b/db/migrate/20190321161913_update_dashboards_flow_paths_mv.rb
@@ -1,0 +1,172 @@
+class UpdateDashboardsFlowPathsMv < ActiveRecord::Migration[5.2]
+  def change
+    drop_view :dashboards_sources_mv, materialized: true
+    drop_view :dashboards_companies_mv, materialized: true
+    drop_view :dashboards_destinations_mv, materialized: true
+    drop_view :dashboards_countries_mv, materialized: true
+    drop_view :dashboards_commodities_mv, materialized: true
+    
+    update_view :dashboards_flow_paths_mv,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+    
+    create_view :dashboards_sources_mv,
+      version: 4,
+      materialized: true
+    
+    create_view :dashboards_companies_mv,
+      version: 4,
+      materialized: true
+    
+    create_view :dashboards_destinations_mv,
+      version: 4,
+      materialized: true
+    
+    create_view :dashboards_countries_mv,
+      version: 3,
+      materialized: true
+    
+    create_view :dashboards_commodities_mv,
+      version: 3,
+      materialized: true
+    
+    redo_dashboards_sources_indexes
+    redo_dashboards_companies_indexes
+    redo_dashboards_destinations_indexes
+    redo_dashboards_commodities_indexes
+  end
+
+  def redo_dashboards_sources_indexes
+    add_index :dashboards_sources_mv,
+      :commodity_id,
+      name: 'dashboards_sources_mv_commodity_id_idx'
+    add_index :dashboards_sources_mv,
+      :country_id,
+      name: 'dashboards_sources_mv_country_id_idx'
+    add_index :dashboards_sources_mv,
+      [:id, :name, :node_type, :parent_name, :parent_node_type],
+      name: 'dashboards_sources_mv_group_columns_idx'
+    add_index :dashboards_sources_mv,
+      :name_tsvector,
+      name: 'dashboards_sources_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_sources_mv,
+      :node_id,
+      name: 'dashboards_sources_mv_node_id_idx'
+    add_index :dashboards_sources_mv,
+      :node_type_id,
+      name: 'dashboards_sources_mv_node_type_id_idx'
+    add_index :dashboards_sources_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_sources_unique_idx'
+    add_index :dashboards_sources_mv,
+      :name,
+      name: 'dashboards_sources_mv_name_idx'
+  end
+
+  def redo_dashboards_companies_indexes
+    add_index :dashboards_companies_mv,
+      :commodity_id,
+      name: 'dashboards_companies_mv_commodity_id_idx'
+    add_index :dashboards_companies_mv,
+      :country_id,
+      name: 'dashboards_companies_mv_country_id_idx'
+    add_index :dashboards_companies_mv,
+      [:id, :name, :node_type],
+      name: 'dashboards_companies_mv_group_columns_idx'
+    add_index :dashboards_companies_mv,
+      :name_tsvector,
+      name: 'dashboards_companies_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_companies_mv,
+      :node_id,
+      name: 'dashboards_companies_mv_node_id_idx'
+    add_index :dashboards_companies_mv,
+      :node_type_id,
+      name: 'dashboards_companies_mv_node_type_id_idx'
+    add_index :dashboards_companies_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_companies_mv_unique_idx' 
+    add_index :dashboards_companies_mv,
+      :name,
+      name: 'dashboards_companies_mv_name_idx'
+  end
+
+  def redo_dashboards_destinations_indexes
+    add_index :dashboards_destinations_mv,
+      :country_id,
+      name: 'dashboards_destinations_mv_country_id_idx'
+    add_index :dashboards_destinations_mv,
+      :commodity_id,
+      name: 'dashboards_destinations_mv_commodity_id_idx'
+    add_index :dashboards_destinations_mv,
+      [:id, :name, :node_type],
+      name: 'dashboards_destinations_mv_group_columns_idx'
+    add_index :dashboards_destinations_mv,
+      :name_tsvector,
+      name: 'dashboards_destinations_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_destinations_mv,
+      :node_id,
+      name: 'dashboards_destinations_mv_node_id_idx'
+    add_index :dashboards_destinations_mv,
+      :node_type_id,
+      name: 'dashboards_destinations_mv_node_type_id_idx'
+    add_index :dashboards_destinations_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_destinations_mv_unique_idx'
+    add_index :dashboards_destinations_mv,
+      :name,
+      name: 'dashboards_destinations_mv_name_idx'
+  end
+
+  def redo_dashboards_countries_indexes
+    add_index :dashboards_countries_mv,
+      :commodity_id,
+      name: 'dashboards_countries_mv_commodity_id_idx'
+    add_index :dashboards_countries_mv,
+      [:id, :name],
+      name: 'dashboards_countries_mv_group_columns_idx'
+    add_index :dashboards_countries_mv,
+      :name_tsvector,
+      name: 'dashboards_countries_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_countries_mv,
+      :node_id,
+      name: 'dashboards_countries_mv_node_id_idx'
+    add_index :dashboards_countries_mv,
+      [:id, :node_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_countries_mv_unique_idx'
+    add_index :dashboards_countries_mv,
+      :name,
+      name: 'dashboards_countries_mv_name_idx'
+  end
+
+  def redo_dashboards_commodities_indexes
+    add_index :dashboards_commodities_mv,
+      :country_id,
+      name: 'dashboards_commodities_mv_country_id_idx'
+    add_index :dashboards_commodities_mv,
+      [:id, :name],
+      name: 'dashboards_commodities_mv_group_columns_idx'
+    add_index :dashboards_commodities_mv,
+      :name_tsvector,
+      name: 'dashboards_commodities_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_commodities_mv,
+      :node_id,
+      name: 'dashboards_commodities_mv_node_id_idx'
+    add_index :dashboards_commodities_mv,
+      [:id, :node_id, :country_id],
+      unique: true,
+      name: 'dashboards_commodities_mv_unique_idx'
+    add_index :dashboards_commodities_mv,
+      :name,
+      name: 'dashboards_commodities_mv_name_idx'
+  end
+end

--- a/db/migrate/20190321161913_update_dashboards_flow_paths_mv.rb
+++ b/db/migrate/20190321161913_update_dashboards_flow_paths_mv.rb
@@ -35,6 +35,7 @@ class UpdateDashboardsFlowPathsMv < ActiveRecord::Migration[5.2]
     redo_dashboards_companies_indexes
     redo_dashboards_destinations_indexes
     redo_dashboards_commodities_indexes
+    redo_dashboards_countries_indexes
   end
 
   def redo_dashboards_sources_indexes

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2991,9 +2991,8 @@ CREATE MATERIALIZED VIEW public.dashboards_flow_paths_mv AS
     cnt.column_position,
     cnt_props.column_group,
         CASE
-            WHEN (cnt_props.column_group = 0) THEN 'SOURCE'::text
-            WHEN (cnt_props.column_group = 3) THEN 'DESTINATION'::text
-            ELSE 'COMPANY'::text
+            WHEN (((cnt_props.role)::text = 'exporter'::text) OR ((cnt_props.role)::text = 'importer'::text)) THEN 'company'::character varying
+            ELSE cnt_props.role
         END AS category
    FROM (((((( SELECT flows.context_id,
             flows.id AS flow_id,
@@ -3006,7 +3005,7 @@ CREATE MATERIALIZED VIEW public.dashboards_flow_paths_mv AS
      JOIN public.node_types ON ((nodes.node_type_id = node_types.id)))
      JOIN public.context_node_types cnt ON (((node_types.id = cnt.node_type_id) AND (flow_paths.context_id = cnt.context_id))))
      JOIN public.context_node_type_properties cnt_props ON ((cnt.id = cnt_props.context_node_type_id)))
-  WHERE ((cnt_props.column_group = ANY (ARRAY[0, 3])) OR (node_types.name = ANY (ARRAY['COUNTRY'::text, 'IMPORTER'::text, 'EXPORTER'::text, 'TRADER'::text])))
+  WHERE (((cnt_props.role)::text = ANY ((ARRAY['source'::character varying, 'exporter'::character varying, 'importer'::character varying, 'destination'::character varying])::text[])) OR (node_types.name = ANY (ARRAY['COUNTRY'::text, 'IMPORTER'::text, 'EXPORTER'::text, 'TRADER'::text])))
   WITH NO DATA;
 
 
@@ -3041,7 +3040,7 @@ CREATE MATERIALIZED VIEW public.dashboards_companies_mv AS
     all_fp.node_id
    FROM (public.dashboards_flow_paths_mv all_fp
      JOIN public.dashboards_flow_paths_mv fp ON ((all_fp.flow_id = fp.flow_id)))
-  WHERE (fp.category = 'COMPANY'::text)
+  WHERE ((fp.category)::text = 'company'::text)
   GROUP BY fp.node_id, fp.node, fp.node_type_id, fp.node_type, all_fp.country_id, all_fp.commodity_id, all_fp.node_id
   WITH NO DATA;
 
@@ -3078,7 +3077,7 @@ CREATE MATERIALIZED VIEW public.dashboards_destinations_mv AS
     all_fp.node_id
    FROM (public.dashboards_flow_paths_mv all_fp
      JOIN public.dashboards_flow_paths_mv fp ON ((all_fp.flow_id = fp.flow_id)))
-  WHERE (fp.category = 'DESTINATION'::text)
+  WHERE ((fp.category)::text = 'destination'::text)
   GROUP BY fp.node_id, fp.node, fp.node_type_id, fp.node_type, all_fp.country_id, all_fp.commodity_id, all_fp.node_id
   WITH NO DATA;
 
@@ -3513,7 +3512,7 @@ CREATE MATERIALIZED VIEW public.dashboards_sources_mv AS
      JOIN public.context_node_types_mv cnt_mv ON (((fp.node_type_id = cnt_mv.node_type_id) AND (fp.context_id = cnt_mv.context_id))))
      LEFT JOIN public.quals ON ((quals.name = cnt_mv.parent_node_type)))
      LEFT JOIN public.node_quals ON (((fp.node_id = node_quals.node_id) AND (quals.id = node_quals.qual_id))))
-  WHERE ((fp.category = 'SOURCE'::text) AND (all_fp.node_id <> fp.node_id))
+  WHERE (((fp.category)::text = 'source'::text) AND (all_fp.node_id <> fp.node_id))
   GROUP BY fp.node_id, fp.node, fp.node_type_id, fp.node_type, quals.name, node_quals.value, all_fp.country_id, all_fp.commodity_id, all_fp.node_id
   WITH NO DATA;
 
@@ -8969,8 +8968,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190301173808'),
 ('20190301173824'),
 ('20190308163938'),
-('20190318161140');
+('20190318161140'),
 ('20190320122547'),
 ('20190320172713'),
-('20190321122822');
+('20190321122822'),
+('20190321161913');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1515,7 +1515,7 @@ UNION ALL
     ind_commodity_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_commodity_properties
-  WITH NO DATA;
+  WITH DATA;
 
 
 --
@@ -2356,7 +2356,7 @@ UNION ALL
     ind_country_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_country_properties
-  WITH NO DATA;
+  WITH DATA;
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1714,7 +1714,7 @@ UNION ALL
     ind_context_properties.ind_id,
     '-1'::integer AS quant_id
    FROM public.ind_context_properties
-  WITH NO DATA;
+  WITH DATA;
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3005,7 +3005,7 @@ CREATE MATERIALIZED VIEW public.dashboards_flow_paths_mv AS
      JOIN public.node_types ON ((nodes.node_type_id = node_types.id)))
      JOIN public.context_node_types cnt ON (((node_types.id = cnt.node_type_id) AND (flow_paths.context_id = cnt.context_id))))
      JOIN public.context_node_type_properties cnt_props ON ((cnt.id = cnt_props.context_node_type_id)))
-  WHERE (((cnt_props.role)::text = ANY ((ARRAY['source'::character varying, 'exporter'::character varying, 'importer'::character varying, 'destination'::character varying])::text[])) OR (node_types.name = ANY (ARRAY['COUNTRY'::text, 'IMPORTER'::text, 'EXPORTER'::text, 'TRADER'::text])))
+  WHERE (cnt_props.role IS NOT NULL)
   WITH NO DATA;
 
 

--- a/db/views/dashboards_companies_mv_v04.sql
+++ b/db/views/dashboards_companies_mv_v04.sql
@@ -1,0 +1,22 @@
+SELECT
+  fp.node_id AS id,
+  TRIM(fp.node) AS name,
+  TO_TSVECTOR('simple', COALESCE(TRIM(fp.node)::TEXT, '')) AS name_tsvector,
+  fp.node_type_id,
+  fp.node_type,
+  all_fp.country_id,
+  all_fp.commodity_id,
+  all_fp.node_id
+FROM
+dashboards_flow_paths_mv all_fp
+JOIN dashboards_flow_paths_mv fp ON all_fp.flow_id = fp.flow_id
+WHERE fp.category = 'company'
+GROUP BY (
+  fp.node_id,
+  fp.node,
+  fp.node_type_id,
+  fp.node_type,
+  all_fp.country_id,
+  all_fp.commodity_id,
+  all_fp.node_id
+);

--- a/db/views/dashboards_destinations_mv_v04.sql
+++ b/db/views/dashboards_destinations_mv_v04.sql
@@ -1,0 +1,22 @@
+SELECT
+  fp.node_id AS id,
+  TRIM(fp.node) AS name,
+  TO_TSVECTOR('simple', COALESCE(TRIM(fp.node)::TEXT, '')) AS name_tsvector,
+  fp.node_type_id,
+  fp.node_type,
+  all_fp.country_id,
+  all_fp.commodity_id,
+  all_fp.node_id
+FROM
+dashboards_flow_paths_mv all_fp
+JOIN dashboards_flow_paths_mv fp ON all_fp.flow_id = fp.flow_id
+WHERE fp.category = 'destination'
+GROUP BY (
+  fp.node_id,
+  fp.node,
+  fp.node_type_id,
+  fp.node_type,
+  all_fp.country_id,
+  all_fp.commodity_id,
+  all_fp.node_id
+);

--- a/db/views/dashboards_flow_paths_mv_v03.sql
+++ b/db/views/dashboards_flow_paths_mv_v03.sql
@@ -1,0 +1,29 @@
+SELECT DISTINCT
+  flow_paths.context_id,
+  contexts.country_id,
+  contexts.commodity_id,
+  flow_paths.node_id,
+  nodes.name AS node,
+  nodes.node_type_id,
+  node_types.name AS node_type,
+  flow_paths.flow_id,
+  column_position,
+  role,
+  CASE
+    WHEN cnt_props.role = 'exporter' OR cnt_props.role = 'importer' THEN 'company'
+    ELSE cnt_props.role
+  END AS category
+FROM (
+  SELECT
+    flows.context_id,
+    flows.id AS flow_id,
+    a.node_id,
+    a."position"
+  FROM flows, LATERAL unnest(flows.path) WITH ORDINALITY a(node_id, "position")
+) flow_paths
+JOIN contexts ON flow_paths.context_id = contexts.id
+JOIN nodes ON flow_paths.node_id = nodes.id
+JOIN node_types ON nodes.node_type_id = node_types.id
+JOIN context_node_types cnt ON node_types.id = cnt.node_type_id AND flow_paths.context_id = cnt.context_id
+JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+WHERE cnt_props.role IN ('source', 'exporter', 'importer', 'destination') OR node_types.name IN ('COUNTRY', 'IMPORTER', 'EXPORTER', 'TRADER');

--- a/db/views/dashboards_flow_paths_mv_v03.sql
+++ b/db/views/dashboards_flow_paths_mv_v03.sql
@@ -8,7 +8,7 @@ SELECT DISTINCT
   node_types.name AS node_type,
   flow_paths.flow_id,
   column_position,
-  role,
+  column_group,
   CASE
     WHEN cnt_props.role = 'exporter' OR cnt_props.role = 'importer' THEN 'company'
     ELSE cnt_props.role

--- a/db/views/dashboards_flow_paths_mv_v03.sql
+++ b/db/views/dashboards_flow_paths_mv_v03.sql
@@ -26,4 +26,4 @@ JOIN nodes ON flow_paths.node_id = nodes.id
 JOIN node_types ON nodes.node_type_id = node_types.id
 JOIN context_node_types cnt ON node_types.id = cnt.node_type_id AND flow_paths.context_id = cnt.context_id
 JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
-WHERE cnt_props.role IN ('source', 'exporter', 'importer', 'destination') OR node_types.name IN ('COUNTRY', 'IMPORTER', 'EXPORTER', 'TRADER');
+WHERE (cnt_props.role IS NOT NULL);

--- a/db/views/dashboards_sources_mv_v04.sql
+++ b/db/views/dashboards_sources_mv_v04.sql
@@ -1,0 +1,29 @@
+SELECT
+  fp.node_id AS id,
+  TRIM(fp.node) AS name,
+  TO_TSVECTOR('simple', COALESCE(TRIM(fp.node)::TEXT, '')) AS name_tsvector,
+  fp.node_type_id,
+  fp.node_type,
+  quals.name AS parent_node_type,
+  node_quals.value AS parent_name,
+  all_fp.country_id,
+  all_fp.commodity_id,
+  all_fp.node_id
+FROM
+dashboards_flow_paths_mv all_fp
+JOIN dashboards_flow_paths_mv fp ON all_fp.flow_id = fp.flow_id
+JOIN context_node_types_mv cnt_mv ON fp.node_type_id = cnt_mv.node_type_id AND fp.context_id = cnt_mv.context_id
+LEFT JOIN quals ON quals.name = cnt_mv.parent_node_type
+LEFT JOIN node_quals ON fp.node_id = node_quals.node_id AND quals.id = node_quals.qual_id
+WHERE fp.category = 'source' AND all_fp.node_id <> fp.node_id
+GROUP BY (
+  fp.node_id,
+  fp.node,
+  fp.node_type_id,
+  fp.node_type,
+  quals.name,
+  node_quals.value,
+  all_fp.country_id,
+  all_fp.commodity_id,
+  all_fp.node_id
+);

--- a/spec/factories/api/v3/api_v3_context_node_type_properties.rb
+++ b/spec/factories/api/v3/api_v3_context_node_type_properties.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :api_v3_context_node_type_property, class: 'Api::V3::ContextNodeTypeProperty' do
     association :context_node_type, factory: :api_v3_context_node_type
     column_group { 0 }
+    role { 'source' }
     is_default { false }
     is_geo_column { true }
     is_choropleth_disabled { false }

--- a/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
+++ b/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
       :api_v3_context_node_type, context: context, node_type: api_v3_exporter_node_type
     )
     FactoryBot.create(
-      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 1
+      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 1, role: 'exporter'
     )
   }
 
@@ -19,7 +19,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
       :api_v3_context_node_type, context: context, node_type: api_v3_country_node_type
     )
     FactoryBot.create(
-      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 3
+      :api_v3_context_node_type_property, context_node_type: cnt, column_group: 3, role: 'destination'
     )
   }
 
@@ -30,7 +30,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
           :api_v3_context_node_type, context: context, node_type: api_v3_biome_node_type
         )
         FactoryBot.create(
-          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0, role: 'source'
         )
       }
       let!(:another_source_node_type) {
@@ -38,7 +38,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
           :api_v3_context_node_type, context: context, node_type: api_v3_state_node_type
         )
         FactoryBot.create(
-          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0, role: 'source'
         )
       }
 
@@ -47,7 +47,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
           :api_v3_context_node_type, context: context, node_type: api_v3_importer_node_type
         )
         FactoryBot.create(
-          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2, role: 'importer'
         )
       }
 
@@ -75,7 +75,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
           :api_v3_context_node_type, context: context, node_type: api_v3_importer_node_type
         )
         FactoryBot.create(
-          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 2, role: 'importer'
         )
       }
 
@@ -102,7 +102,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
           :api_v3_context_node_type, context: context, node_type: api_v3_biome_node_type
         )
         FactoryBot.create(
-          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0, role: 'source'
         )
       }
       let!(:another_source_node_type) {
@@ -110,7 +110,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
           :api_v3_context_node_type, context: context, node_type: api_v3_state_node_type
         )
         FactoryBot.create(
-          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0
+          :api_v3_context_node_type_property, context_node_type: cnt, column_group: 0, role: 'source'
         )
       }
 

--- a/spec/support/contexts/api/v3/brazil/brazil_beef_context_node_types.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_beef_context_node_types.rb
@@ -18,6 +18,7 @@ shared_context 'api v3 brazil beef context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 0,
+        role: 'source',
         is_default: true
       )
     end
@@ -38,7 +39,8 @@ shared_context 'api v3 brazil beef context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 1
+        column_group: 1,
+        role: 'exporter'
       )
       FactoryBot.create(
         :api_v3_profile,
@@ -62,7 +64,8 @@ shared_context 'api v3 brazil beef context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 1
+        column_group: 1,
+        role: 'exporter'
       )
     end
     cnt
@@ -82,7 +85,8 @@ shared_context 'api v3 brazil beef context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 2
+        column_group: 2,
+        role: 'importer'
       )
     end
     cnt
@@ -102,7 +106,8 @@ shared_context 'api v3 brazil beef context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 3
+        column_group: 3,
+        role: 'destination'
       )
     end
     cnt

--- a/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
@@ -16,7 +16,8 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 0
+        column_group: 0,
+        role: 'source'
       )
     end
     cnt
@@ -35,7 +36,8 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 0
+        column_group: 0,
+        role: 'source'
       )
     end
     cnt
@@ -55,6 +57,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 0,
+        role: 'source',
         is_default: true
       )
       FactoryBot.create(
@@ -95,7 +98,8 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 0
+        column_group: 0,
+        role: 'source'
       )
     end
     cnt
@@ -114,7 +118,8 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 1
+        column_group: 1,
+        role: 'exporter'
       )
     end
     cnt
@@ -133,7 +138,8 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 1
+        column_group: 1,
+        role: 'exporter'
       )
     end
     cnt
@@ -163,7 +169,8 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 2
+        column_group: 2,
+        role: 'importer'
       )
     end
     cnt
@@ -193,7 +200,8 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 3
+        column_group: 3,
+        role: 'destination'
       )
     end
     cnt

--- a/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
@@ -119,7 +119,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 1,
-        role: 'exporter'
+        role: nil
       )
     end
     cnt

--- a/spec/support/contexts/api/v3/paraguay/paraguay_context_node_types.rb
+++ b/spec/support/contexts/api/v3/paraguay/paraguay_context_node_types.rb
@@ -17,6 +17,7 @@ shared_context 'api v3 paraguay context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 0,
+        role: 'source',
         is_geo_column: true
       )
     end
@@ -37,7 +38,8 @@ shared_context 'api v3 paraguay context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 1
+        column_group: 1,
+        role: 'exporter'
       )
     end
     cnt
@@ -57,7 +59,8 @@ shared_context 'api v3 paraguay context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 2
+        column_group: 2,
+        role: 'importer'
       )
     end
     cnt
@@ -77,7 +80,8 @@ shared_context 'api v3 paraguay context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
-        column_group: 3
+        column_group: 3,
+        role: 'destination'
       )
     end
     cnt


### PR DESCRIPTION
This PR applies a new **role** attribute from _context_node_type_properties_ to dependent materialized views.
I also updated the specs although two of them are still failing; one has something to do with populating materialized views and the other returns one more company than before - @agnessa could you steer me in the right direction what may be going on in here?