### PR TITLE
Feature/filter nodes by node type or node

### DIFF
--- a/app/controllers/api/v3/nodes_controller.rb
+++ b/app/controllers/api/v3/nodes_controller.rb
@@ -1,14 +1,24 @@
 module Api
   module V3
     class NodesController < ApiController
+      include Api::V3::ParamHelpers
+
       def index
         @nodes = Api::V3::Nodes::Filter.new(
-          @context
+          @context, filter_params
         ).call
 
         render json: @nodes,
                root: 'data',
                each_serializer: Api::V3::Nodes::NodeSerializer
+      end
+
+      private
+
+      def filter_params
+        {
+          node_types_ids: cs_string_to_int_array(params[:node_types_ids])
+        }
       end
     end
   end

--- a/app/controllers/api/v3/nodes_controller.rb
+++ b/app/controllers/api/v3/nodes_controller.rb
@@ -17,7 +17,8 @@ module Api
 
       def filter_params
         {
-          node_types_ids: cs_string_to_int_array(params[:node_types_ids])
+          node_types_ids: cs_string_to_int_array(params[:node_types_ids]),
+          nodes_ids: cs_string_to_int_array(params[:nodes_ids])
         }
       end
     end

--- a/app/controllers/api/v3/nodes_controller.rb
+++ b/app/controllers/api/v3/nodes_controller.rb
@@ -2,26 +2,12 @@ module Api
   module V3
     class NodesController < ApiController
       def index
-        nodes_with_flows = Api::V3::Flow.
-          select('DISTINCT(UNNEST(path)) AS node_id').
-          where(context_id: @context.id)
+        @nodes = Api::V3::Nodes::Filter.new(
+          @context
+        ).call
 
-        nodes = Api::V3::Node.
-          select('
-                 nodes.id, nodes.main_id, nodes.name, geo_id, nodes.node_type_id AS column_id,
-                 NULLIF(node_properties.is_domestic_consumption, FALSE) AS is_domestic_consumption, NULLIF(nodes.is_unknown, FALSE) AS is_unknown,
-                 node_types.name AS type, profiles.name::TEXT AS profile_type,
-                 CASE WHEN nodes_with_flows.node_id IS NOT NULL OR nodes.name = \'OTHER\' THEN true ELSE false END AS has_flows
-                 ').
-          joins(:node_property).
-          joins(node_type: :context_node_types).
-          joins('LEFT JOIN profiles ON profiles.context_node_type_id = context_node_types.id').
-          joins("LEFT OUTER JOIN (#{nodes_with_flows.to_sql}) nodes_with_flows ON nodes_with_flows.node_id = nodes.id").
-          where('nodes_with_flows.node_id IS NOT NULL OR SUBSTRING(geo_id FROM 1 FOR 2) = ? OR nodes.name = \'OTHER\' ', @context.country.iso2).
-          where('context_node_types.context_id' => @context.id).
-          all
-
-        render json: nodes, root: 'data',
+        render json: @nodes,
+               root: 'data',
                each_serializer: Api::V3::Nodes::NodeSerializer
       end
     end

--- a/app/controllers/concerns/api/v3/dashboards/filter_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/filter_params.rb
@@ -3,6 +3,7 @@ module Api
     module Dashboards
       module FilterParams
         extend ActiveSupport::Concern
+        include Api::V3::ParamHelpers
 
         private
 
@@ -32,14 +33,6 @@ module Api
             destinations_ids: cs_string_to_int_array(params[:destinations_ids]),
             node_types_ids: cs_string_to_int_array(params[:node_types_ids])
           }
-        end
-
-        def string_to_int(str)
-          str&.to_i
-        end
-
-        def cs_string_to_int_array(str)
-          str&.split(',')&.map(&:to_i) || []
         end
       end
     end

--- a/app/controllers/concerns/api/v3/param_helpers.rb
+++ b/app/controllers/concerns/api/v3/param_helpers.rb
@@ -1,0 +1,13 @@
+module Api
+  module V3
+    module ParamHelpers
+      def string_to_int(str)
+        str&.to_i
+      end
+
+      def cs_string_to_int_array(str)
+        str&.split(',')&.map(&:to_i) || []
+      end
+    end
+  end
+end

--- a/app/models/api/v3/chart.rb
+++ b/app/models/api/v3/chart.rb
@@ -2,12 +2,12 @@
 #
 # Table name: charts
 #
-#  id                                                                                                :integer          not null, primary key
-#  profile_id                                                                                        :integer          not null
-#  parent_id(Self-reference to parent used to define complex charts, e.g. table with values in tabs) :integer
-#  identifier(Identifier used to map this chart to a part of code which contains calculation logic)  :text             not null
-#  title(Title of chart for display)                                                                 :text             not null
-#  position(Display order in scope of profile)                                                       :integer          not null
+#  id                                                                                                                      :integer          not null, primary key
+#  profile_id                                                                                                              :integer          not null
+#  parent_id(Self-reference to parent used to define complex charts, e.g. table with values in tabs)                       :integer
+#  identifier(Identifier used to map this chart to a part of code which contains calculation logic)                        :text             not null
+#  title(Title of chart for display; you can use {{commodity_name}}, {{company_name}}, {{jurisdiction_name}} and {{year}}) :text             not null
+#  position(Display order in scope of profile)                                                                             :integer          not null
 #
 # Indexes
 #

--- a/app/models/api/v3/node_property.rb
+++ b/app/models/api/v3/node_property.rb
@@ -33,6 +33,7 @@ module Api
 
       def refresh_dependents
         Api::V3::Readonly::Node.refresh
+        Api::V3::Readonly::SankeyNode.refresh
       end
 
       def self.insert_missing_node_properties

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -13,7 +13,8 @@
 #
 # Indexes
 #
-#  download_attributes_mv_id_idx  (id) UNIQUE
+#  download_attributes_mv_context_id_original_type_original_id_idx  (context_id,original_type,original_id)
+#  download_attributes_mv_id_idx                                    (id) UNIQUE
 #
 
 module Api

--- a/app/models/api/v3/readonly/sankey_node.rb
+++ b/app/models/api/v3/readonly/sankey_node.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: sankey_nodes_mv
+#
+#  id                      :integer          primary key
+#  main_id                 :integer
+#  name                    :text
+#  geo_id                  :text
+#  source_country_iso2     :text
+#  is_domestic_consumption :boolean
+#  is_unknown              :boolean
+#  node_type_id            :integer
+#  node_type               :text
+#  profile_type            :text
+#  has_flows               :boolean
+#  is_aggregated           :boolean
+#  context_id              :integer
+#
+# Indexes
+#
+#  sankey_nodes_mv_context_id_id_idx  (context_id,id) UNIQUE
+#  sankey_nodes_mv_node_type_id_idx   (node_type_id)
+#
+
+module Api
+  module V3
+    module Readonly
+      class SankeyNode < Api::V3::Readonly::BaseModel
+        self.table_name = 'sankey_nodes_mv'
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/nodes/node_serializer.rb
+++ b/app/serializers/api/v3/nodes/node_serializer.rb
@@ -3,13 +3,16 @@ module Api
     module Nodes
       class NodeSerializer < ActiveModel::Serializer
         attribute :main_id, key: :main_node_id
-        attributes :id, :name, :type, :column_id, :geo_id,
-                   :is_domestic_consumption, :is_unknown, :profile_type,
-                   :has_flows
-
-        attribute :is_aggregated do
-          object.name.casecmp('other').zero?
-        end
+        attribute :node_type_id, key: :column_id
+        attribute :node_type, key: :type
+        attributes :id,
+                   :name,
+                   :geo_id,
+                   :is_domestic_consumption,
+                   :is_unknown,
+                   :profile_type,
+                   :has_flows,
+                   :is_aggregated
       end
     end
   end

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -104,6 +104,7 @@ module Api
           [
             Api::V3::Readonly::Attribute,
             Api::V3::Readonly::Node,
+            Api::V3::Readonly::SankeyNode,
             Api::V3::Readonly::Flow,
             Api::V3::Readonly::Dashboards::FlowPath
           ].each { |mview| mview.refresh(sync: true, skip_dependents: true) }

--- a/app/services/api/v3/nodes/filter.rb
+++ b/app/services/api/v3/nodes/filter.rb
@@ -1,0 +1,39 @@
+module Api
+  module V3
+    module Nodes
+      class Filter
+        # @param context [Api::V3::Context]
+        def initialize(context)
+          @context = context
+          @query = initialize_query
+        end
+
+        def call
+          @query.all
+        end
+
+        private
+
+        def initialize_query
+          nodes_with_flows = Api::V3::Flow.
+            select('DISTINCT(UNNEST(path)) AS node_id').
+            where(context_id: @context.id)
+
+          Api::V3::Node.
+            select('
+                   nodes.id, nodes.main_id, nodes.name, geo_id, nodes.node_type_id AS column_id,
+                   NULLIF(node_properties.is_domestic_consumption, FALSE) AS is_domestic_consumption, NULLIF(nodes.is_unknown, FALSE) AS is_unknown,
+                   node_types.name AS type, profiles.name::TEXT AS profile_type,
+                   CASE WHEN nodes_with_flows.node_id IS NOT NULL OR nodes.name = \'OTHER\' THEN true ELSE false END AS has_flows
+                   ').
+            joins(:node_property).
+            joins(node_type: :context_node_types).
+            joins('LEFT JOIN profiles ON profiles.context_node_type_id = context_node_types.id').
+            joins("LEFT OUTER JOIN (#{nodes_with_flows.to_sql}) nodes_with_flows ON nodes_with_flows.node_id = nodes.id").
+            where('nodes_with_flows.node_id IS NOT NULL OR SUBSTRING(geo_id FROM 1 FOR 2) = ? OR nodes.name = \'OTHER\' ', @context.country.iso2).
+            where('context_node_types.context_id' => @context.id)
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/nodes/filter.rb
+++ b/app/services/api/v3/nodes/filter.rb
@@ -3,9 +3,13 @@ module Api
     module Nodes
       class Filter
         # @param context [Api::V3::Context]
-        def initialize(context)
+        # @param params [Hash]
+        # @option params [Array<Integer>] node_types_ids
+        def initialize(context, params)
           @context = context
-          @query = initialize_query
+          @node_types_ids = params[:node_types_ids] || []
+          initialize_query
+          apply_node_type_filter
         end
 
         def call
@@ -15,7 +19,7 @@ module Api
         private
 
         def initialize_query
-          Api::V3::Readonly::SankeyNode.
+          @query = Api::V3::Readonly::SankeyNode.
             select([
               :id,
               :main_id,
@@ -31,6 +35,12 @@ module Api
             ]).
             where(context_id: @context.id).
             where('has_flows OR source_country_iso2 = ?', @context.country.iso2)
+        end
+
+        def apply_node_type_filter
+          return unless @node_types_ids.any?
+
+          @query = @query.where(node_type_id: @node_types_ids)
         end
       end
     end

--- a/app/services/api/v3/nodes/filter.rb
+++ b/app/services/api/v3/nodes/filter.rb
@@ -5,11 +5,14 @@ module Api
         # @param context [Api::V3::Context]
         # @param params [Hash]
         # @option params [Array<Integer>] node_types_ids
+        # @option params [Array<Integer>] nodes_ids
         def initialize(context, params)
           @context = context
           @node_types_ids = params[:node_types_ids] || []
+          @nodes_ids = params[:nodes_ids] || []
           initialize_query
           apply_node_type_filter
+          apply_node_filter
         end
 
         def call
@@ -41,6 +44,12 @@ module Api
           return unless @node_types_ids.any?
 
           @query = @query.where(node_type_id: @node_types_ids)
+        end
+
+        def apply_node_filter
+          return unless @nodes_ids.any?
+
+          @query = @query.where(id: @nodes_ids)
         end
       end
     end

--- a/db/migrate/20190529153223_create_sankey_nodes_mv.rb
+++ b/db/migrate/20190529153223_create_sankey_nodes_mv.rb
@@ -1,0 +1,14 @@
+class CreateSankeyNodesMv < ActiveRecord::Migration[5.2]
+  def up
+    create_view :sankey_nodes_mv, version: 1, materialized: true
+
+    add_index :sankey_nodes_mv, [:context_id, :id], unique: true,
+      name: :sankey_nodes_mv_context_id_id_idx
+    add_index :sankey_nodes_mv, [:node_type_id],
+      name: :sankey_nodes_mv_node_type_id_idx
+  end
+
+  def down
+    drop_view :sankey_nodes_mv, materialized: true
+  end
+end

--- a/db/views/sankey_nodes_mv_v01.sql
+++ b/db/views/sankey_nodes_mv_v01.sql
@@ -1,0 +1,33 @@
+SELECT
+  nodes.id,
+  nodes.main_id,
+  nodes.name,
+  geo_id,
+  CASE
+    WHEN context_node_type_properties.is_geo_column
+    THEN SUBSTRING(geo_id FROM 1 FOR 2)
+    ELSE NULL
+  END AS source_country_iso2,
+  NULLIF(node_properties.is_domestic_consumption, FALSE) AS is_domestic_consumption,
+  NULLIF(nodes.is_unknown, FALSE) AS is_unknown,
+  nodes.node_type_id AS node_type_id,
+  node_types.name AS node_type,
+  profiles.name::TEXT AS profile_type,
+  CASE
+    WHEN nodes_with_flows.node_id IS NOT NULL OR nodes.name = 'OTHER'
+    THEN true
+    ELSE false
+  END AS has_flows,
+  (UPPER(BTRIM(nodes.name)) = 'OTHER') AS is_aggregated,
+  context_node_types.context_id
+FROM nodes
+INNER JOIN node_properties ON node_properties.node_id = nodes.id
+INNER JOIN node_types ON node_types.id = nodes.node_type_id
+INNER JOIN context_node_types ON context_node_types.node_type_id = node_types.id
+INNER JOIN context_node_type_properties ON context_node_type_properties.context_node_type_id = context_node_types.id
+LEFT JOIN profiles ON profiles.context_node_type_id = context_node_types.id
+LEFT OUTER JOIN (
+  SELECT
+  DISTINCT(UNNEST(path)) AS node_id, context_id
+  FROM flows
+) nodes_with_flows ON nodes_with_flows.node_id = nodes.id AND nodes_with_flows.context_id = context_node_types.context_id;

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -299,6 +299,8 @@ paths:
       summary: All nodes for a context
       parameters:
         - $ref: "#/components/parameters/context_id_path_param"
+        - $ref: "#/components/parameters/node_types_ids"
+        - $ref: "#/components/parameters/nodes_ids"
       responses:
         "200":
           description: OK
@@ -718,7 +720,7 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
-        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -746,7 +748,7 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
-        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -773,7 +775,7 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
-        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -801,7 +803,7 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
-        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -828,7 +830,7 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
-        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -856,7 +858,7 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
-        - $ref: "#/components/parameters/dashboards_node_type_ids"
+        - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -1386,6 +1388,20 @@ components:
       required: false
       schema:
         type: integer
+    node_types_ids:
+      name: node_types_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    nodes_ids:
+      name: nodes_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
     dashboards_country_id:
       name: country_id
       in: query
@@ -1428,13 +1444,6 @@ components:
         type: string
     dashboards_destinations_ids:
       name: destinations_ids
-      in: query
-      description: String with comma-separated numeric ids
-      required: false
-      schema:
-        type: string
-    dashboards_node_type_ids:
-      name: node_types_ids
       in: query
       description: String with comma-separated numeric ids
       required: false
@@ -2031,10 +2040,10 @@ components:
           properties:
             title:
               type: string
-              example: Top destination countries of {{commodity_name}} exported by {{company_name}} in {{year}}
+              example: "Top destination countries of {{commodity_name}} exported by {{company_name}} in {{year}}"
             legend_title:
               type: string
-              example: {{commodity_name}} exported in {{year}}
+              example: "{{commodity_name}} exported in {{year}}"
             included_years:
               type: array
               items:
@@ -2075,10 +2084,10 @@ components:
           properties:
             title:
               type: string
-              example: Top sourcing regions of {{commodity_name}} exported by {{company_name}} in {{year}}
+              example: "Top sourcing regions of {{commodity_name}} exported by {{company_name}} in {{year}}"
             legend_title:
               type: string
-              example: {{commodity_name}} exported in $year$
+              example: "{{commodity_name}} exported in $year$"
             included_years:
               type: array
               items:

--- a/spec/responses/api/v3/nodes_spec.rb
+++ b/spec/responses/api/v3/nodes_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'Nodes', type: :request do
   include_context 'api v3 brazil flows'
 
   describe 'GET /api/v3/contexts/:context_id/nodes' do
+    before(:each) do
+      Api::V3::Readonly::SankeyNode.refresh(sync: true)
+    end
+
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/nodes"
 

--- a/spec/services/api/v3/nodes/filter_spec.rb
+++ b/spec/services/api/v3/nodes/filter_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Nodes::Filter do
+  include_context 'api v3 brazil flows quants'
+
+  context 'when no params' do
+    let(:result) { Api::V3::Nodes::Filter.new(api_v3_context).call }
+
+    it 'returns all nodes' do
+      expect(result.size).to eq(Api::V3::Node.count)
+    end
+  end
+end

--- a/spec/services/api/v3/nodes/filter_spec.rb
+++ b/spec/services/api/v3/nodes/filter_spec.rb
@@ -30,4 +30,20 @@ RSpec.describe Api::V3::Nodes::Filter do
       )
     end
   end
+
+  context 'when filtered by nodes' do
+    let(:result) {
+      Api::V3::Nodes::Filter.new(
+        api_v3_context, {nodes_ids: [api_v3_municipality_node.id]}
+      ).call
+    }
+
+    it 'returns selected municipality only' do
+      expect(result.pluck(:id)).to match_array(
+        Api::V3::Node.where(
+          id: api_v3_municipality_node.id
+        ).pluck(:id)
+      )
+    end
+  end
 end

--- a/spec/services/api/v3/nodes/filter_spec.rb
+++ b/spec/services/api/v3/nodes/filter_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Api::V3::Nodes::Filter do
   include_context 'api v3 brazil flows quants'
 
+  before(:each) do
+    Api::V3::Readonly::SankeyNode.refresh(sync: true)
+  end
+
   context 'when no params' do
     let(:result) { Api::V3::Nodes::Filter.new(api_v3_context).call }
 

--- a/spec/services/api/v3/nodes/filter_spec.rb
+++ b/spec/services/api/v3/nodes/filter_spec.rb
@@ -8,10 +8,26 @@ RSpec.describe Api::V3::Nodes::Filter do
   end
 
   context 'when no params' do
-    let(:result) { Api::V3::Nodes::Filter.new(api_v3_context).call }
+    let(:result) { Api::V3::Nodes::Filter.new(api_v3_context, {}).call }
 
     it 'returns all nodes' do
       expect(result.size).to eq(Api::V3::Node.count)
+    end
+  end
+
+  context 'when filtered by node type' do
+    let(:result) {
+      Api::V3::Nodes::Filter.new(
+        api_v3_context, {node_types_ids: [api_v3_municipality_node_type.id]}
+      ).call
+    }
+
+    it 'returns municipalities only' do
+      expect(result.pluck(:id)).to match_array(
+        Api::V3::Node.where(
+          node_type_id: api_v3_municipality_node_type.id
+        ).pluck(:id)
+      )
     end
   end
 end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/166237121
https://www.pivotaltracker.com/story/show/166237113

You can now:
- `/api/v3/contexts/1/nodes` - all nodes like before
- `/api/v3/contexts/1/nodes?node_types_ids=3,4` - selected node types
- `/api/v3/contexts/1/nodes?nodes_ids=1060,1165` - selected nodes

It now loads results from a materialized view, which makes it faster in all cases.