### PR TITLE
Fix ranking links to profiles

### DIFF
--- a/frontend/scripts/react-components/chart/chart.component.jsx
+++ b/frontend/scripts/react-components/chart/chart.component.jsx
@@ -22,7 +22,8 @@ import 'react-components/chart/chart-styles.scss';
 class Chart extends PureComponent {
   static propTypes = {
     data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-    config: PropTypes.shape({}).isRequired,
+    meta: PropTypes.object,
+    config: PropTypes.object,
     className: PropTypes.string,
     handleMouseMove: PropTypes.func,
     handleMouseLeave: PropTypes.func,
@@ -36,7 +37,7 @@ class Chart extends PureComponent {
   };
 
   render() {
-    const { className, data, config, handleMouseMove, handleMouseLeave, testId } = this.props;
+    const { className, data, meta, config, handleMouseMove, handleMouseLeave, testId } = this.props;
 
     const {
       margin = {},
@@ -114,8 +115,8 @@ class Chart extends PureComponent {
             </defs>
 
             {cartesianGrid && <CartesianGrid stroke="#536269" {...cartesianGrid} />}
-            {CustomXAxis({ config, data })}
-            {CustomYAxis({ config, data })}
+            {CustomXAxis({ config, data, meta })}
+            {CustomYAxis({ config, data, meta })}
             {areas &&
               Object.keys(areas).map(key => (
                 <Area key={key} dataKey={key} dot={false} {...areas[key]} />

--- a/frontend/scripts/react-components/chart/tick/category-tick.component.jsx
+++ b/frontend/scripts/react-components/chart/tick/category-tick.component.jsx
@@ -11,13 +11,12 @@ const renderText = tickValue => (
 );
 
 function CategoryTick(props) {
-  const { x, y, payload, nodeIds, config } = props;
-  const tickValue = payload && payload.value;
-  const nodeId = nodeIds.find(n => n.y === tickValue);
+  const { x, y, payload, nodeIds, info } = props;
+  const nodeId = nodeIds[payload.index];
   let lastYear;
   let url;
   if (nodeId && nodeId.profile) {
-    lastYear = config.years.end_year || config.years.start_year;
+    lastYear = info.years.end_year || info.years.start_year;
     url = `/profile-${nodeId.profile}?year=${lastYear}&nodeId=${nodeId.id}`;
   }
 
@@ -25,10 +24,10 @@ function CategoryTick(props) {
     <g transform={`translate(${x},${y})`}>
       {url ? (
         <a href={url} className="tick-text-link">
-          {renderText(tickValue)}
+          {renderText(payload.value)}
         </a>
       ) : (
-        renderText(tickValue)
+        renderText(payload.value)
       )}
     </g>
   );
@@ -37,9 +36,9 @@ function CategoryTick(props) {
 CategoryTick.propTypes = {
   x: PropTypes.number,
   y: PropTypes.number,
-  payload: PropTypes.shape({}),
+  payload: PropTypes.object,
   nodeIds: PropTypes.array,
-  config: PropTypes.shape({})
+  info: PropTypes.object
 };
 
 CategoryTick.defaultProps = {

--- a/frontend/scripts/react-components/chart/y-axis.component.jsx
+++ b/frontend/scripts/react-components/chart/y-axis.component.jsx
@@ -7,10 +7,10 @@ import ChartTick from 'react-components/chart/tick/tick.component';
 import CategoryTick from 'react-components/chart/tick/category-tick.component';
 import 'react-components/chart/chart-styles.scss';
 
-function CustomYAxis({ config, data }) {
-  const { yAxis, unit, unitFormat, yKeys, yKey, yLabelsProfileInfo } = config;
-  const nodeIds = yLabelsProfileInfo
-    ? data.map((d, i) => ({ ...d, ...yLabelsProfileInfo[i] }))
+function CustomYAxis({ config, data, meta }) {
+  const { yAxis, unit, unitFormat, yKeys, yKey } = config;
+  const nodeIds = meta.yLabelsProfileInfo
+    ? data.map((d, i) => ({ ...d, ...meta.yLabelsProfileInfo[i] }))
     : null;
   // horizontal charts
   if (yKey) {
@@ -21,7 +21,7 @@ function CustomYAxis({ config, data }) {
         tickMargin={15}
         dataKey={yKey || ''}
         {...yAxis}
-        tick={<CategoryTick config={config} nodeIds={nodeIds} />}
+        tick={<CategoryTick config={config} nodeIds={nodeIds} info={meta.info} />}
       />
     );
   }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
@@ -83,11 +83,10 @@ export const getDynamicSentence = createSelector(
         const filteredValues = values.filter(i => i.nodeType === nodeType);
         return filteredValues.length > 0 ? filteredValues : null;
       }
-      return values;
+      return values.map(value => ({ ...value, name: `${value.name}`.toLowerCase() }));
     };
 
     const sourcesValue = getActivePanelItem('sources') || getActivePanelItem('countries');
-
     return [
       {
         panel: 'commodities',

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.component.jsx
@@ -77,7 +77,7 @@ function DashboardWidget(props) {
       case 'ranking':
         return (
           <div className="widget-centered">
-            <RankingWidget data={data} config={chartConfig} />
+            <RankingWidget data={data} meta={meta} config={chartConfig} />
           </div>
         );
       default:
@@ -93,6 +93,7 @@ function DashboardWidget(props) {
             <Chart
               className="widget-chart"
               data={data}
+              meta={meta}
               config={chartConfig}
               testId="widget-chart"
             />

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.selectors.js
@@ -155,8 +155,6 @@ export const makeGetConfig = () =>
         tooltip: {
           ...defaultConfig.tooltip
         },
-        yLabelsProfileInfo: meta.yLabelsProfileInfo,
-        years: meta.info.years,
         yKeys,
         xKeys,
         colors

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.selectors.js
@@ -5,6 +5,7 @@ import kebabCase from 'lodash/kebabCase';
 import CHART_CONFIG from 'react-components/dashboard-element/dashboard-widget/dashboard-widget-config';
 import { CHART_TYPES } from 'constants';
 import camelCase from 'lodash/camelCase';
+import capitalize from 'lodash/capitalize';
 
 export const PARSED_CHART_TYPES = {
   bar_chart: CHART_TYPES.bar,
@@ -201,7 +202,7 @@ export const makeGetTitle = () =>
       let filterPart = '';
       const filterKey = meta.info.single_filter_key;
       if (filterKey) {
-        const name = meta.info.filter[filterKey][0].name;
+        const name = capitalize(meta.info.filter[filterKey][0].name);
         filterPart = `${getFilterPreposition(filterKey)} ${name}`;
       }
       return [topNPart, nodeTypePart, filterPart].filter(Boolean).join(' ');

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dynamic-sentence-widget/dynamic-sentence-widget.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dynamic-sentence-widget/dynamic-sentence-widget.selectors.js
@@ -21,7 +21,7 @@ export const makeAddIndicatorsPartToSentence = () =>
       const indicatorNamePart = {
         id: 'indicator-name',
         prefix: '',
-        value: [{ name: yAxisLabel.text }],
+        value: [{ name: `${yAxisLabel.text}`.toLowerCase() }],
         transform: 'capitalize'
       };
 
@@ -30,7 +30,7 @@ export const makeAddIndicatorsPartToSentence = () =>
         prefix: 'was',
         value: [
           {
-            name: data[0].y0 ? `${format(',.2f')(data[0].y0)} ${yAxisLabel.suffix}` : 'N/A'
+            name: data[0].y0 ? `${format('.4s')(data[0].y0)} ${yAxisLabel.suffix}` : 'N/A'
           }
         ]
       };
@@ -38,7 +38,7 @@ export const makeAddIndicatorsPartToSentence = () =>
       const yearPart = selectedYears
         ? {
             id: 'year',
-            prefix: 'for',
+            prefix: 'in',
             value: [
               {
                 name:

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget-styles.scss
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget-styles.scss
@@ -45,11 +45,14 @@
 
   .item-name {
     line-height: 1.2;
+    max-height: 100%;
+    overflow: hidden;
   }
 
   .item-value {
-    min-width: 125px;
+    min-width: 185px;
     margin-left: 10px;
+    flex-shrink: 0;
   }
 
   .item-bubble {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
@@ -16,19 +16,37 @@ class RankingWidget extends PureComponent {
     this.setState(state => ({ page: state.page + pageChange }));
   };
 
+  renderItemName(item) {
+    const name = (
+      <Heading as="span" size="lg" weight="bold" color="white" className="item-name">
+        {capitalize(item.y)}
+      </Heading>
+    );
+    if (item.url) {
+      return <Link to={item.url}>{name}</Link>;
+    }
+
+    return name;
+  }
+
   render() {
-    const { data, config, pageSize } = this.props;
+    const { data, meta, config, pageSize } = this.props;
     const { page } = this.state;
     const dataWithUrl = data.map((d, i) => {
-      const node = config.yLabelsProfileInfo[i];
-      const lastYear = config.years.end_year || config.years.start_year;
-      const url = `/profile-${node.profile}?year=${lastYear}&nodeId=${node.id}`;
+      const node = meta.yLabelsProfileInfo[i];
+      const lastYear = meta.info.years.end_year || meta.info.years.start_year;
+      const url = node.profile && `/profile-${node.profile}?year=${lastYear}&nodeId=${node.id}`;
       return { ...d, url };
     });
     const pageData = pageSize
       ? dataWithUrl.slice(page * pageSize, (page + 1) * pageSize)
       : dataWithUrl;
-    const formatValue = format((config.yAxisLabel && config.yAxisLabel.format) || ',.2f');
+    const formatValue = format((config.yAxisLabel && config.yAxisLabel.format) || ',.6s');
+
+    // property is snake_case
+    // eslint-disable-next-line
+    const totalValue = meta.aggregates?.total_value;
+    const formatTotal = format('.0s');
 
     return (
       <div className="c-ranking-widget">
@@ -50,20 +68,11 @@ class RankingWidget extends PureComponent {
                         {index + 1 + pageSize * page}
                       </Text>
                     </div>
-                    <Link to={item.url}>
-                      <Heading
-                        as="span"
-                        size="lg"
-                        weight="bold"
-                        color="white"
-                        className="item-name"
-                      >
-                        {capitalize(item.y)}
-                      </Heading>
-                    </Link>
+                    {this.renderItemName(item)}
                   </div>
                   <Text className="item-value" color="white" variant="mono" size="md">
-                    {formatValue(item.x0)} {config.xAxisLabel && config.xAxisLabel.suffix}
+                    {formatValue(item.x0)} {config.xAxisLabel && config.xAxisLabel.suffix} /{' '}
+                    {formatTotal(totalValue.x0)} {config.xAxisLabel && config.xAxisLabel.suffix}
                   </Text>
                 </div>
               </li>
@@ -84,6 +93,7 @@ class RankingWidget extends PureComponent {
 
 RankingWidget.propTypes = {
   data: PropTypes.array.isRequired,
+  meta: PropTypes.object.isRequired,
   config: PropTypes.object.isRequired,
   pageSize: PropTypes.number
 };

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
@@ -41,12 +41,12 @@ class RankingWidget extends PureComponent {
     const pageData = pageSize
       ? dataWithUrl.slice(page * pageSize, (page + 1) * pageSize)
       : dataWithUrl;
-    const formatValue = format((config.yAxisLabel && config.yAxisLabel.format) || ',.6s');
+    const formatValue = format((config.yAxisLabel && config.yAxisLabel.format) || ',.3s');
 
     // property is snake_case
     // eslint-disable-next-line
     const totalValue = meta.aggregates?.total_value;
-    const formatTotal = format('.0s');
+    const formatTotal = format('.4s');
 
     return (
       <div className="c-ranking-widget">

--- a/frontend/scripts/react-components/shared/tags-group/tag/tag.component.jsx
+++ b/frontend/scripts/react-components/shared/tags-group/tag/tag.component.jsx
@@ -41,7 +41,7 @@ function Tag(props) {
         '-spaced': spaced
       })}
     >
-      {part.value[0].name.toLowerCase()}
+      {part.value[0].name}
       {!isPartReadOnly && clearPanel && (
         <button
           key={`button${part.id}`}

--- a/frontend/scripts/tests/dashboard-widget/__snapshots__/dashboard-widget-selectors.test.js.snap
+++ b/frontend/scripts/tests/dashboard-widget/__snapshots__/dashboard-widget-selectors.test.js.snap
@@ -182,11 +182,6 @@ Object {
   },
   "yKey": "y",
   "yKeys": undefined,
-  "yLabelsProfileInfo": undefined,
-  "years": Object {
-    "end_year": 2015,
-    "start_year": 2012,
-  },
 }
 `;
 
@@ -285,10 +280,5 @@ Object {
   },
   "yKey": "y",
   "yKeys": undefined,
-  "yLabelsProfileInfo": undefined,
-  "years": Object {
-    "end_year": 2015,
-    "start_year": 2012,
-  },
 }
 `;


### PR DESCRIPTION
This PR fixes the link to profiles in the ranking chart. It should only appear if the profile property inside `yLabelsProfileInfo` is not null.

Other miscellaneous fixes:
- Don't pass non chart data through config. I think config should only describe how the chart actually looks like, passing stuff like info or meta feels wrong.
- Translate ignored strings using imperative method: `translateText`.
- Improve _just a bit_ the logo flashing on home page (it was driving me crazy).
- Add missing total value in ranking charts and limit the number of lines the ranking chart elements occupy.