### PR TITLE
Add pages in about and privacy link on footer

### DIFF
--- a/frontend/scripts/react-components/shared/footer/footer.component.jsx
+++ b/frontend/scripts/react-components/shared/footer/footer.component.jsx
@@ -171,6 +171,15 @@ const Footer = () => (
                 Privacy policy
               </Link>
             </li>
+            <li className="separator"> · </li>
+            <li className="link-item">
+              <Link
+                className="title -mono-font"
+                to={{ type: 'about', payload: { section: 'cookie-policy' } }}
+              >
+                Cookie policy
+              </Link>
+            </li>
           </>
         )}
         <li className="separator"> · </li>

--- a/frontend/scripts/react-components/shared/footer/footer.component.jsx
+++ b/frontend/scripts/react-components/shared/footer/footer.component.jsx
@@ -160,6 +160,19 @@ const Footer = () => (
             Terms of Use
           </Link>
         </li>
+        {ENABLE_COOKIE_BANNER && (
+          <>
+            <li className="separator"> · </li>
+            <li className="link-item">
+              <Link
+                className="title -mono-font"
+                to={{ type: 'about', payload: { section: 'privacy-policy' } }}
+              >
+                Privacy policy
+              </Link>
+            </li>
+          </>
+        )}
         <li className="separator"> · </li>
         <li className="link-item">
           <a className="title -mono-font" href="mailto:info@trase.earth">

--- a/frontend/scripts/router/nav-links.js
+++ b/frontend/scripts/router/nav-links.js
@@ -87,6 +87,29 @@ const sidebarNav = [
   }
 ];
 
+if (ENABLE_COOKIE_BANNER) {
+  sidebarNav.push(
+    {
+      name: 'Privacy policy',
+      page: {
+        type: 'about',
+        payload: {
+          section: 'privacy-policy'
+        }
+      }
+    },
+    {
+      name: 'Cookie policy',
+      page: {
+        type: 'about',
+        payload: {
+          section: 'cookie-policy'
+        }
+      }
+    }
+  );
+}
+
 if (ENABLE_DASHBOARDS) {
   nav.splice(-3, 0, {
     name: 'Dashboards',


### PR DESCRIPTION
This simple PR adds privacy and cookie pages to the about page and privacy link to the footer.

Note: The privacy markdown should contain a link to the cookie page

AT:
- [x] Create pages on the CMS
- [x] Create about pages links in sidebar nav
- [x] Add privacy link to the privacy page on the footer
- [x] None of these should be shown if cookies banner is not enabled
