### PR TITLE
fix onTransifexLoad not defined

### DIFF
--- a/frontend/scripts/index.ejs
+++ b/frontend/scripts/index.ejs
@@ -11,6 +11,6 @@
 <script
   type="text/javascript"
   src="//cdn.transifex.com/live.js"
-  onload="javascript: onTransifexLoad()"
+  onload="javascript: typeof onTransifexLoad !== 'undefined' && onTransifexLoad()"
 ></script>
 </html>

--- a/frontend/scripts/index.ejs
+++ b/frontend/scripts/index.ejs
@@ -9,6 +9,7 @@
 <div id="app-root-container"></div>
 </body>
 <script
+  defer
   type="text/javascript"
   src="//cdn.transifex.com/live.js"
   onload="javascript: typeof onTransifexLoad !== 'undefined' && onTransifexLoad()"


### PR DESCRIPTION
There's a crash when the Transifex script loads before the JS bundle.