### PR TITLE
update data column names and avoid future isNaNs

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/table-modal/table-modal.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/table-modal/table-modal.selectors.js
@@ -123,8 +123,12 @@ const getDataColumnNames = createSelector(
     const metaColumns = {
       ...meta
     };
-    const notColumnKeys = ['info', 'xAxis', 'yAxis'];
-    if (chartType === CHART_TYPES.horizontalBar || chartType === CHART_TYPES.horizontalStackedBar) {
+    const notColumnKeys = ['info', 'xAxis', 'yAxis', 'yLabelsProfileInfo', 'aggregates'];
+    if (
+      chartType === CHART_TYPES.horizontalBar ||
+      chartType === CHART_TYPES.horizontalStackedBar ||
+      chartType === CHART_TYPES.ranking
+    ) {
       notColumnKeys.push('y');
     } else {
       notColumnKeys.push('x');
@@ -167,7 +171,6 @@ export const getTableData = createSelector(
         if (_hasVariableColumn) {
           rowData.push(getVariableColumnData(item, column, meta));
         }
-
         rowData.push(item[column]);
         if (_hasNContIndicator) {
           rowData.push(nonContValue(item, column, meta, chartType, _hasMultipleYears));

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/table-modal/table/table.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/table-modal/table/table.component.jsx
@@ -70,7 +70,9 @@ function Table(props) {
           return (
             <div style={style} className={cx('list-item', !(rowIndex % 2) && '-even')}>
               <Text align="center" size="md" as="span" variant="mono">
-                {item && formatFn ? formatFn(item) : item}
+                {formatFn && (item === 0 || item) && !Number.isNaN(parseFloat(item))
+                  ? formatFn(item)
+                  : item}
               </Text>
             </div>
           );


### PR DESCRIPTION
This tiny PR fixes a problem in the table of the ranking chart (and probably many others) where we had some isNANUndefined showing. We needed to update the blacklist of data column names. This could be improved in the future so we don't have this problem again.

Try: Brasil - Soy ... open table with the table button

Before:
![image](https://user-images.githubusercontent.com/9701591/57470006-2ac23480-7288-11e9-91d5-db421a08c4a7.png)
