### PR TITLE
Added axis unit to series legends for stacked bar charts

### DIFF
--- a/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
@@ -39,10 +39,7 @@ module Api
             }
 
             break_by_values_indexes.each do |break_by, idx|
-              @meta[:"y#{idx}"] = {
-                label: break_by,
-                tooltip: {prefix: '', format: '', suffix: ''}
-              }
+              @meta[:"y#{idx}"] = series_legend_meta(break_by, @cont_attribute)
             end
 
             {data: @data, meta: @meta}

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
@@ -52,11 +52,8 @@ module Api
                   profile: profile_for_node_type_id(node['node_type_id'])
                 }
               end
-              @meta[:"y#{idx}"] = {
-                label: break_by,
-                profileInfo: profile_info,
-                tooltip: {prefix: '', format: '', suffix: ''}
-              }
+              @meta[:"y#{idx}"] = series_legend_meta(break_by, @cont_attribute).
+                merge(profileInfo: profile_info)
             end
 
             without_string_values = @data.map(&reject_strings)

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
@@ -51,10 +51,7 @@ module Api
             }
 
             break_by_values_indexes.each do |break_by, idx|
-              @meta[:"y#{idx}"] = {
-                label: break_by,
-                tooltip: {prefix: '', format: '', suffix: ''}
-              }
+              @meta[:"y#{idx}"] = series_legend_meta(break_by, @cont_attribute)
             end
 
             swap_x_and_y

--- a/app/services/concerns/api/v3/dashboards/charts/helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/helpers.rb
@@ -108,6 +108,13 @@ module Api
             }
           end
 
+          def series_legend_meta(series_name, attribute)
+            {
+              label: series_name,
+              tooltip: {prefix: '', format: '', suffix: attribute.unit}
+            }
+          end
+
           def node_type_legend_meta(node_type)
             {
               label: node_type.name,

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -2769,8 +2769,8 @@ components:
               description: not used
             suffix:
               type: string
-              example: ""
-              description: not used
+              example: "t"
+              description: Same unit as in yAxis
     DashboardsMetaInfo:
       type: object
       properties:


### PR DESCRIPTION
Applies to multi year ncont overview, multi year no ncont node type view, single year ncont node type view.

Issue mentioned in https://github.com/Vizzuality/trase/pull/794