### PR TITLE
Feat/remove default map dimensions

### DIFF
--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -830,12 +830,13 @@ export function saveMapView(latlng, zoom) {
 
 export function toggleMapDimension(uid) {
   return (dispatch, getState) => {
-    const { selectedYears } = getState().app;
+    const state = getState();
+    const selectedMapDimensions = getSelectedMapDimensionsUids(state);
     dispatch({
       type: TOGGLE_MAP_DIMENSION,
       payload: {
         uid,
-        selectedYears
+        selectedMapDimensions
       }
     });
 

--- a/frontend/scripts/actions/tool.actions.js
+++ b/frontend/scripts/actions/tool.actions.js
@@ -30,6 +30,7 @@ import isEmpty from 'lodash/isEmpty';
 import xor from 'lodash/xor';
 import { getCurrentContext } from 'reducers/helpers/contextHelper';
 import {
+  getSelectedMapDimensionsUids,
   getSelectedNodesColumnsPos,
   getSelectedResizeBy
 } from 'react-components/tool/tool.selectors';
@@ -53,7 +54,6 @@ export const SELECT_VIEW = 'SELECT_VIEW';
 export const SELECT_COLUMN = 'SELECT_COLUMN';
 export const GET_MAP_VECTOR_DATA = 'GET_MAP_VECTOR_DATA';
 export const GET_CONTEXT_LAYERS = 'GET_CONTEXT_LAYERS';
-export const SET_MAP_DIMENSIONS_SELECTION = 'SET_MAP_DIMENSIONS_SELECTION';
 export const TOGGLE_MAP_DIMENSION = 'TOGGLE_MAP_DIMENSION';
 export const SELECT_CONTEXTUAL_LAYERS = 'SELECT_CONTEXTUAL_LAYERS';
 export const SELECT_BASEMAP = 'SELECT_BASEMAP';
@@ -130,23 +130,6 @@ const _setBiomeFilterAction = (biomeFilterName, state) => {
     payload: selectedBiomeFilter
   };
 };
-
-function _getAvailableMapDimensions(dimensions, selectedMapDimensions) {
-  const allAvailableMapDimensionsUids = Object.keys(dimensions);
-  const selectedMapDimensionsSet = compact(selectedMapDimensions);
-  // are all currently selected map dimensions available ?
-  if (
-    selectedMapDimensionsSet.length > 0 &&
-    difference(selectedMapDimensionsSet, allAvailableMapDimensionsUids).length === 0
-  ) {
-    return [...selectedMapDimensions];
-  }
-
-  // use default map dimensions
-  const defaultMapDimensions = Object.values(dimensions).filter(dimension => dimension.isDefault);
-  const uids = defaultMapDimensions.map(selectedDimension => selectedDimension.uid);
-  return [uids[0] || null, uids[1] || null];
-}
 
 export function selectView(detailedView, reloadLinks) {
   return _reloadLinks('detailedView', detailedView, SELECT_VIEW, reloadLinks);
@@ -266,21 +249,6 @@ export function selectColumn(columnIndex, columnId, reloadLinks = true) {
       state.toolLinks.data.columns
     );
     dispatch(updateNodes(selectedNodesIds));
-    const selectedColumn = state.toolLinks.data.columns && state.toolLinks.data.columns[columnId];
-    if (
-      selectedColumn &&
-      selectedColumn.group === 0 &&
-      selectedColumn.isGeo &&
-      selectedColumn.isChoroplethDisabled
-    ) {
-      dispatch(setMapDimensions([null, null]));
-    } else if (selectedColumn.isGeo && selectedColumn.isChoroplethDisabled === false) {
-      const availableMapDimensions = _getAvailableMapDimensions(
-        state.toolLayers.data.mapDimensions,
-        state.toolLayers.selectedMapDimensions
-      );
-      dispatch(setMapDimensions(availableMapDimensions));
-    }
 
     dispatch({
       type: FILTER_LINKS_BY_NODES
@@ -306,6 +274,7 @@ export function loadToolDataForCurrentContext() {
     const allNodesURL = getURLFromParams(GET_ALL_NODES_URL, params);
     const columnsURL = getURLFromParams(GET_COLUMNS_URL, params);
     const promises = [allNodesURL, columnsURL].map(url => fetch(url).then(resp => resp.json()));
+    dispatch(loadNodes());
 
     Promise.all(promises).then(payload => {
       // TODO do not wait for end of all promises/use another .all call
@@ -315,7 +284,6 @@ export function loadToolDataForCurrentContext() {
       });
 
       dispatch(loadLinks());
-      dispatch(loadNodes());
       dispatch(loadMapVectorData());
     });
   };
@@ -330,7 +298,6 @@ export function loadNodes() {
     };
 
     const getMapBaseDataURL = getURLFromParams(GET_MAP_BASE_DATA_URL, params);
-    const selectedMapDimensions = getState().toolLayers.selectedMapDimensions;
 
     fetch(getMapBaseDataURL)
       .then(response => {
@@ -384,23 +351,7 @@ export function loadNodes() {
         if (selectedBiomeFilter && selectedBiomeFilter.nodeId) {
           dispatch(_setBiomeFilterAction(selectedBiomeFilter.name, getState()));
         }
-
-        const { columns } = getState().toolLinks.data;
-        const selectedGeoColumn =
-          columns &&
-          Object.values(columns).find(column =>
-            getState().toolLinks.selectedColumnsIds.some(id => id === column.id && column.isGeo)
-          );
-
-        if (selectedGeoColumn.isChoroplethDisabled === false) {
-          const availableMapDimensions = _getAvailableMapDimensions(
-            payload.mapDimensionsMetaJSON.dimensions,
-            selectedMapDimensions
-          );
-          dispatch(setMapDimensions(availableMapDimensions));
-        } else {
-          dispatch(setMapDimensions([null, null]));
-        }
+        loadMapChoropeth(getState, dispatch);
       });
   };
 }
@@ -551,6 +502,7 @@ export function loadMapVectorData() {
         type: GET_MAP_VECTOR_DATA,
         mapVectorData
       });
+      loadMapChoropeth(getState, dispatch);
     });
   };
 }
@@ -891,27 +843,12 @@ export function toggleMapDimension(uid) {
   };
 }
 
-export function setMapDimensions(uids) {
-  return (dispatch, getState) => {
-    const selectedYears = getState().app.selectedYears;
-    dispatch({
-      type: SET_MAP_DIMENSIONS_SELECTION,
-      payload: {
-        uids,
-        selectedYears
-      }
-    });
-
-    loadMapChoropeth(getState, dispatch);
-  };
-}
-
 export function loadMapChoropeth(getState, dispatch) {
   const state = getState();
 
-  const uids = state.toolLayers.selectedMapDimensions;
+  const uids = getSelectedMapDimensionsUids(state);
 
-  if (compact(uids).length === 0) {
+  if (new Set(uids.filter(Boolean)).size === 0) {
     dispatch({
       type: SET_NODE_ATTRIBUTES,
       payload: { data: [] }

--- a/frontend/scripts/react-components/tool-layers/tool-layer.selectors.js
+++ b/frontend/scripts/react-components/tool-layers/tool-layer.selectors.js
@@ -1,10 +1,12 @@
 import { createSelector } from 'reselect';
 import getChoropleth from 'reducers/helpers/getChoropleth';
 import { getMapDimensionsWarnings as getMapDimensionsWarningsUtil } from 'scripts/reducers/helpers/getMapDimensionsWarnings';
-import { getHighlightedNodesData } from 'react-components/tool/tool.selectors';
+import {
+  getHighlightedNodesData,
+  getSelectedMapDimensionsUids
+} from 'react-components/tool/tool.selectors';
 
 const getMapDimensions = state => state.toolLayers.data.mapDimensions;
-const getSelectedMapDimensions = state => state.toolLayers.selectedMapDimensions;
 const getToolNodes = state => state.toolLinks.data.nodes;
 const getToolColumns = state => state.toolLinks.data.columns;
 const getMapContextualLayers = state => state.toolLayers.data.mapContextualLayers;
@@ -13,13 +15,19 @@ const getSelectedYears = state => state.app.selectedYears;
 const getToolNodeAttributes = state => state.toolLinks.data.nodeAttributes;
 
 export const getChoroplethOptions = createSelector(
-  [getMapDimensions, getToolNodes, getToolNodeAttributes, getToolColumns, getSelectedMapDimensions],
-  (mapDimensions, nodes, attributes, columns, selectedMapDimensions) =>
+  [
+    getSelectedMapDimensionsUids,
+    getToolNodes,
+    getToolNodeAttributes,
+    getToolColumns,
+    getMapDimensions
+  ],
+  (selectedMapDimensions, nodes, attributes, columns, mapDimensions) =>
     getChoropleth(selectedMapDimensions, nodes, attributes, columns, mapDimensions)
 );
 
 export const getMapDimensionsWarnings = createSelector(
-  [getMapDimensions, getSelectedMapDimensions, getSelectedYears],
+  [getMapDimensions, getSelectedMapDimensionsUids, getSelectedYears],
   (mapDimensions, selectedMapDimensions, selectedYears) => {
     if (selectedYears.length === 0) {
       return null;

--- a/frontend/scripts/react-components/tool-layers/tool-layers.reducer.js
+++ b/frontend/scripts/react-components/tool-layers/tool-layers.reducer.js
@@ -98,13 +98,16 @@ const toolLayersReducer = {
   },
   [TOGGLE_MAP_DIMENSION](state, action) {
     return immer(state, draft => {
+      if (!draft.selectedMapDimensions) {
+        draft.selectedMapDimensions = [...action.payload.selectedMapDimensions];
+      }
       const uidIndex = draft.selectedMapDimensions.indexOf(action.payload.uid);
 
       if (uidIndex === -1) {
         // dimension was not found: put it on a free slot
-        if (draft.selectedMapDimensions[0] === null) {
+        if (!draft.selectedMapDimensions[0]) {
           draft.selectedMapDimensions[0] = action.payload.uid;
-        } else if (draft.selectedMapDimensions[1] === null) {
+        } else if (!draft.selectedMapDimensions[1]) {
           draft.selectedMapDimensions[1] = action.payload.uid;
         }
         draft.mapLoading = true;

--- a/frontend/scripts/react-components/tool-layers/tool-layers.reducer.js
+++ b/frontend/scripts/react-components/tool-layers/tool-layers.reducer.js
@@ -8,7 +8,6 @@ import {
   SAVE_MAP_VIEW,
   SELECT_BASEMAP,
   SELECT_CONTEXTUAL_LAYERS,
-  SET_MAP_DIMENSIONS_SELECTION,
   TOGGLE_MAP,
   TOGGLE_MAP_DIMENSION,
   SET_MAP_DIMENSIONS_DATA
@@ -28,11 +27,11 @@ export const toolLayersInitialState = {
   highlightedNodeCoordinates: null, // TODO: this should be local state only used for map tooltip
   isMapVisible: false,
   linkedGeoIds: [],
-  mapLoading: true,
+  mapLoading: false,
   mapView: null,
   selectedMapBasemap: null,
   selectedMapContextualLayers: null,
-  selectedMapDimensions: [null, null],
+  selectedMapDimensions: null,
   selectedMapDimensionsWarnings: null
 };
 
@@ -95,12 +94,6 @@ const toolLayersReducer = {
       action.mapContextualLayers.forEach(layer => {
         draft.data.mapContextualLayers[layer.id] = layer;
       });
-    });
-  },
-  [SET_MAP_DIMENSIONS_SELECTION](state, action) {
-    return immer(state, draft => {
-      const { uids } = action.payload;
-      draft.selectedMapDimensions = uids;
     });
   },
   [TOGGLE_MAP_DIMENSION](state, action) {

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -27,8 +27,8 @@ import getNodesMetaUid from 'reducers/helpers/getNodeMetaUid';
 export const toolLinksInitialState = {
   data: {
     columns: null,
-    nodes: {},
-    links: [],
+    nodes: null,
+    links: null,
     nodeHeights: null,
     nodeAttributes: null,
     nodesByColumnGeoId: null
@@ -71,7 +71,9 @@ const toolLinksReducer = {
         detailedView: false,
         highlightedNodesIds: [],
         selectedNodesIds: [],
-        expandedNodesIds: []
+        expandedNodesIds: [],
+        flowsLoading: true,
+        data: toolLinksInitialState.data
       });
     });
   },

--- a/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.component.js
+++ b/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.component.js
@@ -15,8 +15,12 @@ export default class {
     };
 
     this._onDimensionClicked = event => {
-      const uid = event.currentTarget.getAttribute('data-dimension-uid');
-      this.callbacks.onDimensionClick(uid);
+      const dimension = event.currentTarget;
+      const uid = dimension.getAttribute('data-dimension-uid');
+      const isEnabled = !dimension.classList.contains('-disabled');
+      if (isEnabled) {
+        this.callbacks.onDimensionClick(uid);
+      }
     };
 
     this.loadMapDimensions(props);

--- a/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.component.js
+++ b/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.component.js
@@ -20,7 +20,7 @@ export default class {
     };
 
     this.loadMapDimensions(props);
-    this.selectMapDimensions(props);
+    this.setMapDimensions(props);
     this.toggleSidebarGroups(props);
     this.setVisibility(props);
   }
@@ -61,10 +61,11 @@ export default class {
     this.toggleSidebarGroups({ expandedMapSidebarGroupsIds });
   }
 
-  selectMapDimensions({ selectedMapDimensions }) {
+  setMapDimensions({ selectedMapDimensions }) {
     if (this.dimensions === undefined) {
       return;
     }
+
     const isFull = selectedMapDimensions[0] !== null && selectedMapDimensions[1] !== null;
     this.dimensions.forEach(dimension => {
       const uid = dimension.getAttribute('data-dimension-uid');

--- a/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.container.js
+++ b/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.container.js
@@ -38,7 +38,7 @@ const methodProps = [
     returned: ['mapDimensionsGroups', 'expandedMapSidebarGroupsIds']
   },
   {
-    name: 'selectMapDimensions',
+    name: 'setMapDimensions',
     compared: ['selectedMapDimensions'],
     returned: ['selectedMapDimensions']
   },

--- a/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.container.js
+++ b/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.container.js
@@ -4,6 +4,7 @@ import MapDimensions from 'react-components/tool/map-dimensions/map-dimensions.c
 import { toggleMapDimension } from 'actions/tool.actions';
 import { loadTooltip } from 'actions/app.actions';
 import { mapToVanilla } from 'react-components/shared/vanilla-react-bridge.component';
+import { getSelectedMapDimensionsUids } from 'react-components/tool/tool.selectors';
 
 // There's an update infinite loop inside loadMapDimensions, so mapDimensionsGroups should always be memoized
 const getLegacyMapDimensionsGroups = createSelector(
@@ -25,7 +26,7 @@ const isCloroplethEnabled = state => {
 };
 const mapStateToProps = state => ({
   mapDimensionsGroups: getLegacyMapDimensionsGroups(state),
-  selectedMapDimensions: state.toolLayers.selectedMapDimensions,
+  selectedMapDimensions: getSelectedMapDimensionsUids(state),
   isCloroplethEnabled: isCloroplethEnabled(state),
   selectedColumnsIds: state.toolLinks.selectedColumnsIds
 });

--- a/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.container.js
+++ b/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.container.js
@@ -4,7 +4,7 @@ import { selectNode, navigateToProfile, resetState } from 'actions/tool.actions'
 import NodesTitles from 'react-components/tool/nodes-titles/nodes-titles.component';
 import {
   getSelectedResizeBy,
-  getSelectedMapDimensions,
+  getSelectedMapDimensionsData,
   getToolRecolorGroups,
   getSelectedNodesData,
   getHighlightedNodesData
@@ -12,7 +12,7 @@ import {
 
 const mapStateToProps = state => ({
   selectedResizeBy: getSelectedResizeBy(state),
-  selectedMapDimensions: getSelectedMapDimensions(state),
+  selectedMapDimensions: getSelectedMapDimensionsData(state),
   selectedNodesData: getSelectedNodesData(state),
   nodeHeights: state.toolLinks.data.nodeHeights,
   columns: state.toolLinks.data.columns,

--- a/frontend/scripts/react-components/tool/tool.selectors.js
+++ b/frontend/scripts/react-components/tool/tool.selectors.js
@@ -55,20 +55,27 @@ export const getSelectedMapDimensionsUids = createSelector(
   (selectedGeoColumn, mapDimensions, selectedMapDimensions) => {
     if (selectedGeoColumn && selectedGeoColumn.isChoroplethDisabled === false) {
       const allAvailableMapDimensionsUids = new Set(Object.keys(mapDimensions));
-      const selectedMapDimensionsSet = new Set(selectedMapDimensions);
+      const selectedMapDimensionsSet = new Set(selectedMapDimensions?.filter(Boolean));
       const intersection = new Set(
         [...selectedMapDimensionsSet].filter(x => allAvailableMapDimensionsUids.has(x))
       );
+
       // are all currently selected map dimensions available ?
-      if (selectedMapDimensionsSet.size > 0 && intersection.size === 2) {
+      if (
+        selectedMapDimensionsSet.size > 0 &&
+        intersection.size === selectedMapDimensionsSet.size
+      ) {
         return selectedMapDimensions;
       }
 
-      // use default map dimensions
-      const uids = Object.values(mapDimensions)
-        .filter(dimension => dimension.isDefault)
-        .map(selectedDimension => selectedDimension.uid);
-      return [uids[0] || null, uids[1] || null];
+      // use default map dimensions but only if selectedMapDimensions is null
+      // we want to allow the user to disable all selections
+      if (!selectedMapDimensions) {
+        const uids = Object.values(mapDimensions)
+          .filter(dimension => dimension.isDefault)
+          .map(selectedDimension => selectedDimension.uid);
+        return [uids[0] || null, uids[1] || null];
+      }
     }
 
     return [null, null];

--- a/frontend/scripts/react-components/tool/tool.thunks.js
+++ b/frontend/scripts/react-components/tool/tool.thunks.js
@@ -13,7 +13,7 @@ export const resizeSankeyTool = dispatch => dispatch(resize());
 export const loadToolInitialData = (dispatch, getState) => {
   const state = getState();
 
-  if (!state.app.selectedContext || state.toolLinks.data.links.length > 0) {
+  if (!state.app.selectedContext || state.toolLinks.data.links) {
     return;
   }
 
@@ -23,6 +23,7 @@ export const loadToolInitialData = (dispatch, getState) => {
   const allNodesURL = getURLFromParams(GET_ALL_NODES_URL, params);
   const columnsURL = getURLFromParams(GET_COLUMNS_URL, params);
   const promises = [allNodesURL, columnsURL].map(url => fetch(url).then(resp => resp.json()));
+  dispatch(loadNodes());
 
   Promise.all(promises).then(payload => {
     // TODO do not wait for end of all promises/use another .all call
@@ -32,7 +33,6 @@ export const loadToolInitialData = (dispatch, getState) => {
     });
 
     dispatch(loadLinks());
-    dispatch(loadNodes());
     dispatch(loadMapVectorData());
   });
 };

--- a/frontend/scripts/reducers/helpers/getChoropleth.js
+++ b/frontend/scripts/reducers/helpers/getChoropleth.js
@@ -1,5 +1,4 @@
 import chroma from 'chroma-js';
-import compact from 'lodash/compact';
 import { CHOROPLETH_COLORS, CHOROPLETH_CLASS_ZERO } from 'constants';
 
 const _shortenTitle = title => {
@@ -15,7 +14,7 @@ const generateColorScale = (baseColorScale, length) => {
 };
 
 export default function(selectedMapDimensionsUids, nodes, attributes, columns, mapDimensions) {
-  const uids = compact(selectedMapDimensionsUids);
+  const uids = [...new Set(selectedMapDimensionsUids.filter(Boolean))];
   const selectedMapDimensions = uids.map(uid => mapDimensions[uid]);
 
   if (!selectedMapDimensions.length) {

--- a/frontend/scripts/utils/getBasemap.js
+++ b/frontend/scripts/utils/getBasemap.js
@@ -1,9 +1,10 @@
 import { DEFAULT_BASEMAP_FOR_CHOROPLETH } from 'constants';
+import { getSelectedMapDimensionsUids } from 'react-components/tool/tool.selectors';
 
-const shouldUseDefaultBasemap = state =>
-  state.toolLayers.selectedMapDimensions &&
-  state.toolLayers.selectedMapDimensions.length &&
-  state.toolLayers.selectedMapDimensions.filter(d => d !== null).length > 0;
+const shouldUseDefaultBasemap = state => {
+  const selectedMapDimensions = getSelectedMapDimensionsUids(state);
+  return selectedMapDimensions.filter(d => d !== null).length > 0;
+};
 
 export default state =>
   shouldUseDefaultBasemap(state)


### PR DESCRIPTION
This PR changes the way the app deals with default selected dimensions. Previously we imperatively set the dimensions after fetching them. Now we use a selector that declaratively does that, among other things this allows us to fetch the map nodes data in parallel to the sankey nodes and columns also making it easier to reason about.