### PR TITLE
Add additional meta info to dashboard charts endpoints

### DIFF
--- a/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
@@ -34,7 +34,8 @@ module Api
             @meta = {
               xAxis: year_axis_meta,
               yAxis: axis_meta(@cont_attribute, 'number'),
-              x: year_legend_meta
+              x: year_legend_meta,
+              info: info
             }
 
             break_by_values_indexes.each do |break_by, idx|

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
@@ -39,7 +39,8 @@ module Api
             @meta = {
               xAxis: year_axis_meta,
               yAxis: axis_meta(@cont_attribute, 'number'),
-              x: year_legend_meta
+              x: year_legend_meta,
+              info: info
             }
 
             break_by_values_indexes.each do |break_by, idx|

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
@@ -24,7 +24,8 @@ module Api
               xAxis: year_axis_meta,
               yAxis: axis_meta(@cont_attribute, 'number'),
               x: year_legend_meta,
-              y0: legend_meta(@cont_attribute)
+              y0: legend_meta(@cont_attribute),
+              info: info
             }
             {data: @data, meta: @meta}
           end

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
@@ -40,7 +40,8 @@ module Api
             @meta = {
               xAxis: node_type_axis_meta(@node_type),
               yAxis: axis_meta(@cont_attribute, 'number'),
-              x: node_type_legend_meta(@node_type)
+              x: node_type_legend_meta(@node_type),
+              info: info
             }
 
             break_by_values_indexes.each do |break_by, idx|

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
@@ -24,7 +24,8 @@ module Api
               xAxis: axis_meta(@ncont_attribute, 'category'),
               yAxis: axis_meta(@cont_attribute, 'number'),
               x: legend_meta(@ncont_attribute),
-              y0: legend_meta(@cont_attribute)
+              y0: legend_meta(@cont_attribute),
+              info: info
             }
             {data: @data, meta: @meta}
           end

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
@@ -16,6 +16,7 @@ module Api
             @node_type = chart_parameters.node_type
             @node_type_idx = chart_parameters.node_type_idx
             @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
+            @top_n = chart_parameters.top_n
             initialize_query
             initialize_top_n_and_others_query(chart_parameters.top_n)
           end
@@ -31,7 +32,8 @@ module Api
               xAxis: node_type_axis_meta(@node_type),
               yAxis: axis_meta(@cont_attribute, 'number'),
               x: node_type_legend_meta(@node_type),
-              y0: legend_meta(@cont_attribute)
+              y0: legend_meta(@cont_attribute),
+              info: info
             }
 
             swap_x_and_y

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
@@ -18,7 +18,7 @@ module Api
             @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             @top_n = chart_parameters.top_n
             initialize_query
-            initialize_top_n_and_others_query(chart_parameters.top_n)
+            initialize_top_n_and_others_query
           end
 
           def call
@@ -51,11 +51,11 @@ module Api
             apply_flow_path_filters
           end
 
-          def initialize_top_n_and_others_query(top_n)
+          def initialize_top_n_and_others_query
             subquery = <<~SQL
               (
                 WITH q AS (#{@query.to_sql}),
-                u1 AS (SELECT x, y0 FROM q ORDER BY y0 DESC LIMIT #{top_n}),
+                u1 AS (SELECT x, y0 FROM q ORDER BY y0 DESC LIMIT #{@top_n}),
                 u2 AS (
                   SELECT '#{OTHER}' AS x, SUM(y0) AS y0 FROM q
                   WHERE NOT EXISTS (SELECT 1 FROM u1 WHERE q.x = u1.x)

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
@@ -23,7 +23,8 @@ module Api
               xAxis: {},
               yAxis: axis_meta(@cont_attribute, 'number'),
               x: {},
-              y0: legend_meta(@cont_attribute)
+              y0: legend_meta(@cont_attribute),
+              info: info
             }
             {data: @data, meta: @meta}
           end

--- a/app/services/concerns/api/v3/dashboards/charts/helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/helpers.rb
@@ -165,15 +165,15 @@ module Api
 
           def info
             {
-              node_type: @node_type&.name,
+              node_type: @node_type.try(:name),
               years: {
                 start_year: @start_year || @year,
                 end_year: @end_year
               },
               top_n: @top_n,
               filter: {
-                cont_attribute: @cont_attribute&.display_name,
-                ncont_attribute: @ncont_attribute&.display_name
+                cont_attribute: @cont_attribute.try(:display_name),
+                ncont_attribute: @ncont_attribute.try(:display_name)
               }
             }
           end

--- a/app/services/concerns/api/v3/dashboards/charts/helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/helpers.rb
@@ -162,6 +162,21 @@ module Api
             end
             output
           end
+
+          def info
+            {
+              node_type: @node_type&.name,
+              years: {
+                start_year: @start_year || @year,
+                end_year: @end_year
+              },
+              top_n: @top_n,
+              filter: {
+                cont_attribute: @cont_attribute&.display_name,
+                ncont_attribute: @ncont_attribute&.display_name
+              }
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
Add additional info to `meta` key in dashboard charts endpoints of this structure:
```
meta: {
    ...,
    info: {
         node_type: @node_type&.name,
         years: {
             start_year: @start_year || @year,
             end_year: @end_year
         },
         top_n: @top_n,
         filter: {
             cont_attribute: @cont_attribute&.display_name,
             ncont_attribute: @ncont_attribute&.display_name
         }
}
```
If for any of the properties value is not existent it will return `null`. Note, that also for `single_year..` endpoints the year is nested in `years.start_year`

The change affects these endpoints:
`api/v3/dashboards/charts/single_year_no_ncont_overview`
`api/v3/dashboards/charts/single_year_ncont_overview`
`api/v3/dashboards/charts/single_year_no_ncont_node_type_view`
`api/v3/dashboards/charts/single_year_ncont_node_type_view`
`api/v3/dashboards/charts/multi_year_no_ncont_overview`
`api/v3/dashboards/charts/multi_year_ncont_overview`
`api/v3/dashboards/charts/multi_year_no_ncont_node_type_view`

PT task: https://www.pivotaltracker.com/n/projects/1637931/stories/165025131