### PR TITLE
Feat: use sagas to load nodes columns

### DIFF
--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -10,7 +10,7 @@ import {
   SELECT_YEARS,
   loadNodes,
   loadLinks
-} from 'scripts/actions/tool.actions';
+} from 'react-components/tool/tool.actions';
 import { getContextById } from 'scripts/reducers/helpers/contextHelper';
 import getPageTitle from 'scripts/router/page-title';
 import { redirect } from 'redux-first-router';

--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -4,13 +4,7 @@ import {
   GET_NODES_WITH_SEARCH_URL,
   getURLFromParams
 } from 'utils/getURLFromParams';
-import {
-  TOGGLE_MAP,
-  loadToolDataForCurrentContext,
-  SELECT_YEARS,
-  loadNodes,
-  loadLinks
-} from 'react-components/tool/tool.actions';
+import { TOGGLE_MAP, SELECT_YEARS, loadNodes, loadLinks } from 'react-components/tool/tool.actions';
 import { getContextById } from 'scripts/reducers/helpers/contextHelper';
 import getPageTitle from 'scripts/router/page-title';
 import { redirect } from 'redux-first-router';
@@ -63,10 +57,6 @@ export function selectContextById(contextId) {
     });
 
     dispatch(setContextIsUserSelected(true));
-
-    if (getState().location.type === 'tool') {
-      dispatch(loadToolDataForCurrentContext());
-    }
 
     document.title = getPageTitle(getState());
   };

--- a/frontend/scripts/analytics/tool.events.js
+++ b/frontend/scripts/analytics/tool.events.js
@@ -9,7 +9,7 @@ import {
   SELECT_YEARS,
   TOGGLE_MAP,
   UPDATE_NODE_SELECTION
-} from 'actions/tool.actions';
+} from 'react-components/tool/tool.actions';
 
 export default [
   {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
@@ -1,6 +1,6 @@
 import deburr from 'lodash/deburr';
 import pickBy from 'lodash/pickBy';
-import { put, call, cancelled, delay, select, fork } from 'redux-saga/effects';
+import { put, call, cancelled, select, fork } from 'redux-saga/effects';
 import isEmpty from 'lodash/isEmpty';
 import {
   DASHBOARD_ELEMENT__SET_PANEL_TABS,
@@ -19,16 +19,7 @@ import {
   GET_DASHBOARD_SEARCH_RESULTS_URL,
   GET_DASHBOARD_PARAMETRISED_CHARTS_URL
 } from 'utils/getURLFromParams';
-import { fetchWithCancel } from './fetch-with-cancel';
-
-export function* setLoadingSpinner(timeout, action) {
-  try {
-    yield delay(timeout);
-    yield put(action);
-  } catch (e) {
-    console.error(e);
-  }
-}
+import { fetchWithCancel, setLoadingSpinner } from 'utils/saga-utils';
 
 export function* getDashboardPanelData(dashboardElement, optionsType, options) {
   const { page, activeTab } = dashboardElement[`${dashboardElement.activePanelId}Panel`];

--- a/frontend/scripts/react-components/nav/filters-nav/filters-nav.container.js
+++ b/frontend/scripts/react-components/nav/filters-nav/filters-nav.container.js
@@ -10,7 +10,7 @@ import {
   setLogisticsMapActiveModal,
   selectLogisticsMapInspectionLevel
 } from 'react-components/logistics-map/logistics-map.actions';
-import { selectBiomeFilter, selectResizeBy, selectView } from 'actions/tool.actions';
+import { selectBiomeFilter, selectResizeBy, selectView } from 'react-components/tool/tool.actions';
 
 function mapStateToProps(state) {
   return {

--- a/frontend/scripts/react-components/nav/filters-nav/recolor-by-selector/recolor-by-selector.js
+++ b/frontend/scripts/react-components/nav/filters-nav/recolor-by-selector/recolor-by-selector.js
@@ -1,5 +1,5 @@
 import { connect } from 'react-redux';
-import { selectRecolorBy } from 'actions/tool.actions';
+import { selectRecolorBy } from 'react-components/tool/tool.actions';
 import { getToolRecolorGroups } from 'react-components/tool/tool.selectors';
 import RecolorBySelector from './recolor-by.component';
 import { getSelectedRecolorByValue, getRecolorByOptions } from './recolor-by-selector.selectors';

--- a/frontend/scripts/react-components/tool-layers/tool-layers.reducer.js
+++ b/frontend/scripts/react-components/tool-layers/tool-layers.reducer.js
@@ -11,7 +11,7 @@ import {
   TOGGLE_MAP,
   TOGGLE_MAP_DIMENSION,
   SET_MAP_DIMENSIONS_DATA
-} from 'actions/tool.actions';
+} from 'react-components/tool/tool.actions';
 import { SET_CONTEXT } from 'scripts/actions/app.actions';
 import immer from 'immer';
 import createReducer from 'utils/createReducer';

--- a/frontend/scripts/react-components/tool-links/tool-links.actions.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.actions.js
@@ -1,0 +1,23 @@
+export const TOOL_LINKS__SET_FLOWS_LOADING = 'TOOL_LINKS__SET_FLOWS_LOADING';
+export const TOOL_LINKS__GET_NODES_AND_COLUMNS = 'TOOL_LINKS__GET_NODES_AND_COLUMNS';
+export const TOOL_LINKS__SET_NODES_AND_COLUMNS = 'TOOL_LINKS__SET_NODES_AND_COLUMNS';
+
+export function setToolFlowsLoading(loading) {
+  return {
+    type: TOOL_LINKS__SET_FLOWS_LOADING,
+    payload: { loading }
+  };
+}
+
+export function getToolNodesAndColumns() {
+  return {
+    type: TOOL_LINKS__GET_NODES_AND_COLUMNS
+  };
+}
+
+export function setToolNodesAndColumns(nodes, columns) {
+  return {
+    type: TOOL_LINKS__SET_NODES_AND_COLUMNS,
+    payload: { nodes, columns }
+  };
+}

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -1,0 +1,35 @@
+import { put, call, cancelled, fork } from 'redux-saga/effects';
+import { GET_COLUMNS_URL, GET_ALL_NODES_URL, getURLFromParams } from 'utils/getURLFromParams';
+import { fetchWithCancel, setLoadingSpinner } from 'utils/saga-utils';
+import { setToolFlowsLoading, setToolNodesAndColumns } from './tool-links.actions';
+
+export function* getToolNodesAndColumnsData(selectedContext) {
+  const params = {
+    context_id: selectedContext.id
+  };
+  const nodesUrl = getURLFromParams(GET_ALL_NODES_URL, params);
+  const columnsUrl = getURLFromParams(GET_COLUMNS_URL, params);
+  const task = yield fork(setLoadingSpinner, 750, setToolFlowsLoading(true));
+  const { source: nodesSource, fetchPromise: nodesFetchPromise } = fetchWithCancel(nodesUrl);
+  const { source: columnsSource, fetchPromise: columnsFetchPromise } = fetchWithCancel(columnsUrl);
+  try {
+    const { data: nodesResponse } = yield call(nodesFetchPromise);
+    const { data: columnsResponse } = yield call(columnsFetchPromise);
+    if (task.isRunning()) {
+      task.cancel();
+    }
+    yield put(setToolNodesAndColumns(nodesResponse.data, columnsResponse.data));
+  } catch (e) {
+    console.error('Error', e);
+  } finally {
+    if (yield cancelled()) {
+      if (NODE_ENV_DEV) console.error('Cancelled');
+      if (nodesSource) {
+        nodesSource.cancel();
+      }
+      if (columnsSource) {
+        columnsSource.cancel();
+      }
+    }
+  }
+}

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -40,7 +40,7 @@ export const toolLinksInitialState = {
   forcedOverview: false,
   expandedNodesIds: [],
   highlightedNodesIds: [],
-  flowsLoading: false,
+  flowsLoading: true, // TODO: remove this, should not be true by default.
   selectedBiomeFilter: null,
   selectedColumnsIds: [],
   selectedNodesIds: [],
@@ -50,8 +50,11 @@ export const toolLinksInitialState = {
 };
 
 const toolLinksReducer = {
-  [TOOL_LINKS__SET_FLOWS_LOADING](state) {
-    return { ...state, flowsLoading: true };
+  [TOOL_LINKS__SET_FLOWS_LOADING](state, action) {
+    const { loading } = action.payload;
+    return immer(state, draft => {
+      draft.flowsLoading = loading;
+    });
   },
   [RESET_SELECTION](state) {
     return immer(state, draft => {

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -1,5 +1,4 @@
 import {
-  GET_COLUMNS,
   GET_LINKS,
   HIGHLIGHT_NODE,
   RESET_SELECTION,
@@ -10,13 +9,16 @@ import {
   SELECT_RESIZE_BY,
   SELECT_VIEW,
   SET_NODE_ATTRIBUTES,
-  SET_FLOWS_LOADING_STATE,
   SET_SANKEY_SEARCH_VISIBILITY,
   SHOW_LINKS_ERROR,
   UPDATE_NODE_SELECTION,
   EXPAND_NODE_SELECTION,
   COLLAPSE_NODE_SELECTION
-} from 'actions/tool.actions';
+} from 'react-components/tool/tool.actions';
+import {
+  TOOL_LINKS__SET_FLOWS_LOADING,
+  TOOL_LINKS__SET_NODES_AND_COLUMNS
+} from 'react-components/tool-links/tool-links.actions';
 import { SET_CONTEXT } from 'actions/app.actions';
 import groupBy from 'lodash/groupBy';
 import isEmpty from 'lodash/isEmpty';
@@ -38,7 +40,7 @@ export const toolLinksInitialState = {
   forcedOverview: false,
   expandedNodesIds: [],
   highlightedNodesIds: [],
-  flowsLoading: true,
+  flowsLoading: false,
   selectedBiomeFilter: null,
   selectedColumnsIds: [],
   selectedNodesIds: [],
@@ -48,7 +50,7 @@ export const toolLinksInitialState = {
 };
 
 const toolLinksReducer = {
-  [SET_FLOWS_LOADING_STATE](state) {
+  [TOOL_LINKS__SET_FLOWS_LOADING](state) {
     return { ...state, flowsLoading: true };
   },
   [RESET_SELECTION](state) {
@@ -77,10 +79,10 @@ const toolLinksReducer = {
       });
     });
   },
-  [GET_COLUMNS](state, action) {
+
+  [TOOL_LINKS__SET_NODES_AND_COLUMNS](state, action) {
     return immer(state, draft => {
-      const nodes = action.payload[0].data;
-      const columns = action.payload[1].data;
+      const { nodes, columns } = action.payload;
 
       // context-dependant columns
       const columnsByGroupObj = groupBy(columns, 'group');

--- a/frontend/scripts/react-components/tool-links/tool-links.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.saga.js
@@ -1,4 +1,6 @@
-import { select, all, fork, takeLatest } from 'redux-saga/effects';
+import { select, all, call, fork, put, takeLatest } from 'redux-saga/effects';
+import { SET_CONTEXT } from 'actions/app.actions';
+import { loadLinks, loadMapVectorData } from 'react-components/tool/tool.actions';
 import { TOOL_LINKS__GET_NODES_AND_COLUMNS } from './tool-links.actions';
 import { getToolNodesAndColumnsData } from './tool-links.fetch.saga';
 
@@ -8,9 +10,13 @@ export function* fetchToolNodesAndColumns() {
     const {
       app: { selectedContext }
     } = state;
-    yield fork(getToolNodesAndColumnsData, selectedContext);
+    yield call(getToolNodesAndColumnsData, selectedContext);
+
+    // TODO: remove this calls, just here to split the refactor in stages
+    yield put(loadLinks());
+    yield put(loadMapVectorData());
   }
-  yield takeLatest(TOOL_LINKS__GET_NODES_AND_COLUMNS, performFetch);
+  yield takeLatest([TOOL_LINKS__GET_NODES_AND_COLUMNS, SET_CONTEXT], performFetch);
 }
 
 export default function* toolLinksSaga() {

--- a/frontend/scripts/react-components/tool-links/tool-links.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.saga.js
@@ -1,0 +1,19 @@
+import { select, all, fork, takeLatest } from 'redux-saga/effects';
+import { TOOL_LINKS__GET_NODES_AND_COLUMNS } from './tool-links.actions';
+import { getToolNodesAndColumnsData } from './tool-links.fetch.saga';
+
+export function* fetchToolNodesAndColumns() {
+  function* performFetch() {
+    const state = yield select();
+    const {
+      app: { selectedContext }
+    } = state;
+    yield fork(getToolNodesAndColumnsData, selectedContext);
+  }
+  yield takeLatest(TOOL_LINKS__GET_NODES_AND_COLUMNS, performFetch);
+}
+
+export default function* toolLinksSaga() {
+  const sagas = [fetchToolNodesAndColumns];
+  yield all(sagas.map(saga => fork(saga)));
+}

--- a/frontend/scripts/react-components/tool/column-selector/column-selector.container.jsx
+++ b/frontend/scripts/react-components/tool/column-selector/column-selector.container.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
-import { selectColumn } from 'actions/tool.actions';
+import { selectColumn } from 'react-components/tool/tool.actions';
 import ColumnSelector from 'react-components/tool/column-selector/column-selector.component';
 import PropTypes from 'prop-types';
 

--- a/frontend/scripts/react-components/tool/map-basemaps/map-basemaps.container.js
+++ b/frontend/scripts/react-components/tool/map-basemaps/map-basemaps.container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { mapToVanilla } from 'react-components/shared/vanilla-react-bridge.component';
-import { selectMapBasemap } from 'actions/tool.actions';
+import { selectMapBasemap } from 'react-components/tool/tool.actions';
 import { BASEMAPS } from 'constants';
 import MapBasemaps from 'react-components/tool/map-basemaps/map-basemaps.component';
 import getBasemap, { shouldUseDefaultBasemap } from 'utils/getBasemap';

--- a/frontend/scripts/react-components/tool/map-context/map-context.container.js
+++ b/frontend/scripts/react-components/tool/map-context/map-context.container.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-shadow */
 import { connect } from 'react-redux';
-import { selectContextualLayers } from 'actions/tool.actions';
+import { selectContextualLayers } from 'react-components/tool/tool.actions';
 import MapContext from 'react-components/tool/map-context/map-context.component';
 import { loadTooltip } from 'actions/app.actions';
 import { mapToVanilla } from 'react-components/shared/vanilla-react-bridge.component';

--- a/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.container.js
+++ b/frontend/scripts/react-components/tool/map-dimensions/map-dimensions.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 import MapDimensions from 'react-components/tool/map-dimensions/map-dimensions.component';
-import { toggleMapDimension } from 'actions/tool.actions';
+import { toggleMapDimension } from 'react-components/tool/tool.actions';
 import { loadTooltip } from 'actions/app.actions';
 import { mapToVanilla } from 'react-components/shared/vanilla-react-bridge.component';
 import { getSelectedMapDimensionsUids } from 'react-components/tool/tool.selectors';

--- a/frontend/scripts/react-components/tool/map/map.component.js
+++ b/frontend/scripts/react-components/tool/map/map.component.js
@@ -365,7 +365,7 @@ export default class {
     return topoLayer;
   }
 
-  _createPointVolumeShadowLayer(geoJSON, visibleNodes) {
+  _createPointVolumeShadowLayer(geoJSON, visibleNodes, nodeHeights) {
     const style = {
       smoothFactor: 0.9,
       stroke: false,
@@ -377,15 +377,19 @@ export default class {
       pane: MAP_PANES.vectorBelow,
       style,
       pointToLayer: (feature, latlng) => {
+        if (!visibleNodes) {
+          return null;
+        }
         const node = visibleNodes.find(n => n.geoId === feature.properties.geoid);
         // node is not visible bail
         if (!node) return null;
 
-        feature.properties.nodeHeight = node.height;
+        const nodeHeight = nodeHeights[node.id];
+        feature.properties.nodeHeight = nodeHeight.height;
 
         return L.circleMarker(latlng, {
           pane: MAP_PANES.vectorBelow,
-          radius: this._calculatePointVolumeShadowRadius(node.height)
+          radius: this._calculatePointVolumeShadowRadius(nodeHeight.height)
         });
       }
     });
@@ -598,7 +602,7 @@ export default class {
     }, 3000);
   }
 
-  updatePointShadowLayer({ mapVectorData, visibleNodes }) {
+  updatePointShadowLayer({ mapVectorData, visibleNodes, nodeHeights }) {
     if (!mapVectorData) return;
 
     if (this.pointVolumeShadowLayer) {
@@ -611,7 +615,8 @@ export default class {
 
     this.pointVolumeShadowLayer = this._createPointVolumeShadowLayer(
       polygonTypeLayer.geoJSON,
-      visibleNodes
+      visibleNodes,
+      nodeHeights
     );
     this.map.addLayer(this.pointVolumeShadowLayer);
   }

--- a/frontend/scripts/react-components/tool/map/map.container.js
+++ b/frontend/scripts/react-components/tool/map/map.container.js
@@ -1,7 +1,11 @@
 /* eslint-disable no-shadow */
 // see sankey.container for details on how to use those containers
 import { toggleMap, toggleMapLayerMenu } from 'actions/app.actions';
-import { selectNodeFromGeoId, highlightNodeFromGeoId, saveMapView } from 'actions/tool.actions';
+import {
+  selectNodeFromGeoId,
+  highlightNodeFromGeoId,
+  saveMapView
+} from 'react-components/tool/tool.actions';
 import {
   getVisibleNodes,
   getSelectedBiomeFilter,

--- a/frontend/scripts/react-components/tool/map/map.container.js
+++ b/frontend/scripts/react-components/tool/map/map.container.js
@@ -30,6 +30,7 @@ const mapStateToProps = state => {
     selectedNodesGeoIds: getSelectedNodesGeoIds(state),
     recolorByNodeIds: state.toolLinks.recolorByNodeIds,
     linkedGeoIds: state.toolLayers.linkedGeoIds,
+    nodeHeights: state.toolLinks.data.nodeHeights,
     highlightedGeoIds: getHighlightedNodesGeoIds(state)[0],
     defaultMapView: state.app.selectedContext ? state.app.selectedContext.map : null,
     selectedNodesIdsLength: state.toolLinks.selectedNodesIds.length,
@@ -102,7 +103,7 @@ const methodProps = [
   {
     name: 'updatePointShadowLayer',
     compared: ['visibleNodes', 'mapVectorData'],
-    returned: ['visibleNodes', 'mapVectorData']
+    returned: ['visibleNodes', 'mapVectorData', 'nodeHeights']
   }
 ];
 

--- a/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.container.js
+++ b/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.container.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import { mapToVanilla } from 'react-components/shared/vanilla-react-bridge.component';
-import { selectNode, navigateToProfile, resetState } from 'actions/tool.actions';
+import { selectNode, navigateToProfile, resetState } from 'react-components/tool/tool.actions';
 import NodesTitles from 'react-components/tool/nodes-titles/nodes-titles.component';
 import {
   getSelectedResizeBy,

--- a/frontend/scripts/react-components/tool/sankey/sankey.container.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.container.js
@@ -8,7 +8,7 @@ import {
   collapseNodeSelection,
   expandNodeSelection,
   resetState
-} from 'actions/tool.actions';
+} from 'react-components/tool/tool.actions';
 import {
   getIsVisible,
   getIsReExpand,

--- a/frontend/scripts/react-components/tool/tool-content/tool-content.container.js
+++ b/frontend/scripts/react-components/tool/tool-content/tool-content.container.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { mapToVanilla } from 'react-components/shared/vanilla-react-bridge.component';
 import ToolContent from 'react-components/tool/tool-content/tool-content.component';
-import { resetSankey } from 'actions/tool.actions';
+import { resetSankey } from 'react-components/tool/tool.actions';
 import { getMergedLinks } from 'react-components/tool/tool.selectors';
 
 const mapStateToProps = state => ({

--- a/frontend/scripts/react-components/tool/tool-content/tool-content.container.js
+++ b/frontend/scripts/react-components/tool/tool-content/tool-content.container.js
@@ -7,8 +7,7 @@ import { getMergedLinks } from 'react-components/tool/tool.selectors';
 const mapStateToProps = state => ({
   isMapVisible: state.toolLayers.isMapVisible,
   isVisible: state.app.isMapLayerVisible,
-  loading:
-    getMergedLinks(state) !== null && (state.toolLinks.flowsLoading || state.toolLayers.mapLoading),
+  loading: state.toolLinks.flowsLoading || state.toolLayers.mapLoading,
   hasError: getMergedLinks(state) === null && !state.toolLinks.flowsLoading
 });
 

--- a/frontend/scripts/react-components/tool/tool-search/node-title-group/node-title-group.container.js
+++ b/frontend/scripts/react-components/tool/tool-search/node-title-group/node-title-group.container.js
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { selectNode } from 'actions/tool.actions';
+import { selectNode } from 'react-components/tool/tool.actions';
 import NodeTitleGroup from 'react-components/tool/tool-search/node-title-group/node-title-group.component';
 import { getSelectedNodesData, getToolRecolorGroups } from 'react-components/tool/tool.selectors';
 

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
@@ -1,4 +1,4 @@
-import { selectExpandedNode, setSankeySearchVisibility } from 'actions/tool.actions';
+import { selectExpandedNode, setSankeySearchVisibility } from 'react-components/tool/tool.actions';
 import ToolSearch from 'react-components/tool/tool-search/tool-search.component';
 import { connect } from 'react-redux';
 import { getToolSearchNodes } from 'react-components/tool/tool-search/tool-search.selectors';

--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -9,7 +9,6 @@ import {
   YEARS_DISABLED_UNAVAILABLE
 } from 'constants';
 import {
-  GET_ALL_NODES_URL,
   GET_COLUMNS_URL,
   GET_FLOWS_URL,
   GET_LINKED_GEO_IDS_URL,
@@ -36,9 +35,9 @@ import {
 } from 'react-components/tool/tool.selectors';
 import pSettle from 'p-settle';
 
+import { TOOL_LINKS__SET_FLOWS_LOADING } from 'react-components/tool-links/tool-links.actions';
+
 export const RESET_SELECTION = 'RESET_SELECTION';
-export const SET_FLOWS_LOADING_STATE = 'SET_FLOWS_LOADING_STATE';
-export const GET_COLUMNS = 'GET_COLUMNS';
 export const SET_MAP_LOADING_STATE = 'SET_MAP_LOADING_STATE';
 export const GET_LINKS = 'GET_LINKS';
 export const SET_NODE_ATTRIBUTES = 'SET_NODE_ATTRIBUTES';
@@ -265,27 +264,27 @@ export function loadToolDataForCurrentContext() {
     const state = getState();
 
     if (!state.app.selectedContext) {
-      return;
+      // return;
     }
 
-    const params = {
-      context_id: state.app.selectedContext.id
-    };
-    const allNodesURL = getURLFromParams(GET_ALL_NODES_URL, params);
-    const columnsURL = getURLFromParams(GET_COLUMNS_URL, params);
-    const promises = [allNodesURL, columnsURL].map(url => fetch(url).then(resp => resp.json()));
-    dispatch(loadNodes());
-
-    Promise.all(promises).then(payload => {
-      // TODO do not wait for end of all promises/use another .all call
-      dispatch({
-        type: GET_COLUMNS,
-        payload
-      });
-
-      dispatch(loadLinks());
-      dispatch(loadMapVectorData());
-    });
+    // const params = {
+    //   context_id: state.app.selectedContext.id
+    // };
+    //
+    // const columnsURL = getURLFromParams(GET_COLUMNS_URL, params);
+    // const promises = [allNodesURL, columnsURL].map(url => fetch(url).then(resp => resp.json()));
+    // dispatch(loadNodes());
+    //
+    // Promise.all(promises).then(payload => {
+    //   // TODO do not wait for end of all promises/use another .all call
+    //   dispatch({
+    //     type: GET_COLUMNS,
+    //     payload
+    //   });
+    //
+    //   dispatch(loadLinks());
+    //   dispatch(loadMapVectorData());
+    // });
   };
 }
 
@@ -358,7 +357,7 @@ export function loadNodes() {
 
 export function loadLinks() {
   return (dispatch, getState) => {
-    dispatch({ type: SET_FLOWS_LOADING_STATE });
+    dispatch({ type: TOOL_LINKS__SET_FLOWS_LOADING });
     const state = getState();
     const selectedResizeBy = getSelectedResizeBy(state);
     const params = {

--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -9,7 +9,6 @@ import {
   YEARS_DISABLED_UNAVAILABLE
 } from 'constants';
 import {
-  GET_COLUMNS_URL,
   GET_FLOWS_URL,
   GET_LINKED_GEO_IDS_URL,
   GET_MAP_BASE_DATA_URL,
@@ -259,35 +258,6 @@ export function selectColumn(columnIndex, columnId, reloadLinks = true) {
   };
 }
 
-export function loadToolDataForCurrentContext() {
-  return (dispatch, getState) => {
-    const state = getState();
-
-    if (!state.app.selectedContext) {
-      // return;
-    }
-
-    // const params = {
-    //   context_id: state.app.selectedContext.id
-    // };
-    //
-    // const columnsURL = getURLFromParams(GET_COLUMNS_URL, params);
-    // const promises = [allNodesURL, columnsURL].map(url => fetch(url).then(resp => resp.json()));
-    // dispatch(loadNodes());
-    //
-    // Promise.all(promises).then(payload => {
-    //   // TODO do not wait for end of all promises/use another .all call
-    //   dispatch({
-    //     type: GET_COLUMNS,
-    //     payload
-    //   });
-    //
-    //   dispatch(loadLinks());
-    //   dispatch(loadMapVectorData());
-    // });
-  };
-}
-
 export function loadNodes() {
   return (dispatch, getState) => {
     const params = {
@@ -357,7 +327,7 @@ export function loadNodes() {
 
 export function loadLinks() {
   return (dispatch, getState) => {
-    dispatch({ type: TOOL_LINKS__SET_FLOWS_LOADING });
+    dispatch({ type: TOOL_LINKS__SET_FLOWS_LOADING, payload: { loading: true } });
     const state = getState();
     const selectedResizeBy = getSelectedResizeBy(state);
     const params = {

--- a/frontend/scripts/react-components/tool/tool.thunks.js
+++ b/frontend/scripts/react-components/tool/tool.thunks.js
@@ -1,10 +1,10 @@
 import { loadDisclaimer, resize } from 'actions/app.actions';
-import { GET_COLUMNS, loadMapVectorData, loadNodes, loadLinks } from 'scripts/actions/tool.actions';
-import {
-  GET_COLUMNS_URL,
-  GET_ALL_NODES_URL,
-  getURLFromParams
-} from 'scripts/utils/getURLFromParams';
+// import {
+//   loadMapVectorData,
+//   loadNodes,
+//   loadLinks
+// } from 'react-components/tool/tool.actions';
+import { getToolNodesAndColumns } from 'react-components/tool-links/tool-links.actions';
 
 export const loadDisclaimerTool = dispatch => dispatch(loadDisclaimer());
 
@@ -17,22 +17,11 @@ export const loadToolInitialData = (dispatch, getState) => {
     return;
   }
 
-  const params = {
-    context_id: state.app.selectedContext.id
-  };
-  const allNodesURL = getURLFromParams(GET_ALL_NODES_URL, params);
-  const columnsURL = getURLFromParams(GET_COLUMNS_URL, params);
-  const promises = [allNodesURL, columnsURL].map(url => fetch(url).then(resp => resp.json()));
-  dispatch(loadNodes());
+  dispatch(getToolNodesAndColumns());
+  // dispatch(loadNodes());
 
-  Promise.all(promises).then(payload => {
-    // TODO do not wait for end of all promises/use another .all call
-    dispatch({
-      type: GET_COLUMNS,
-      payload
-    });
-
-    dispatch(loadLinks());
-    dispatch(loadMapVectorData());
-  });
+  // Promise.all(promises).then(([nodesResponse, columnsResponse]) => {
+  //   dispatch(loadLinks());
+  //   dispatch(loadMapVectorData());
+  // });
 };

--- a/frontend/scripts/react-components/tool/tool.thunks.js
+++ b/frontend/scripts/react-components/tool/tool.thunks.js
@@ -1,9 +1,5 @@
 import { loadDisclaimer, resize } from 'actions/app.actions';
-// import {
-//   loadMapVectorData,
-//   loadNodes,
-//   loadLinks
-// } from 'react-components/tool/tool.actions';
+import { loadNodes } from 'react-components/tool/tool.actions';
 import { getToolNodesAndColumns } from 'react-components/tool-links/tool-links.actions';
 
 export const loadDisclaimerTool = dispatch => dispatch(loadDisclaimer());
@@ -18,10 +14,5 @@ export const loadToolInitialData = (dispatch, getState) => {
   }
 
   dispatch(getToolNodesAndColumns());
-  // dispatch(loadNodes());
-
-  // Promise.all(promises).then(([nodesResponse, columnsResponse]) => {
-  //   dispatch(loadLinks());
-  //   dispatch(loadMapVectorData());
-  // });
+  dispatch(loadNodes());
 };

--- a/frontend/scripts/reducers/app.reducer.js
+++ b/frontend/scripts/reducers/app.reducer.js
@@ -17,7 +17,7 @@ import {
   APP__TRANSIFEX_LANGUAGES_LOADED
 } from 'actions/app.actions';
 import createReducer from 'utils/createReducer';
-import { SELECT_YEARS } from 'actions/tool.actions';
+import { SELECT_YEARS } from 'react-components/tool/tool.actions';
 
 const initialState = {
   languages: [],

--- a/frontend/scripts/sagas.js
+++ b/frontend/scripts/sagas.js
@@ -1,7 +1,8 @@
 import { all, fork } from 'redux-saga/effects';
 import dashboardElement from 'react-components/dashboard-element/dashboard-element.saga';
+import toolLinks from 'react-components/tool-links/tool-links.saga';
 
-const sagas = [dashboardElement];
+const sagas = [dashboardElement, toolLinks];
 
 export function* rootSaga() {
   yield all(sagas.map(saga => fork(saga)));

--- a/frontend/scripts/tests/dashboard-element/fetch.saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/fetch.saga.test.js
@@ -1,6 +1,6 @@
 import { initialState } from 'react-components/dashboard-element/dashboard-element.reducer';
 import { cancelled } from 'redux-saga/effects';
-import { fetchWithCancel } from 'react-components/dashboard-element/fetch-with-cancel';
+import { fetchWithCancel } from 'utils/saga-utils';
 
 import {
   getDashboardPanelData,

--- a/frontend/scripts/tests/dashboard-element/saga.test.js
+++ b/frontend/scripts/tests/dashboard-element/saga.test.js
@@ -24,7 +24,7 @@ import {
   DASHBOARD_ELEMENT__CLEAR_PANELS
 } from 'react-components/dashboard-element/dashboard-element.actions';
 import { getURLFromParams } from 'utils/getURLFromParams';
-import { fetchWithCancel } from 'react-components/dashboard-element/fetch-with-cancel';
+import { fetchWithCancel } from 'utils/saga-utils';
 import { recordSaga } from '../utils/record-saga';
 
 jest.mock('utils/getURLFromParams', () => ({

--- a/frontend/scripts/utils/saga-utils.js
+++ b/frontend/scripts/utils/saga-utils.js
@@ -1,4 +1,5 @@
 import axios, { CancelToken } from 'axios';
+import { put, delay } from 'redux-saga/effects';
 
 export function fetchWithCancel(url) {
   const source = CancelToken.source();
@@ -9,4 +10,13 @@ export function fetchWithCancel(url) {
     });
 
   return { fetchPromise, source };
+}
+
+export function* setLoadingSpinner(timeout, action) {
+  try {
+    yield delay(timeout);
+    yield put(action);
+  } catch (e) {
+    console.error(e);
+  }
 }


### PR DESCRIPTION
This PR moves some things around to start fetch data with sagas. I was able to remove an imperative call to update the fetching when context switches. Now we listen to the `SET_CONTEXT` action and fetch the data.