### PR TITLE
Fix/loading spinner on profile pages when no chart defined

### DIFF
--- a/app/models/api/v3/chart.rb
+++ b/app/models/api/v3/chart.rb
@@ -10,21 +10,7 @@
 #  position   :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  chart_type :string
 #
-# Indexes
-#
-#  charts_profile_id_parent_id_identifier_key  (profile_id,parent_id,identifier) UNIQUE
-#  charts_profile_id_parent_id_position_key    (profile_id,parent_id,position) UNIQUE
-#  index_charts_on_parent_id                   (parent_id)
-#  index_charts_on_profile_id                  (profile_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (parent_id => charts.id) ON DELETE => cascade
-#  fk_rails_...  (profile_id => profiles.id) ON DELETE => cascade
-#
-
 # Indexes
 #
 #  charts_profile_id_parent_id_identifier_key  (profile_id,parent_id,identifier) UNIQUE
@@ -59,6 +45,27 @@ module Api
       validate :parent_is_root
 
       after_commit :refresh_dependencies
+
+      def chart_type
+        case identifier
+        when 'actor_top_countries', 'actor_top_sources'
+          :line_chart_with_map
+        when
+          'actor_sustainability_table',
+          'place_environmental_indicators',
+          'place_socioeconomic_indicators',
+          'place_agricultural_indicators',
+          'place_territorial_governance',
+          'place_indicators_table'
+          :tabs_table
+        when 'actor_exporting_companies'
+          :scatterplot
+        when 'place_trajectory_deforestation'
+          :stacked_line_chart
+        when 'place_top_consumer_actors', 'place_top_consumer_countries'
+          :sankey
+        end
+      end
 
       def self.select_options
         Api::V3::Chart.includes(:profile).all.map do |chart|

--- a/app/services/api/v3/profile_metadata/response_builder.rb
+++ b/app/services/api/v3/profile_metadata/response_builder.rb
@@ -8,9 +8,14 @@ module Api
         end
 
         def call
+          context_node_type = Api::V3::ContextNodeType.
+            find_by(
+              node_type_id: @node.node_type_id,
+              context_id: @context.id
+            )
+
           Api::V3::Profile.
-            joins(context_node_type: [node_type: :nodes]).
-            where('nodes.id' => @node.id).
+            where(context_node_type_id: context_node_type.id).
             includes(charts: :children).
             references(:charts).
             where('charts.parent_id IS NULL').

--- a/db/migrate/20190513125050_remove_chart_type_from_charts.rb
+++ b/db/migrate/20190513125050_remove_chart_type_from_charts.rb
@@ -1,0 +1,5 @@
+class RemoveChartTypeFromCharts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :charts, :chart_type
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1258,8 +1258,7 @@ CREATE TABLE public.charts (
     title text NOT NULL,
     "position" integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    chart_type character varying
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -8790,6 +8789,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190321122822'),
 ('20190321161913'),
 ('20190429104832'),
-('20190429112751');
+('20190429112751'),
+('20190513125050');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -922,7 +922,7 @@ COMMENT ON COLUMN public.chart_attributes.display_name IS 'Name of attribute for
 -- Name: COLUMN chart_attributes.legend_name; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.chart_attributes.legend_name IS 'Legend title';
+COMMENT ON COLUMN public.chart_attributes.legend_name IS 'Legend title; you can use {{commodity_name}}, {{company_name}}, {{jurisdiction_name}} and {{year}}';
 
 
 --
@@ -1287,7 +1287,7 @@ COMMENT ON COLUMN public.charts.identifier IS 'Identifier used to map this chart
 -- Name: COLUMN charts.title; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.charts.title IS 'Title of chart for display';
+COMMENT ON COLUMN public.charts.title IS 'Title of chart for display; you can use {{commodity_name}}, {{company_name}}, {{jurisdiction_name}} and {{year}}';
 
 
 --

--- a/spec/models/api/v3/chart_spec.rb
+++ b/spec/models/api/v3/chart_spec.rb
@@ -43,4 +43,32 @@ RSpec.describe Api::V3::Chart, type: :model do
       expect(chart_with_parent_is_not_root).to have(1).error_on(:parent)
     end
   end
+
+  describe :chart_type do
+    include_context 'api v3 brazil municipality place profile'
+    include_context 'api v3 brazil exporter actor profile'
+    it 'is line_chart_with_map for actor_top_countries' do
+      expect(api_v3_exporter_top_countries.chart_type).to eq(:line_chart_with_map)
+    end
+
+    it 'is tabs_table for place_indicators_table' do
+      expect(api_v3_place_indicators_table.chart_type).to eq(:tabs_table)
+    end
+
+    it 'is scatterplot for actor_exporting_companies' do
+      expect(api_v3_exporter_exporting_companies.chart_type).to eq(:scatterplot)
+    end
+
+    it 'is stacked_line_chart for place_trajectory_deforestation' do
+      expect(api_v3_place_trajectory_deforestation.chart_type).to eq(:stacked_line_chart)
+    end
+
+    it 'is sankey for place_top_consumer_actors' do
+      expect(api_v3_place_top_consumer_actors.chart_type).to eq(:sankey)
+    end
+
+    it 'is null for actor_basic_attributes' do
+      expect(api_v3_exporter_basic_attributes.chart_type).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165939319

Two problems here:
1. the wrong charts were pulled via the `profile_metadata` endpoint, because they were not filtered by context 🤦‍♀ Added the context filter.
2. `chart_type`, a new database column in `charts` we added ad-hoc when implementing configurable profiles, was empty for all the new charts. 🤦‍♀  Removed it from the database and implemented as a virtual attribute in the `Chart` model.