### PR TITLE
Fixed uniqueness constraint exception

### DIFF
--- a/app/models/api/v3/chart_attribute.rb
+++ b/app/models/api/v3/chart_attribute.rb
@@ -41,7 +41,10 @@ module Api
                 presence: true,
                 uniqueness: {scope: :chart},
                 if: proc { |chart_attr| chart_attr.identifier.blank? }
-      validates :identifier, uniqueness: {scope: :chart, allow_blank: true}
+      validates :identifier,
+                presence: true,
+                uniqueness: {scope: :chart},
+                if: proc { |chart_attr| chart_attr.position.blank? }
       validates_with OneAssociatedAttributeValidator,
                      attributes: [:chart_ind, :chart_qual, :chart_quant]
       validates_with AttributeAssociatedOnceValidator,
@@ -54,6 +57,7 @@ module Api
                      attribute: :chart_quant, scope: [:chart_id, :state_average],
                      if: :new_chart_quant_given?
 
+      before_save :nullify_empty_identifier
       after_commit :refresh_dependencies
 
       stringy_array :years
@@ -73,6 +77,12 @@ module Api
         Api::V3::ChartInd.distinct.pluck(:chart_attribute_id) +
           Api::V3::ChartQual.distinct.pluck(:chart_attribute_id) +
           Api::V3::ChartQuant.distinct.pluck(:chart_attribute_id)
+      end
+
+      private
+
+      def nullify_empty_identifier
+        self.identifier = nil if identifier.blank?
       end
     end
   end

--- a/spec/support/contexts/api/v3/brazil/brazil_municipality_place_profile.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_municipality_place_profile.rb
@@ -28,7 +28,8 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_basic_attributes,
-        identifier: 'area'
+        identifier: 'area',
+        position: nil
       )
       FactoryBot.create(
         :api_v3_chart_quant,
@@ -50,7 +51,8 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_basic_attributes,
-        identifier: 'commodity_farmland'
+        identifier: 'commodity_farmland',
+        position: nil
       )
       FactoryBot.create(
         :api_v3_chart_ind,
@@ -72,7 +74,8 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_basic_attributes,
-        identifier: 'commodity_production'
+        identifier: 'commodity_production',
+        position: nil
       )
       FactoryBot.create(
         :api_v3_chart_quant,
@@ -94,7 +97,8 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_basic_attributes,
-        identifier: 'commodity_yield'
+        identifier: 'commodity_yield',
+        position: nil
       )
       FactoryBot.create(
         :api_v3_chart_ind,
@@ -166,6 +170,7 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_environmental_indicators,
+        identifier: nil,
         position: 0
       )
       FactoryBot.create(
@@ -204,6 +209,7 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_socioeconomic_indicators,
+        identifier: nil,
         position: 0
       )
       FactoryBot.create(
@@ -242,6 +248,7 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_agricultural_indicators,
+        identifier: nil,
         position: 0
       )
       FactoryBot.create(
@@ -280,6 +287,7 @@ shared_context 'api v3 brazil municipality place profile' do
       chart_attribute = FactoryBot.create(
         :api_v3_chart_attribute,
         chart: api_v3_place_territorial_governance,
+        identifier: nil,
         position: 0
       )
       FactoryBot.create(
@@ -320,6 +328,7 @@ shared_context 'api v3 brazil municipality place profile' do
         legend_name: 'Territorial<br/>Deforestation',
         display_type: 'area',
         display_style: 'area-black',
+        identifier: nil,
         position: 0
       )
       FactoryBot.create(


### PR DESCRIPTION
when saving chart attributes with empty identifier, it would get saved as an empty string rather than `NULL`, upsetting the database constraint

https://www.pivotaltracker.com/story/show/165792069