### PR TITLE
Fix corejs2 to corejs3 migration

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -7,7 +7,9 @@
     "@babel/preset-react"
   ],
   "plugins": [
-    "@babel/plugin-transform-runtime",
+    ["@babel/transform-runtime", {
+      "corejs": 3
+    }],
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-object-rest-spread",
     "@babel/plugin-transform-exponentiation-operator",
@@ -28,7 +30,9 @@
         "@babel/plugin-transform-exponentiation-operator",
         ["@babel/plugin-proposal-class-properties", { "spec": true }],
         "transform-react-remove-prop-types",
-        "@babel/plugin-transform-runtime",
+        ["@babel/transform-runtime", {
+          "corejs": 3
+        }],
         "lodash"
       ]
     },
@@ -46,7 +50,9 @@
         "@babel/plugin-transform-exponentiation-operator",
         ["@babel/plugin-proposal-class-properties", { "spec": true }],
         "@babel/plugin-transform-modules-commonjs",
-        "@babel/plugin-transform-runtime",
+        ["@babel/transform-runtime", {
+          "corejs": 3
+        }],
         ["module-resolver", {
           "alias": {
             "scripts": "./scripts",

--- a/frontend/config/webpack.config.js
+++ b/frontend/config/webpack.config.js
@@ -18,7 +18,7 @@ const templates = require('./static.templates');
 module.exports = {
   entry: {
     fetch: 'whatwg-fetch',
-    main: ['@babel/polyfill', path.join(srcPath, 'index')]
+    main: path.join(srcPath, 'index')
   },
   output: {
     filename: '[name].[chunkhash].js',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,8 +110,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.4.3",
-    "@babel/polyfill": "^7.4.3",
-    "@babel/runtime": "^7.4.3",
+    "@babel/runtime-corejs3": "^7.4.3",
     "@turf/bbox": "6.0.1",
     "axios": "^0.18.0",
     "chroma-js": "1.3.7",

--- a/frontend/scripts/index.js
+++ b/frontend/scripts/index.js
@@ -1,4 +1,7 @@
 /* eslint-disable global-require,import/no-extraneous-dependencies */
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import createSagaMiddleware from 'redux-saga';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -966,14 +966,6 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
-"@babel/polyfill@^7.4.3":
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.3.tgz#332dc6f57b718017c3a8b37b4eea8aa6eeac1187"
-  integrity sha512-rkv8WIvJshA5Ev8iNMGgz5WZkRtgtiPexiT7w5qevGTuT7ZBfM3de9ox1y9JR5/OXb/sWGBbWlHNa7vQKqku3Q==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
-
 "@babel/preset-env@7.2.3":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.2.3.tgz#948c8df4d4609c99c7e0130169f052ea6a7a8933"
@@ -1150,6 +1142,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
+
+"@babel/runtime-corejs3@^7.4.3":
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.4.3.tgz#32a5114bdf255f2eed3078f07d675f774adbb394"
+  integrity sha512-12jcdiSTZu6bLXyjCqD4E8/rFoctaLjR/MvIiI4I4kvqFEnifeDbaChDpYHrt9meOXbkDpykXdqhXfRJCJYHxQ==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.2"
 
 "@babel/runtime@7.0.0":
   version "7.0.0"
@@ -4218,7 +4218,7 @@ core-js-compat@^3.0.0:
     core-js-pure "3.0.1"
     semver "^6.0.0"
 
-core-js-pure@3.0.1:
+core-js-pure@3.0.1, core-js-pure@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.0.1.tgz#37358fb0d024e6b86d443d794f4e37e949098cbe"
   integrity sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==


### PR DESCRIPTION
Adds missing config and updates babel transform-runtime.

This is a polyfill change, could you test it on browserstack 🙏 .

I tested in Chrome, FF and Safari, but prefer to be sure.