### PR TITLE
Replace modal with non supported page for non desktop pages

### DIFF
--- a/frontend/html/tool.ejs
+++ b/frontend/html/tool.ejs
@@ -10,15 +10,6 @@
       <div class="c-modal js-modal"></div>
     </div>
 
-    <div class="mobile-warning">
-      <div class="veil"></div>
-      <div class="c-modal">
-        <div class="content">
-          The TRASE supply chain Tool is not available for mobile devices. We recommend using a screen resolution of at least 1280 by 720 pixels.
-        </div>
-      </div>
-    </div>
-
     <div class="js-sankey-error is-hidden">
       <div class="veil -with-menu -below-nav"></div>
       <div class="c-modal -below-nav">

--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -225,7 +225,8 @@ export const HOME_VIDEO = {
 };
 
 export const BREAKPOINTS = {
-  small: 640
+  small: 640,
+  tablet: 768
 };
 
 export const MAX_SEARCH_RESULTS = 50;

--- a/frontend/scripts/router/router.js
+++ b/frontend/scripts/router/router.js
@@ -157,9 +157,9 @@ const config = {
     return route;
   },
   onBeforeChange: (dispatch, getState, { action }) => {
-    const isMobile = window.innerWidth <= BREAKPOINTS.small;
+    const isNarrowerThanDesktop = window.innerWidth <= BREAKPOINTS.tablet;
 
-    if (isMobile && pagesNotSupportedOnMobile.includes(action.type)) {
+    if (isNarrowerThanDesktop && pagesNotSupportedOnMobile.includes(action.type)) {
       return dispatch(redirect({ type: 'notSupportedOnMobile' }));
     }
 

--- a/frontend/scripts/router/router.js
+++ b/frontend/scripts/router/router.js
@@ -17,7 +17,11 @@ import { redirectToExplore } from 'react-components/explore/explore.thunks';
 import { loadToolInitialData } from 'scripts/react-components/tool/tool.thunks';
 import getPageTitle from 'scripts/router/page-title';
 
-const pagesNotSupportedOnMobile = ['tool', 'map', 'data'];
+const pagesSupportedLimit = {
+  data: 'small',
+  tool: 'tablet',
+  map: 'tablet'
+};
 
 // We await for all thunks using Promise.all, this makes the result then-able and allows us to
 // add an await solely to the thunks that need it.
@@ -157,9 +161,8 @@ const config = {
     return route;
   },
   onBeforeChange: (dispatch, getState, { action }) => {
-    const isNarrowerThanDesktop = window.innerWidth <= BREAKPOINTS.tablet;
-
-    if (isNarrowerThanDesktop && pagesNotSupportedOnMobile.includes(action.type)) {
+    const supportedLimit = pagesSupportedLimit[action.type];
+    if (supportedLimit && window.innerWidth <= BREAKPOINTS[supportedLimit]) {
       return dispatch(redirect({ type: 'notSupportedOnMobile' }));
     }
 

--- a/frontend/styles/components/shared/modal.scss
+++ b/frontend/styles/components/shared/modal.scss
@@ -77,10 +77,3 @@
     display: block;
   }
 }
-
-.mobile-warning {
-  display: block;
-  @media screen and (min-width: $breakpoint-tablet) {
-    display: none;
-  }
-}


### PR DESCRIPTION
We are going to use the non-supported page for all non desktop pages

![image](https://user-images.githubusercontent.com/9701591/58031838-91194380-7b21-11e9-84d4-9bd26f08a2ba.png)
