### PR TITLE
Add profile info to axis labels and legend

### DIFF
--- a/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
@@ -26,7 +26,12 @@ module Api
             break_by_values_indexes = ncont_break_by_values_map
 
             data_by_x = {}
+            x_labels_profile_info = []
             @top_n_and_others_query.each do |record|
+              x_labels_profile_info << {
+                id: record['id'],
+                profile: profile_for_node_type_id(record['node_type_id'])
+              }
               break_by_values_indexes.each do |break_by, idx|
                 data_by_x[record['x']] ||= {}
                 data_by_x[record['x']]["y#{idx}"] = record['per_break_by'][break_by]
@@ -39,6 +44,7 @@ module Api
 
             @meta = {
               xAxis: node_type_axis_meta(@node_type),
+              xLabelsProfileInfo: x_labels_profile_info,
               yAxis: axis_meta(@cont_attribute, 'number'),
               x: node_type_legend_meta(@node_type),
               info: info
@@ -72,14 +78,14 @@ module Api
               (
                 WITH q AS (#{@query.to_sql}),
                 u1 AS (
-                  SELECT x, JSONB_OBJECT_AGG(break_by, y0) AS per_break_by, SUM(y0) AS y
+                  SELECT id, node_type_id, x, JSONB_OBJECT_AGG(break_by, y0) AS per_break_by, SUM(y0) AS y
                   FROM q
                   WHERE NOT is_unknown
-                  GROUP BY x
+                  GROUP BY id, node_type_id, x
                   ORDER BY SUM(y0) DESC LIMIT #{@top_n}
                 ),
                 u2 AS (
-                  SELECT x, JSONB_OBJECT_AGG(break_by, y0), SUM(y0) AS y
+                  SELECT NULL::INT, NULL::INT, x, JSONB_OBJECT_AGG(break_by, y0), SUM(y0) AS y
                   FROM (
                     SELECT '#{OTHER}'::TEXT AS x, break_by, SUM(y0) AS y0 FROM q
                     WHERE NOT EXISTS (SELECT 1 FROM u1 WHERE q.x = u1.x)

--- a/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view.rb
@@ -22,14 +22,22 @@ module Api
           end
 
           def call
-            @data = @top_n_and_others_query.map do |r|
-              r.attributes.slice('x', 'y0').symbolize_keys
+            @data = []
+            x_labels_profile_info = []
+            @top_n_and_others_query.map do |record|
+              x_labels_profile_info << {
+                id: record['id'],
+                profile: profile_for_node_type_id(record['node_type_id'])
+              }
+              @data << record.attributes.slice('x', 'y0').symbolize_keys
             end
             if (last = @data.last) && last[:x] == OTHER && last[:y0].blank?
               @data.pop
+              x_labels_profile_info.pop
             end
             @meta = {
               xAxis: node_type_axis_meta(@node_type),
+              xLabelsProfileInfo: x_labels_profile_info,
               yAxis: axis_meta(@cont_attribute, 'number'),
               x: node_type_legend_meta(@node_type),
               y0: legend_meta(@cont_attribute),
@@ -55,9 +63,9 @@ module Api
             subquery = <<~SQL
               (
                 WITH q AS (#{@query.to_sql}),
-                u1 AS (SELECT x, y0 FROM q WHERE NOT is_unknown ORDER BY y0 DESC LIMIT #{@top_n}),
+                u1 AS (SELECT id, node_type_id, x, y0 FROM q WHERE NOT is_unknown ORDER BY y0 DESC LIMIT #{@top_n}),
                 u2 AS (
-                  SELECT '#{OTHER}'::TEXT AS x, SUM(y0) AS y0 FROM q
+                  SELECT NULL::INT, NULL::INT, '#{OTHER}'::TEXT AS x, SUM(y0) AS y0 FROM q
                   WHERE NOT EXISTS (SELECT 1 FROM u1 WHERE q.x = u1.x)
                 )
                 SELECT * FROM u1


### PR DESCRIPTION
Adds profile information to allow displaying links to profile pages. Where the info is depends on type of chart.

- dynamic sentence, or any kind of dynamic title, which incorporates information about current filters: use meta -> info -> filter -> [sources | companies]
- horizontal bar chart (single year, no ncont and ncont) - to display axis labels as links, use meta -> yLabelsProfileInfo. It's an array of elements corresponding to data, e.g.
```
"data":[  
      {  
         "y":"DOMESTIC CONSUMPTION",
         "x0":58.408964958192
      },
      {  
         "y":"GRANOL",
         "x0":15.4620350246747
      }
   ]
```

```
      "yLabelsProfileInfo":[  
         {  
            "id":3,
            "profile":"actor"
         },
         {  
            "id":27717,
            "profile":"actor"
         }
      ],
```
- stacked bar chart (multi year, no ncont and ncont) - use meta -> yn -> profileInfo, e.g.

```
      "y0":{  
         "label":"ADAMANTINA",
         "profileInfo":{  
            "id":6803,
            "profile":"place"
         },
         "tooltip":{  
            "prefix":"",
            "format":"",
            "suffix":""
         }
      },
```