### PR TITLE
Works fine in development, on sandbox cannot find the serializer ¯\_(ツ)_/¯

### DIFF
--- a/app/serializers/api/v3/profile_metadata/profile_serializer.rb
+++ b/app/serializers/api/v3/profile_metadata/profile_serializer.rb
@@ -7,7 +7,7 @@ module Api
                    :adm_1_name, :adm_1_topojson_path, :adm_1_topojson_root,
                    :adm_2_name, :adm_2_topojson_path, :adm_2_topojson_root
 
-        has_many :charts
+        has_many :charts, serializer: Api::V3::ProfileMetadata::ChartSerializer
       end
     end
   end


### PR DESCRIPTION
Serializer needs to be specified explicitly, otherwise a generic serializer is used and the virtual attribute `chart_type` is not serialized.