### PR TITLE
Use a middleware to add the current Language to url when we switch pages

### DIFF
--- a/frontend/scripts/router/router.js
+++ b/frontend/scripts/router/router.js
@@ -165,7 +165,6 @@ const config = {
 
     return dispatchThunks(redirectToExplore)(dispatch, getState, { action });
   },
-  // eslint-disable-next-line consistent-return
   onAfterChange: (dispatch, getState, { action }) => {
     const currentLanguage = action.meta.location?.current?.query?.lang;
     const previousLanguage = action.meta.location?.prev?.query?.lang;
@@ -173,7 +172,7 @@ const config = {
       const { location } = getState();
       const query = { ...location.query, lang: previousLanguage || 'en' };
       const payload = { ...location.payload, query };
-      return dispatch(redirect({ type: location.type, payload }));
+      dispatch(redirect({ type: location.type, payload }));
     }
   },
   restoreScroll: restoreScroll({

--- a/frontend/scripts/router/router.js
+++ b/frontend/scripts/router/router.js
@@ -165,6 +165,17 @@ const config = {
 
     return dispatchThunks(redirectToExplore)(dispatch, getState, { action });
   },
+  // eslint-disable-next-line consistent-return
+  onAfterChange: (dispatch, getState, { action }) => {
+    const currentLanguage = action.meta.location?.current?.query?.lang;
+    const previousLanguage = action.meta.location?.prev?.query?.lang;
+    if (!currentLanguage) {
+      const { location } = getState();
+      const query = { ...location.query, lang: previousLanguage || 'en' };
+      const payload = { ...location.payload, query };
+      return dispatch(redirect({ type: location.type, payload }));
+    }
+  },
   restoreScroll: restoreScroll({
     shouldUpdateScroll: (prev, current) => {
       if (


### PR DESCRIPTION
Use a middleware to add the current Language to url when we switch pages. Its in the after change as in the before change we still not have the variable.

The default is 'en' and we can't use Transifex as its not loading in this hook