### PR TITLE
Fix/flow path filters metadata

### DIFF
--- a/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
@@ -8,12 +8,12 @@ module Api
 
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
+            @chart_parameters = chart_parameters
             @cont_attribute = chart_parameters.cont_attribute
             @context = chart_parameters.context
             @start_year = chart_parameters.start_year
             @end_year = chart_parameters.end_year
             @ncont_attribute = chart_parameters.ncont_attribute
-            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             initialize_query
           end
 

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
@@ -10,13 +10,13 @@ module Api
 
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
+            @chart_parameters = chart_parameters
             @cont_attribute = chart_parameters.cont_attribute
             @context = chart_parameters.context
             @start_year = chart_parameters.start_year
             @end_year = chart_parameters.end_year
             @node_type = chart_parameters.node_type
             @node_type_idx = chart_parameters.node_type_idx
-            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             @top_n = chart_parameters.top_n
             initialize_query
             initialize_top_n_and_others_query

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_overview.rb
@@ -8,11 +8,11 @@ module Api
 
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
+            @chart_parameters = chart_parameters
             @cont_attribute = chart_parameters.cont_attribute
             @context = chart_parameters.context
             @start_year = chart_parameters.start_year
             @end_year = chart_parameters.end_year
-            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             initialize_query
           end
 

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
@@ -10,13 +10,13 @@ module Api
 
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
+            @chart_parameters = chart_parameters
             @cont_attribute = chart_parameters.cont_attribute
             @ncont_attribute = chart_parameters.ncont_attribute
             @context = chart_parameters.context
             @year = chart_parameters.start_year
             @node_type = chart_parameters.node_type
             @node_type_idx = chart_parameters.node_type_idx
-            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             @top_n = chart_parameters.top_n
             initialize_query
             initialize_top_n_and_others_query

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_overview.rb
@@ -8,11 +8,11 @@ module Api
 
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
+            @chart_parameters = chart_parameters
             @cont_attribute = chart_parameters.cont_attribute
             @context = chart_parameters.context
             @year = chart_parameters.start_year
             @ncont_attribute = chart_parameters.ncont_attribute
-            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             initialize_query
           end
 

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
@@ -10,12 +10,12 @@ module Api
 
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
+            @chart_parameters = chart_parameters
             @cont_attribute = chart_parameters.cont_attribute
             @context = chart_parameters.context
             @year = chart_parameters.start_year
             @node_type = chart_parameters.node_type
             @node_type_idx = chart_parameters.node_type_idx
-            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             @top_n = chart_parameters.top_n
             initialize_query
             initialize_top_n_and_others_query

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_overview.rb
@@ -8,10 +8,10 @@ module Api
 
           # @param chart_parameters [Api::V3::Dashboards::ChartParameters]
           def initialize(chart_parameters)
+            @chart_parameters = chart_parameters
             @cont_attribute = chart_parameters.cont_attribute
             @context = chart_parameters.context
             @year = chart_parameters.start_year
-            @nodes_ids_by_position = chart_parameters.nodes_ids_by_position
             initialize_query
           end
 

--- a/app/services/api/v3/dashboards/parametrised_charts.rb
+++ b/app/services/api/v3/dashboards/parametrised_charts.rb
@@ -132,7 +132,11 @@ module Api
         # are presented using the same chart type
         # however, node type view has one chart per selected node
         def multi_year_ncont_charts
-          parametrised_charts = [all_params.merge(multi_year_ncont_overview)]
+          parametrised_charts = [
+            all_params.
+              except(*flow_path_param_names).
+              merge(multi_year_ncont_overview)
+          ]
           [
             :sources_ids, :companies_ids, :destinations_ids
           ].each do |nodes_ids_param_name|
@@ -197,6 +201,10 @@ module Api
             start_year: @start_year,
             end_year: @end_year
           }
+        end
+
+        def flow_path_param_names
+          [:sources_ids, :companies_ids, :destinations_ids]
         end
       end
     end

--- a/app/services/concerns/api/v3/dashboards/charts/helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/helpers.rb
@@ -64,7 +64,7 @@ module Api
           end
 
           def apply_flow_path_filters
-            @nodes_ids_by_position.each do |position, nodes_ids|
+            @chart_parameters.nodes_ids_by_position.each do |position, nodes_ids|
               @query = @query.where(
                 'flows.path[?] IN (?)', position + 1, nodes_ids
               )

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -1020,6 +1020,8 @@ paths:
                         $ref: "#/components/schemas/DashboardsEmptyXLegend"
                       y0:
                         $ref: "#/components/schemas/DashboardsYLegend"
+                      info:
+                        $ref: "#/components/schemas/DashboardsMetaInfo"
 
   /dashboards/charts/single_year_ncont_overview:
     get:
@@ -1067,6 +1069,8 @@ paths:
                         $ref: "#/components/schemas/DashboardsNcontXLegend"
                       y0:
                         $ref: "#/components/schemas/DashboardsYLegend"
+                      info:
+                        $ref: "#/components/schemas/DashboardsMetaInfo"
 
   /dashboards/charts/multi_year_no_ncont_overview:
     get:
@@ -1114,6 +1118,8 @@ paths:
                         $ref: "#/components/schemas/DashboardsYearXLegend"
                       y0:
                         $ref: "#/components/schemas/DashboardsYLegend"
+                      info:
+                        $ref: "#/components/schemas/DashboardsMetaInfo"
 
   /dashboards/charts/multi_year_ncont_overview:
     get:
@@ -1200,7 +1206,9 @@ paths:
                               label:
                                 type: string
                                 example: '5.0'
-
+                      info:
+                        $ref: "#/components/schemas/DashboardsMetaInfo"
+                            
   /dashboards/charts/single_year_no_ncont_node_type_view:
     get:
       tags:
@@ -1248,6 +1256,8 @@ paths:
                         $ref: "#/components/schemas/DashboardsNodeTypeXLegend"
                       y0:
                         $ref: "#/components/schemas/DashboardsYLegend"
+                      info:
+                        $ref: "#/components/schemas/DashboardsMetaInfo"
 
   /dashboards/charts/single_year_ncont_node_type_view:
     get:
@@ -1325,6 +1335,8 @@ paths:
                               label:
                                 type: string
                                 example: 'Soy Moratorium'
+                      info:
+                        $ref: "#/components/schemas/DashboardsMetaInfo"
 
   /dashboards/charts/multi_year_no_ncont_node_type_view:
     get:
@@ -1400,6 +1412,8 @@ paths:
                               label:
                                 type: string
                                 example: 'OTHER'
+                      info:
+                        $ref: "#/components/schemas/DashboardsMetaInfo"
 
 servers:
   - url: https://trase.earth/api/v3
@@ -2695,7 +2709,6 @@ components:
               type: string
               example: ""
               description: not used
-              
     DashboardsYearXLegend:
       type: object
       properties:
@@ -2758,3 +2771,85 @@ components:
               type: string
               example: ""
               description: not used
+    DashboardsMetaInfo:
+      type: object
+      properties:
+        node_type:
+          type: integer
+          example: 1
+          nullable: true
+        years:
+          type: object
+          properties:
+            start_year:
+              type: integer
+              example: 2016
+            end_year:
+              type: integer
+              example: 2017
+        top_n:
+          type: integer
+          example: null
+          nullable: true
+        filter:
+          type: object
+          properties:
+            cont_attribute:
+              type: string
+              example: 'Trade volume'
+            ncont_attribute:
+              type: string
+              example: 'Forest 500 score'
+            sources:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  node_type_id:
+                    type: integer
+                  node_type:
+                    type: string
+                  profile:
+                    type: string
+                    example: 'place'
+                    nullable: true
+                    description: 'place or null'
+            companies:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  node_type_id:
+                    type: integer
+                  node_type:
+                    type: string
+                  profile:
+                    type: string
+                    example: 'actor'
+                    nullable: true
+                    description: 'actor or null'
+            destinations:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  node_type_id:
+                    type: integer
+                  node_type:
+                    type: string
+                  profile:
+                    type: string
+                    example: 'null'
+                    nullable: true

--- a/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
@@ -55,7 +55,8 @@
         "y1",
         "y2",
         "y3",
-        "y4"
+        "y4",
+        "info"
       ],
       "properties": {
         "xAxis": {
@@ -370,6 +371,77 @@
                   "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "info": {
+          "$id": "#/properties/meta/properties/info",
+          "type": "object",
+          "required": [
+            "node_type",
+            "years",
+            "top_n",
+            "filter"
+          ],
+          "properties": {
+            "node_type": {
+              "$id": "#/properties/meta/properties/info/properties/node_type",
+              "type": "null"
+            },
+            "years": {
+              "$id": "#/properties/meta/properties/info/properties/years",
+              "type": "object",
+              "required": [
+                "start_year",
+                "end_year"
+              ],
+              "properties": {
+                "start_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/start_year",
+                  "type": "integer"
+                },
+                "end_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/end_year",
+                  "type": "integer"
+                }
+              }
+            },
+            "top_n": {
+              "$id": "#/properties/meta/properties/info/properties/top_n",
+              "type": "null"
+            },
+            "filter": {
+              "$id": "#/properties/meta/properties/info/properties/filter",
+              "type": "object",
+              "required": [
+                "cont_attribute",
+                "ncont_attribute",
+                "sources",
+                "companies",
+                "destinations"
+              ],
+              "properties": {
+                "cont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/cont_attribute",
+                  "type": "string"
+                },
+                "ncont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/ncont_attribute",
+                  "type": ["string", "null"]
+                },
+                "sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/sources",
+                  "type": "array"
+                },
+                "companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/companies",
+                  "type": "array"
+                },
+                "destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
                 }
               }
             }

--- a/spec/support/schemas/dashboards_charts_multi_year_no_ncont_node_type_view.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_no_ncont_node_type_view.json
@@ -41,7 +41,8 @@
         "yAxis",
         "x",
         "y0",
-        "y1"
+        "y1",
+        "info"
       ],
       "properties": {
         "xAxis": {
@@ -238,6 +239,77 @@
                   "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "info": {
+          "$id": "#/properties/meta/properties/info",
+          "type": "object",
+          "required": [
+            "node_type",
+            "years",
+            "top_n",
+            "filter"
+          ],
+          "properties": {
+            "node_type": {
+              "$id": "#/properties/meta/properties/info/properties/node_type",
+              "type": "string"
+            },
+            "years": {
+              "$id": "#/properties/meta/properties/info/properties/years",
+              "type": "object",
+              "required": [
+                "start_year",
+                "end_year"
+              ],
+              "properties": {
+                "start_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/start_year",
+                  "type": "integer"
+                },
+                "end_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/end_year",
+                  "type": "integer"
+                }
+              }
+            },
+            "top_n": {
+              "$id": "#/properties/meta/properties/info/properties/top_n",
+              "type": "integer"
+            },
+            "filter": {
+              "$id": "#/properties/meta/properties/info/properties/filter",
+              "type": "object",
+              "required": [
+                "cont_attribute",
+                "ncont_attribute",
+                "sources",
+                "companies",
+                "destinations"
+              ],
+              "properties": {
+                "cont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/cont_attribute",
+                  "type": "string"
+                },
+                "ncont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/ncont_attribute",
+                  "type": ["string", "null"]
+                },
+                "sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/sources",
+                  "type": "array"
+                },
+                "companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/companies",
+                  "type": "array"
+                },
+                "destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
                 }
               }
             }

--- a/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
@@ -37,7 +37,8 @@
         "xAxis",
         "yAxis",
         "x",
-        "y0"
+        "y0",
+        "info"
       ],
       "properties": {
         "xAxis": {
@@ -193,6 +194,77 @@
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "info": {
+          "$id": "#/properties/meta/properties/info",
+          "type": "object",
+          "required": [
+            "node_type",
+            "years",
+            "top_n",
+            "filter"
+          ],
+          "properties": {
+            "node_type": {
+              "$id": "#/properties/meta/properties/info/properties/node_type",
+              "type": "null"
+            },
+            "years": {
+              "$id": "#/properties/meta/properties/info/properties/years",
+              "type": "object",
+              "required": [
+                "start_year",
+                "end_year"
+              ],
+              "properties": {
+                "start_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/start_year",
+                  "type": "integer"
+                },
+                "end_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/end_year",
+                  "type": "integer"
+                }
+              }
+            },
+            "top_n": {
+              "$id": "#/properties/meta/properties/info/properties/top_n",
+              "type": "null"
+            },
+            "filter": {
+              "$id": "#/properties/meta/properties/info/properties/filter",
+              "type": "object",
+              "required": [
+                "cont_attribute",
+                "ncont_attribute",
+                "sources",
+                "companies",
+                "destinations"
+              ],
+              "properties": {
+                "cont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/cont_attribute",
+                  "type": "string"
+                },
+                "ncont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/ncont_attribute",
+                  "type": ["string", "null"]
+                },
+                "sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/sources",
+                  "type": "array"
+                },
+                "companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/companies",
+                  "type": "array"
+                },
+                "destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
                 }
               }
             }

--- a/spec/support/schemas/dashboards_charts_single_year_ncont_node_type_view.json
+++ b/spec/support/schemas/dashboards_charts_single_year_ncont_node_type_view.json
@@ -62,7 +62,8 @@
         "x1",
         "x2",
         "x3",
-        "x4"
+        "x4",
+        "info"
       ],
       "properties": {
         "yAxis": {
@@ -382,6 +383,77 @@
                   "$id": "#/properties/meta/properties/x4/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "info": {
+          "$id": "#/properties/meta/properties/info",
+          "type": "object",
+          "required": [
+            "node_type",
+            "years",
+            "top_n",
+            "filter"
+          ],
+          "properties": {
+            "node_type": {
+              "$id": "#/properties/meta/properties/info/properties/node_type",
+              "type": "string"
+            },
+            "years": {
+              "$id": "#/properties/meta/properties/info/properties/years",
+              "type": "object",
+              "required": [
+                "start_year",
+                "end_year"
+              ],
+              "properties": {
+                "start_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/start_year",
+                  "type": "integer"
+                },
+                "end_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/end_year",
+                  "type": "null"
+                }
+              }
+            },
+            "top_n": {
+              "$id": "#/properties/meta/properties/info/properties/top_n",
+              "type": "integer"
+            },
+            "filter": {
+              "$id": "#/properties/meta/properties/info/properties/filter",
+              "type": "object",
+              "required": [
+                "cont_attribute",
+                "ncont_attribute",
+                "sources",
+                "companies",
+                "destinations"
+              ],
+              "properties": {
+                "cont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/cont_attribute",
+                  "type": "string"
+                },
+                "ncont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/ncont_attribute",
+                  "type": ["string", "null"]
+                },
+                "sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/sources",
+                  "type": "array"
+                },
+                "companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/companies",
+                  "type": "array"
+                },
+                "destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
                 }
               }
             }

--- a/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
@@ -37,7 +37,8 @@
         "xAxis",
         "yAxis",
         "x",
-        "y0"
+        "y0",
+        "info"
       ],
       "properties": {
         "xAxis": {
@@ -193,6 +194,77 @@
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "info": {
+          "$id": "#/properties/meta/properties/info",
+          "type": "object",
+          "required": [
+            "node_type",
+            "years",
+            "top_n",
+            "filter"
+          ],
+          "properties": {
+            "node_type": {
+              "$id": "#/properties/meta/properties/info/properties/node_type",
+              "type": "null"
+            },
+            "years": {
+              "$id": "#/properties/meta/properties/info/properties/years",
+              "type": "object",
+              "required": [
+                "start_year",
+                "end_year"
+              ],
+              "properties": {
+                "start_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/start_year",
+                  "type": "integer"
+                },
+                "end_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/end_year",
+                  "type": "null"
+                }
+              }
+            },
+            "top_n": {
+              "$id": "#/properties/meta/properties/info/properties/top_n",
+              "type": "null"
+            },
+            "filter": {
+              "$id": "#/properties/meta/properties/info/properties/filter",
+              "type": "object",
+              "required": [
+                "cont_attribute",
+                "ncont_attribute",
+                "sources",
+                "companies",
+                "destinations"
+              ],
+              "properties": {
+                "cont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/cont_attribute",
+                  "type": "string"
+                },
+                "ncont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/ncont_attribute",
+                  "type": ["string", "null"]
+                },
+                "sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/sources",
+                  "type": "array"
+                },
+                "companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/companies",
+                  "type": "array"
+                },
+                "destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
                 }
               }
             }

--- a/spec/support/schemas/dashboards_charts_single_year_no_ncont_node_type_view.json
+++ b/spec/support/schemas/dashboards_charts_single_year_no_ncont_node_type_view.json
@@ -38,7 +38,8 @@
         "yAxis",
         "xAxis",
         "y",
-        "x0"
+        "x0",
+        "info"
       ],
       "properties": {
         "yAxis": {
@@ -194,6 +195,77 @@
                   "$id": "#/properties/meta/properties/x0/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "info": {
+          "$id": "#/properties/meta/properties/info",
+          "type": "object",
+          "required": [
+            "node_type",
+            "years",
+            "top_n",
+            "filter"
+          ],
+          "properties": {
+            "node_type": {
+              "$id": "#/properties/meta/properties/info/properties/node_type",
+              "type": "string"
+            },
+            "years": {
+              "$id": "#/properties/meta/properties/info/properties/years",
+              "type": "object",
+              "required": [
+                "start_year",
+                "end_year"
+              ],
+              "properties": {
+                "start_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/start_year",
+                  "type": "integer"
+                },
+                "end_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/end_year",
+                  "type": "null"
+                }
+              }
+            },
+            "top_n": {
+              "$id": "#/properties/meta/properties/info/properties/top_n",
+              "type": "integer"
+            },
+            "filter": {
+              "$id": "#/properties/meta/properties/info/properties/filter",
+              "type": "object",
+              "required": [
+                "cont_attribute",
+                "ncont_attribute",
+                "sources",
+                "companies",
+                "destinations"
+              ],
+              "properties": {
+                "cont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/cont_attribute",
+                  "type": "string"
+                },
+                "ncont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/ncont_attribute",
+                  "type": ["string", "null"]
+                },
+                "sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/sources",
+                  "type": "array"
+                },
+                "companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/companies",
+                  "type": "array"
+                },
+                "destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
                 }
               }
             }

--- a/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
@@ -32,7 +32,8 @@
         "xAxis",
         "yAxis",
         "x",
-        "y0"
+        "y0",
+        "info"
       ],
       "properties": {
         "xAxis": {
@@ -117,6 +118,77 @@
                   "$id": "#/properties/meta/properties/y0/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
+                }
+              }
+            }
+          }
+        },
+        "info": {
+          "$id": "#/properties/meta/properties/info",
+          "type": "object",
+          "required": [
+            "node_type",
+            "years",
+            "top_n",
+            "filter"
+          ],
+          "properties": {
+            "node_type": {
+              "$id": "#/properties/meta/properties/info/properties/node_type",
+              "type": "null"
+            },
+            "years": {
+              "$id": "#/properties/meta/properties/info/properties/years",
+              "type": "object",
+              "required": [
+                "start_year",
+                "end_year"
+              ],
+              "properties": {
+                "start_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/start_year",
+                  "type": "integer"
+                },
+                "end_year": {
+                  "$id": "#/properties/meta/properties/info/properties/years/properties/end_year",
+                  "type": "null"
+                }
+              }
+            },
+            "top_n": {
+              "$id": "#/properties/meta/properties/info/properties/top_n",
+              "type": "null"
+            },
+            "filter": {
+              "$id": "#/properties/meta/properties/info/properties/filter",
+              "type": "object",
+              "required": [
+                "cont_attribute",
+                "ncont_attribute",
+                "sources",
+                "companies",
+                "destinations"
+              ],
+              "properties": {
+                "cont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/cont_attribute",
+                  "type": "string"
+                },
+                "ncont_attribute": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/ncont_attribute",
+                  "type": ["string", "null"]
+                },
+                "sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/sources",
+                  "type": "array"
+                },
+                "companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/companies",
+                  "type": "array"
+                },
+                "destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
                 }
               }
             }


### PR DESCRIPTION
Adds extra metadata to info -> filters to identify the applied flow path filters.

e.g.

```
"info": {
      "filter":{
            "sources":[  
               {  
                  "id":11444,
                  "name":"AMAZONIA",
                  "node_type_id":1,
                  "node_type":"BIOME",
                  "profile":null
               }
            ],
            "companies":[  

            ],
            "destinations":[  

            ]
      }
}
```