### PR TITLE
Fix: dashboard loading spinners

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.actions.js
@@ -23,6 +23,7 @@ export const DASHBOARD_ELEMENT__SET_SELECTED_RECOLOR_BY =
 export const DASHBOARD_ELEMENT__SET_CHARTS = 'DASHBOARD_ELEMENT__SET_CHARTS';
 export const DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS =
   'DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS';
+export const DASHBOARD_ELEMENT__SET_CHARTS_LOADING = 'DASHBOARD_ELEMENT__SET_CHARTS_LOADING';
 
 export const getDashboardPanelParams = (state, optionsType, options = {}) => {
   const {
@@ -134,4 +135,14 @@ export const setDashboardSelectedResizeBy = indicator => ({
 export const setDashboardSelectedRecolorBy = indicator => ({
   type: DASHBOARD_ELEMENT__SET_SELECTED_RECOLOR_BY,
   payload: { indicator }
+});
+
+export const setDashboardCharts = charts => ({
+  type: DASHBOARD_ELEMENT__SET_CHARTS,
+  payload: { charts }
+});
+
+export const setDashboardChartsLoading = loading => ({
+  type: DASHBOARD_ELEMENT__SET_CHARTS_LOADING,
+  payload: { loading }
 });

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -21,7 +21,8 @@ import {
   DASHBOARD_ELEMENT__SET_SELECTED_RECOLOR_BY,
   DASHBOARD_ELEMENT__SET_SELECTED_RESIZE_BY,
   DASHBOARD_ELEMENT__SET_CHARTS,
-  DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS
+  DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS,
+  DASHBOARD_ELEMENT__SET_CHARTS_LOADING
 } from './dashboard-element.actions';
 
 const initialState = {
@@ -74,7 +75,8 @@ const initialState = {
   selectedYears: null,
   selectedResizeBy: null,
   selectedRecolorBy: null,
-  charts: []
+  charts: [],
+  chartsLoading: false
 };
 
 const updateItems = (currentItems, newItem) => {
@@ -360,6 +362,13 @@ const dashboardElementReducer = {
       selectedResizeBy: resizeBy.attributeId,
       selectedRecolorBy: recolorBy.attributeId
     };
+  },
+  [DASHBOARD_ELEMENT__SET_CHARTS_LOADING](state, action) {
+    const { loading } = action.payload;
+    return {
+      ...state,
+      chartsLoading: loading
+    };
   }
 };
 
@@ -389,7 +398,8 @@ const dashboardElementReducerTypes = PropTypes => {
     commoditiesPanel: PropTypes.shape(PanelTypes).isRequired,
     selectedYears: PropTypes.arrayOf(PropTypes.number),
     selectedResizeBy: PropTypes.string,
-    selectedRecolorBy: PropTypes.string
+    selectedRecolorBy: PropTypes.string,
+    chartsLoading: PanelTypes.bool
   };
 };
 

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.component.jsx
@@ -21,6 +21,16 @@ function DashboardWidget(props) {
   );
 
   const renderChart = () => {
+    if (data && data.length === 0) {
+      return (
+        <div className="widget-centered background-no-data">
+          <Text color="white" weight="bold" variant="mono" size="lg">
+            No data available.
+          </Text>
+        </div>
+      );
+    }
+
     switch (chartConfig.type) {
       case 'sentence':
         return (
@@ -54,14 +64,6 @@ function DashboardWidget(props) {
     }
   };
 
-  const renderNoData = () => (
-    <div className="widget-centered background-no-data">
-      <Text color="white" weight="bold" variant="mono" size="lg">
-        No data available.
-      </Text>
-    </div>
-  );
-
   return (
     <div className="c-dashboard-widget">
       <div className="widget-title-container">
@@ -82,7 +84,7 @@ function DashboardWidget(props) {
               <Spinner className="-large -white" />
             </div>
           )}
-          {data && data.length > 0 && chartConfig ? renderChart() : renderNoData()}
+          {!loading && chartConfig && renderChart()}
         </ErrorCatch>
       </div>
     </div>

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.container.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.container.jsx
@@ -8,7 +8,8 @@ import { makeGetConfig } from 'react-components/dashboard-element/dashboard-widg
 const makeMapStateToProps = () => {
   const getDashboardWidgetsConfig = makeGetConfig();
   const mapStateToProps = (state, props) => ({
-    config: getDashboardWidgetsConfig(state, props)
+    config: getDashboardWidgetsConfig(state, props),
+    chartsLoading: state.dashboardElement.chartsLoading
   });
   return mapStateToProps;
 };
@@ -25,13 +26,13 @@ class DashboardWidgetContainer extends Component {
   }
 
   render() {
-    const { data, loading, error, meta, title, config } = this.props;
+    const { data, loading, error, meta, title, config, chartsLoading } = this.props;
     return config ? (
       <DashboardWidgetComponent
         data={data}
         title={title}
         error={error}
-        loading={loading}
+        loading={loading || chartsLoading}
         chartConfig={this.addTooltipContentToConfig(config, meta)}
       />
     ) : null;
@@ -44,7 +45,8 @@ DashboardWidgetContainer.propTypes = {
   meta: PropTypes.object,
   loading: PropTypes.bool,
   title: PropTypes.string,
-  config: PropTypes.object
+  config: PropTypes.object,
+  chartsLoading: PropTypes.bool
 };
 
 export default connect(makeMapStateToProps)(DashboardWidgetContainer);

--- a/frontend/scripts/tests/dashboard-element/reducer.test.js
+++ b/frontend/scripts/tests/dashboard-element/reducer.test.js
@@ -14,7 +14,18 @@ import {
   DASHBOARD_ELEMENT__SET_SEARCH_RESULTS,
   DASHBOARD_ELEMENT__SET_ACTIVE_ITEM,
   DASHBOARD_ELEMENT__SET_ACTIVE_ITEMS,
-  DASHBOARD_ELEMENT__SET_ACTIVE_ITEMS_WITH_SEARCH
+  DASHBOARD_ELEMENT__SET_ACTIVE_ITEMS_WITH_SEARCH,
+  DASHBOARD_ELEMENT__SET_SELECTED_YEARS,
+  setDashboardSelectedYears,
+  setDashboardSelectedResizeBy,
+  DASHBOARD_ELEMENT__SET_SELECTED_RESIZE_BY,
+  DASHBOARD_ELEMENT__SET_SELECTED_RECOLOR_BY,
+  setDashboardSelectedRecolorBy,
+  DASHBOARD_ELEMENT__SET_CHARTS,
+  setDashboardCharts,
+  DASHBOARD_ELEMENT__SET_CHARTS_LOADING,
+  setDashboardChartsLoading,
+  DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS
 } from 'react-components/dashboard-element/dashboard-element.actions';
 
 describe(DASHBOARD_ELEMENT__SET_ACTIVE_PANEL, () => {
@@ -733,5 +744,74 @@ test(DASHBOARD_ELEMENT__SET_ACTIVE_ITEMS_WITH_SEARCH, () => {
       activeTab: tabs.companies[0],
       page: initialState.companiesPanel.page
     }
+  });
+});
+
+test(DASHBOARD_ELEMENT__SET_SELECTED_YEARS, () => {
+  const years = [2010, 2015];
+  const action = setDashboardSelectedYears(years);
+  const newState = reducer(initialState, action);
+  expect(newState).toEqual({
+    ...initialState,
+    selectedYears: years
+  });
+});
+
+test(DASHBOARD_ELEMENT__SET_SELECTED_RESIZE_BY, () => {
+  const resizeBy = { attributeId: 0 };
+  const action = setDashboardSelectedResizeBy(resizeBy);
+  const newState = reducer(initialState, action);
+  expect(newState).toEqual({
+    ...initialState,
+    selectedResizeBy: resizeBy.attributeId
+  });
+});
+
+test(DASHBOARD_ELEMENT__SET_SELECTED_RECOLOR_BY, () => {
+  const recolorBy = { attributeId: 1 };
+  const action = setDashboardSelectedRecolorBy(recolorBy);
+  const newState = reducer(initialState, action);
+  expect(newState).toEqual({
+    ...initialState,
+    selectedRecolorBy: recolorBy.attributeId
+  });
+});
+
+test(DASHBOARD_ELEMENT__SET_CHARTS, () => {
+  const charts = [{ type: 'bar_chart', url: 'my_url' }];
+  const action = setDashboardCharts(charts);
+  const newState = reducer(initialState, action);
+  expect(newState).toEqual({
+    ...initialState,
+    charts
+  });
+});
+
+test(DASHBOARD_ELEMENT__SET_CHARTS_LOADING, () => {
+  const loading = true;
+  const action = setDashboardChartsLoading(loading);
+  const newState = reducer(initialState, action);
+  expect(newState).toEqual({
+    ...initialState,
+    chartsLoading: loading
+  });
+});
+
+test(DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS, () => {
+  const payload = {
+    years: [2010, 2015],
+    resizeBy: { attributeId: 0 },
+    recolorBy: { attributeId: 1 }
+  };
+  const action = {
+    type: DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS,
+    payload
+  };
+  const newState = reducer(initialState, action);
+  expect(newState).toEqual({
+    ...initialState,
+    selectedYears: payload.years,
+    selectedResizeBy: payload.resizeBy.attributeId,
+    selectedRecolorBy: payload.recolorBy.attributeId
   });
 });

--- a/frontend/scripts/tests/dashboard-element/saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/saga.test.js
@@ -78,7 +78,7 @@ describe('fetchDashboardPanelInitialData', () => {
   it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_TABS} if the current active panel is companies`, async () => {
     const dispatched = await recordSaga(
       fetchDashboardPanelInitialData,
-      setDashboardActivePanel('any'),
+      setDashboardActivePanel('commodities'),
       stateCompanies
     );
     expect(dispatched).toContainEqual({
@@ -95,17 +95,6 @@ describe('fetchDashboardPanelInitialData', () => {
       setDashboardActivePanel('sources'),
       baseState
     );
-    // Clears panel data
-    expect(dispatched).toContainEqual({
-      payload: {
-        key: 'countries',
-        data: null,
-        meta: null,
-        tab: null,
-        loading: true
-      },
-      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
-    });
     // Sets panel data for countries
     expect(dispatched).toContainEqual({
       payload: {
@@ -139,10 +128,10 @@ describe('fetchDashboardPanelInitialData', () => {
     expect(dispatched).toContainEqual({
       payload: {
         key: 'commodities',
-        data: null,
-        meta: null,
+        data,
+        meta,
         tab: null,
-        loading: true
+        loading: false
       },
       type: DASHBOARD_ELEMENT__SET_PANEL_DATA
     });
@@ -205,17 +194,6 @@ describe('onTabChange', () => {
 
   it(`dispatches ${DASHBOARD_ELEMENT__SET_PANEL_DATA} if tab action is triggered`, async () => {
     const dispatched = await recordSaga(onTabChange, searchAction, differentTabChangeState);
-    // Clears data
-    expect(dispatched).toContainEqual({
-      payload: {
-        key: 'sources',
-        data: null,
-        meta: null,
-        tab: 3,
-        loading: true
-      },
-      type: DASHBOARD_ELEMENT__SET_PANEL_DATA
-    });
     expect(dispatched).toContainEqual({
       payload: {
         key: 'sources',

--- a/frontend/scripts/tests/dashboard-widget/__snapshots__/dashboard-widget-selectors.test.js.snap
+++ b/frontend/scripts/tests/dashboard-widget/__snapshots__/dashboard-widget-selectors.test.js.snap
@@ -129,16 +129,19 @@ Object {
   "xKeys": Object {
     "bars": Object {
       "x0": Object {
+        "barSize": 10,
         "fill": "#C2E699",
         "interval": "preserveStartEnd",
         "stroke": "#C2E699",
       },
       "x1": Object {
+        "barSize": 10,
         "fill": "#e36845",
         "interval": "preserveStartEnd",
         "stroke": "#e36845",
       },
       "x2": Object {
+        "barSize": 10,
         "fill": "#1D6837",
         "interval": "preserveStartEnd",
         "stroke": "#1D6837",
@@ -147,6 +150,7 @@ Object {
   },
   "xKeysAttributes": Object {
     "bars": Object {
+      "barSize": 10,
       "interval": "preserveStartEnd",
     },
   },
@@ -218,16 +222,19 @@ Object {
   "xKeys": Object {
     "bars": Object {
       "x0": Object {
+        "barSize": 10,
         "fill": "#ea6869",
         "interval": "preserveStartEnd",
         "stroke": "#ea6869",
       },
       "x1": Object {
+        "barSize": 10,
         "fill": "#ffeb8b",
         "interval": "preserveStartEnd",
         "stroke": "#ffeb8b",
       },
       "x2": Object {
+        "barSize": 10,
         "fill": "#2d586e",
         "interval": "preserveStartEnd",
         "stroke": "#2d586e",
@@ -236,6 +243,7 @@ Object {
   },
   "xKeysAttributes": Object {
     "bars": Object {
+      "barSize": 10,
       "interval": "preserveStartEnd",
     },
   },


### PR DESCRIPTION
This PR fixes the broken snapshot tests and prevents sets the widgets to loading when a indicator has changed. It also prevents spinners from showing if there's no need for them to show.