### PR TITLE
Fixes to multi-year ncont scenario

### DIFF
--- a/app/controllers/concerns/api/v3/dashboards/filter_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/filter_params.rb
@@ -18,7 +18,8 @@ module Api
             companies_ids: cs_string_to_int_array(params[:companies_ids]),
             destinations_ids: cs_string_to_int_array(params[:destinations_ids]),
             node_type_id: string_to_int(params[:node_type_id]),
-            top_n: string_to_int(params[:top_n])
+            top_n: string_to_int(params[:top_n]),
+            single_filter_key: params[:single_filter_key]
           }
         end
 

--- a/app/services/api/v3/dashboards/chart_parameters.rb
+++ b/app/services/api/v3/dashboards/chart_parameters.rb
@@ -13,7 +13,8 @@ module Api
                     :companies_ids,
                     :destinations_ids,
                     :node_type,
-                    :top_n
+                    :top_n,
+                    :single_filter_key
 
         # @param params [Hash]
         # @option params [Integer] country_id
@@ -27,6 +28,7 @@ module Api
         # @option params [Integer] end_year
         # @option params [Integer] node_type_id
         # @option params [Integer] top_n
+        # @option params [String] single_filter_key
         def initialize(params)
           @country_id = params[:country_id]
           @commodity_id = params[:commodity_id]
@@ -48,6 +50,7 @@ module Api
           @start_year = params[:start_year]
           @end_year = params[:end_year]
           @top_n = params[:top_n]
+          @single_filter_key = params[:single_filter_key]
         end
 
         def node_type_idx

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
@@ -91,7 +91,7 @@ module Api
 
           def apply_top_nodes_break_by
             @query = @query.
-              select("COALESCE(top_nodes.name, '#{OTHER}') AS break_by").
+              select("COALESCE(top_nodes.name, '#{OTHER}'::TEXT) AS break_by").
               joins("LEFT JOIN top_nodes ON top_nodes.id = flows.path[#{@node_type_idx}]").
               group('top_nodes.name')
           end

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
@@ -81,7 +81,7 @@ module Api
                 u2 AS (
                   SELECT x, JSONB_OBJECT_AGG(break_by, y0), SUM(y0) AS y
                   FROM (
-                    SELECT '#{OTHER}' AS x, break_by, SUM(y0) AS y0 FROM q
+                    SELECT '#{OTHER}'::TEXT AS x, break_by, SUM(y0) AS y0 FROM q
                     WHERE NOT EXISTS (SELECT 1 FROM u1 WHERE q.x = u1.x)
                     GROUP BY break_by
                   ) s GROUP BY x

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
@@ -57,7 +57,7 @@ module Api
                 WITH q AS (#{@query.to_sql}),
                 u1 AS (SELECT x, y0 FROM q WHERE NOT is_unknown ORDER BY y0 DESC LIMIT #{@top_n}),
                 u2 AS (
-                  SELECT '#{OTHER}' AS x, SUM(y0) AS y0 FROM q
+                  SELECT '#{OTHER}'::TEXT AS x, SUM(y0) AS y0 FROM q
                   WHERE NOT EXISTS (SELECT 1 FROM u1 WHERE q.x = u1.x)
                 )
                 SELECT * FROM u1

--- a/app/services/api/v3/dashboards/node_types_to_break_by.rb
+++ b/app/services/api/v3/dashboards/node_types_to_break_by.rb
@@ -5,12 +5,6 @@ module Api
   module V3
     module Dashboards
       class NodeTypesToBreakBy
-        # TODO: incorporate the new "role" attribute here
-        SOURCE_COLUMN_GROUP = 0
-        EXPORTER_COLUMN_GROUP = 1
-        IMPORTER_COLUMN_GROUP = 2
-        DESTINATION_COLUMN_GROUP = 3
-
         # @param context [Api::V3::Context]
         # @param [Array<Integer>] source_node_types_ids
         # @param [Array<Integer>] company_node_types_ids
@@ -25,79 +19,75 @@ module Api
           @source_node_types_ids = source_node_types_ids || []
           @company_node_types_ids = company_node_types_ids || []
           @destination_node_types_ids = destination_node_types_ids || []
-        end
 
-        def call
           context_node_types = @context.context_node_types.
             includes(:context_node_type_property, :node_type)
-          grouped_context_node_types = context_node_types.group_by do |cnt|
-            cnt.context_node_type_property.column_group
+          @context_node_types_by_role = context_node_types.group_by do |cnt|
+            cnt.context_node_type_property.role
           end
+        end
 
-          result =
-            enabled_source_node_types(
-              grouped_context_node_types[SOURCE_COLUMN_GROUP]
-            ) +
-            enabled_exporter_node_types(
-              grouped_context_node_types[EXPORTER_COLUMN_GROUP]
-            ) +
-            enabled_importer_node_types(
-              grouped_context_node_types[IMPORTER_COLUMN_GROUP]
-            ) +
-            enabled_destination_node_types(
-              grouped_context_node_types[DESTINATION_COLUMN_GROUP]
-            )
+        def selected_node_types
+          selected_source_node_types +
+            selected_exporter_node_types +
+            selected_importer_node_types +
+            selected_destination_node_types
+        end
 
-          result.map(&:node_type)
+        def unselected_node_types
+          (source_node_types - selected_source_node_types) +
+            (exporter_node_types - selected_exporter_node_types) +
+            (importer_node_types - selected_importer_node_types) +
+            (destination_node_types - selected_destination_node_types)
         end
 
         private
 
-        def enabled_source_node_types(source_node_types)
-          return [] unless source_node_types
+        def source_node_types
+          @context_node_types_by_role[
+            Api::V3::ContextNodeTypeProperty::SOURCE_ROLE
+          ]&.map(&:node_type) || []
+        end
 
-          source_node_types.select do |cnt|
-            if @source_node_types_ids.any?
-              @source_node_types_ids.include?(cnt.node_type_id)
-            else
-              true
-            end
+        def selected_source_node_types
+          source_node_types.select do |nt|
+            @source_node_types_ids.include?(nt.id)
           end
         end
 
-        def enabled_exporter_node_types(exporter_node_types)
-          return [] unless exporter_node_types
+        def exporter_node_types
+          @context_node_types_by_role[
+            Api::V3::ContextNodeTypeProperty::EXPORTER_ROLE
+          ]&.map(&:node_type) || []
+        end
 
-          exporter_node_types.select do |cnt|
-            if @company_node_types_ids.any?
-              @company_node_types_ids.include?(cnt.node_type_id)
-            else
-              true
-            end
+        def selected_exporter_node_types
+          exporter_node_types.select do |nt|
+            @company_node_types_ids.include?(nt.id)
           end
         end
 
-        def enabled_importer_node_types(importer_node_types)
-          return [] unless importer_node_types
+        def importer_node_types
+          @context_node_types_by_role[
+            Api::V3::ContextNodeTypeProperty::IMPORTER_ROLE
+          ]&.map(&:node_type) || []
+        end
 
-          importer_node_types.select do |cnt|
-            if @company_node_types_ids.any?
-              @company_node_types_ids.include?(cnt.node_type_id)
-            else
-              true
-            end
+        def selected_importer_node_types
+          importer_node_types.select do |nt|
+            @company_node_types_ids.include?(nt.id)
           end
         end
 
-        def enabled_destination_node_types(destination_node_types)
-          return [] unless destination_node_types
+        def destination_node_types
+          @context_node_types_by_role[
+            Api::V3::ContextNodeTypeProperty::DESTINATION_ROLE
+          ]&.map(&:node_type) || []
+        end
 
-          destination_node_types.select do |cnt|
-            if @destination_node_types_ids.any?
-              @destination_node_types_ids.include?(cnt.node_type_id)
-            else
-              true
-            end
+        def selected_destination_node_types
+          destination_node_types.select do |nt|
+            @destination_node_types_ids.include?(nt.id)
           end
         end
       end

--- a/app/services/concerns/api/v3/dashboards/charts/helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/helpers.rb
@@ -207,7 +207,8 @@ module Api
               filter: {
                 cont_attribute: @cont_attribute.try(:display_name),
                 ncont_attribute: @ncont_attribute.try(:display_name)
-              }.merge(flow_path_filters)
+              }.merge(flow_path_filters),
+              single_filter_key: @chart_parameters.single_filter_key
             }
           end
         end

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -2853,3 +2853,8 @@ components:
                     type: string
                     example: 'null'
                     nullable: true
+        single_filter_key:
+          type: string
+          example: 'destinations'
+          nullable: true
+          description: 'one of [sources|companies|destinations] or null'

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.container.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.container.jsx
@@ -6,15 +6,18 @@ import DashboardWidgetComponent from 'react-components/dashboard-element/dashboa
 import DashboardWidgetTooltip from 'react-components/dashboard-element/dashboard-widget/dashboard-widget-tooltip';
 import {
   makeGetConfig,
-  makeGetChartType
+  makeGetChartType,
+  makeGetTitle
 } from 'react-components/dashboard-element/dashboard-widget/dashboard-widget.selectors';
 
 const makeMapStateToProps = () => {
   const getDashboardWidgetsConfig = makeGetConfig();
   const getChartType = makeGetChartType();
+  const getTitle = makeGetTitle();
   const mapStateToProps = (state, props) => ({
     config: getDashboardWidgetsConfig(state, props),
     chartType: getChartType(state, props),
+    title: getTitle(state, props),
     chartsLoading: state.dashboardElement.chartsLoading
   });
   return mapStateToProps;
@@ -44,23 +47,8 @@ class DashboardWidgetContainer extends Component {
     );
   };
 
-  getTitle(meta) {
-    if (!meta || !meta.info) return '';
-    const topNPart = meta.info.top_n ? `Top ${meta.info.top_n}` : null;
-    const nodeTypePart = meta.info.node_type
-      ? this.getPluralNodeType(meta.info.node_type)
-      : 'Selection overview';
-    // const resizeByPart = meta.info.filter.cont_attribute;
-    // const recolorByPart = meta.info.filter.ncont_attribute
-    //   ? `broken by ${meta.info.filter.ncont_attribute}`
-    //   : null;
-
-    return [topNPart, nodeTypePart].filter(Boolean).join(' ');
-  }
-
   render() {
-    const { data, loading, error, meta, config, chartType, chartsLoading } = this.props;
-    const title = this.getTitle(meta);
+    const { data, loading, error, meta, config, chartType, chartsLoading, title } = this.props;
     return config ? (
       <DashboardWidgetComponent
         data={data}
@@ -82,7 +70,8 @@ DashboardWidgetContainer.propTypes = {
   loading: PropTypes.bool,
   config: PropTypes.object,
   chartType: PropTypes.string,
-  chartsLoading: PropTypes.bool
+  chartsLoading: PropTypes.bool,
+  title: PropTypes.string
 };
 
 export default connect(makeMapStateToProps)(DashboardWidgetContainer);

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.selectors.js
@@ -4,6 +4,7 @@ import sortBy from 'lodash/sortBy';
 import kebabCase from 'lodash/kebabCase';
 import CHART_CONFIG from 'react-components/dashboard-element/dashboard-widget/dashboard-widget-config';
 import { CHART_TYPES } from 'constants';
+import camelCase from 'lodash/camelCase';
 
 const parsedChartTypes = {
   bar_chart: CHART_TYPES.bar,
@@ -154,5 +155,49 @@ export const makeGetConfig = () =>
         colors
       };
       return config;
+    }
+  );
+
+const getPluralNodeType = nodeType => {
+  const name = camelCase(nodeType);
+  return (
+    {
+      country: 'countries',
+      municipality: 'municipalities'
+    }[name] || `${nodeType}s`.toLowerCase()
+  );
+};
+const getNodeTypeName = pluralNodeType =>
+  pluralNodeType === 'countries' ? 'importing countries' : pluralNodeType;
+
+const getFilterPreposition = filterKey => {
+  switch (filterKey) {
+    case 'companies':
+      return 'of';
+    case 'destinations':
+      return 'to';
+    case 'sources':
+      return 'in';
+    default:
+      return '';
+  }
+};
+
+export const makeGetTitle = () =>
+  createSelector(
+    [getMeta],
+    meta => {
+      if (!meta || !meta.info) return '';
+      const topNPart = meta.info.top_n ? `Top ${meta.info.top_n}` : null;
+      const nodeTypePart = meta.info.node_type
+        ? getNodeTypeName(getPluralNodeType(meta.info.node_type))
+        : 'Selection overview';
+      let filterPart = '';
+      const filterKey = meta.info.single_filter_key;
+      if (filterKey) {
+        const name = meta.info.filter[filterKey][0].name;
+        filterPart = `${getFilterPreposition(filterKey)} ${name}`;
+      }
+      return [topNPart, nodeTypePart, filterPart].filter(Boolean).join(' ');
     }
   );

--- a/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Api::V3::Dashboards::SourcesController, type: :controller do
     let(:all_results_alphabetically) {
       [
         api_v3_biome_node,
-        api_v3_logistics_hub_node,
         api_v3_state_node,
         api_v3_municipality_node
       ]

--- a/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
+++ b/spec/services/api/v3/dashboards/node_types_to_break_by_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
     )
   }
 
-  describe 'call' do
+  describe 'selected_node_types' do
     context 'when subnational context with importer node' do
       let!(:source_node_type) {
         cnt = FactoryBot.create(
@@ -60,7 +60,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
         )
       }
       it 'returns available node types to break by' do
-        expect(node_types_to_break_by.call).to eq([
+        expect(node_types_to_break_by.selected_node_types).to eq([
           api_v3_biome_node_type,
           api_v3_exporter_node_type,
           api_v3_importer_node_type,
@@ -88,7 +88,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
         )
       }
       it 'returns available node types to break by' do
-        expect(node_types_to_break_by.call).to eq([
+        expect(node_types_to_break_by.selected_node_types).to eq([
           api_v3_exporter_node_type,
           api_v3_importer_node_type,
           api_v3_country_node_type
@@ -123,7 +123,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
         )
       }
       it 'returns available node types to break by' do
-        expect(node_types_to_break_by.call).to eq([
+        expect(node_types_to_break_by.selected_node_types).to eq([
           api_v3_biome_node_type,
           api_v3_exporter_node_type,
           api_v3_country_node_type
@@ -141,7 +141,7 @@ RSpec.describe Api::V3::Dashboards::NodeTypesToBreakBy do
         )
       }
       it 'returns available node types to break by' do
-        expect(node_types_to_break_by.call).to eq([
+        expect(node_types_to_break_by.selected_node_types).to eq([
           api_v3_exporter_node_type,
           api_v3_country_node_type
         ])

--- a/spec/services/api/v3/dashboards/parametrised_charts_spec.rb
+++ b/spec/services/api/v3/dashboards/parametrised_charts_spec.rb
@@ -73,8 +73,6 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
         api_v3_biome_node_type,
         api_v3_state_node_type,
         api_v3_municipality_node_type,
-        api_v3_logistics_hub_node_type,
-        api_v3_port_node_type,
         api_v3_exporter_node_type,
         api_v3_importer_node_type,
         api_v3_country_node_type
@@ -109,8 +107,6 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
         api_v3_biome_node_type,
         api_v3_state_node_type,
         api_v3_municipality_node_type,
-        api_v3_logistics_hub_node_type,
-        api_v3_port_node_type,
         api_v3_exporter_node_type,
         api_v3_importer_node_type,
         api_v3_country_node_type
@@ -146,8 +142,6 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
         api_v3_biome_node_type,
         api_v3_state_node_type,
         api_v3_municipality_node_type,
-        api_v3_logistics_hub_node_type,
-        api_v3_port_node_type,
         api_v3_exporter_node_type,
         api_v3_importer_node_type,
         api_v3_country_node_type
@@ -168,7 +162,7 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
 
   context 'when multiple years, non-cont indicator, no flow path filters' do
     let(:parameters) {
-      mandatory_parameters.merge(multi_year).merge(
+      mandatory_parameters.merge(multi_year).merge(no_flow_path_filters).merge(
         ncont_attribute_id: ncont_attribute.id
       )
     }
@@ -180,7 +174,22 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
           x: :year,
           break_by: :ncont_attribute
         }
-      ]
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_exporter_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_node_type_view,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
     }
 
     it 'returns expected chart types' do
@@ -203,23 +212,13 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
           ]
         )
     }
-    let(:simplified_overview_chart_type) {
-      {
-        source: :multi_year_ncont_overview,
-        type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
-        x: :year,
-        break_by: :ncont_attribute
-      }
-    }
     let(:simplified_expected_chart_types) {
       [
         {
           source: :multi_year_ncont_overview,
           type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
           x: :year,
-          break_by: :ncont_attribute,
-          node_type_id: api_v3_exporter_node_type.id,
-          companies_ids: [api_v3_exporter1_node.id]
+          break_by: :ncont_attribute
         },
         {
           source: :multi_year_ncont_overview,
@@ -227,19 +226,33 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts do
           x: :year,
           break_by: :ncont_attribute,
           node_type_id: api_v3_exporter_node_type.id,
-          companies_ids: [api_v3_other_exporter_node.id]
+          companies_ids: [api_v3_exporter1_node.id],
+          single_filter_key: :companies
+        },
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          node_type_id: api_v3_exporter_node_type.id,
+          companies_ids: [api_v3_other_exporter_node.id],
+          single_filter_key: :companies
         }
-      ]
-    }
-    let(:expected_chart_types) {
-      [
-        chart_type_with_applied_parameters(
-          simplified_overview_chart_type, overview_parameters
-        )
-      ] +
-        simplified_expected_chart_types.map do |chart_type|
-          chart_type_with_applied_parameters(chart_type, parameters)
-        end
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_node_type_view,
+          type: Api::V3::Dashboards::ParametrisedCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
     }
 
     it 'returns expected chart types' do

--- a/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
@@ -99,7 +99,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 0,
-        role: 'source'
+        role: nil
       )
     end
     cnt


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165237654

- overview chart filtered by all flow path filters
- "single node view" charts filtered by 1 node from a category + remaining selection, for example: when 2 sources and one destination selected, that generates 3 charts of this type:
    1. chart for source1 filtered by source1 and destination
    2. chart for source2 filtered by source2 and destination
    3. chart for destination, filtered by destination and both sources
- adds missing "break by top nodes" charts
- adds a new `single_filter_key` property, with the value of one of `sources, companies, destinations` - telling you in which of the arrays under `filter` the selected node is

The below screenshot shows the charts generated for multiple years, ncont indicator, 2 sources, 1 destination, they are in order:
- 1 overview
- 2 - 4 chart for source1, source2 and destination (please note: the one for destination is equivalent to the overview in this case)
- 5 - 8 charts with node type break downs for municipalities, states, importers and exporters. biomes and countries of destination are omitted, because they're part of selection. logistics hubs and ports are omitted, because they're "turned off" via the CMS.

<img width="430" alt="Screenshot 2019-04-11 at 19 14 02" src="https://user-images.githubusercontent.com/134055/55977727-ce232800-5c8f-11e9-94c5-13f27457f115.png">

It made sense to fix https://www.pivotaltracker.com/story/show/165237654 at the same time