### PR TITLE
Feature/refactor tool search

### DIFF
--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -143,9 +143,12 @@ export const setLanguage = lang => (dispatch, getState) => {
   return dispatch(redirect({ type: location.type, payload }));
 };
 
-export function loadSearchResults(searchTerm) {
+export function loadSearchResults(searchTerm, contextId) {
   return dispatch => {
-    const url = `${getURLFromParams(GET_NODES_WITH_SEARCH_URL)}?query=${searchTerm}`;
+    const contextIdParam = contextId ? `&context_id=${contextId}` : '';
+    const url = `${getURLFromParams(
+      GET_NODES_WITH_SEARCH_URL
+    )}?query=${searchTerm}${contextIdParam}`;
 
     if (isEmpty(searchTerm)) {
       dispatch(resetSearchResults());

--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -145,11 +145,7 @@ export const setLanguage = lang => (dispatch, getState) => {
 
 export function loadSearchResults(searchTerm, contextId) {
   return dispatch => {
-    const contextIdParam = contextId ? `&context_id=${contextId}` : '';
-    const url = `${getURLFromParams(
-      GET_NODES_WITH_SEARCH_URL
-    )}?query=${searchTerm}${contextIdParam}`;
-
+    const url = getURLFromParams(GET_NODES_WITH_SEARCH_URL, { query: searchTerm, contextId });
     if (isEmpty(searchTerm)) {
       dispatch(resetSearchResults());
       return;

--- a/frontend/scripts/react-components/tool-layers/tool-layers.saga.js
+++ b/frontend/scripts/react-components/tool-layers/tool-layers.saga.js
@@ -6,7 +6,11 @@ import {
   TOOL_LINKS__SELECT_COLUMN
 } from 'react-components/tool-links/tool-links.actions';
 import { SET_CONTEXT, LOAD_INITIAL_CONTEXT } from 'actions/app.actions';
-import { SELECT_YEARS, loadMapChoropleth } from 'react-components/tool/tool.actions';
+import {
+  SELECT_YEARS,
+  loadMapChoropleth,
+  SET_SELECTED_NODES_BY_SEARCH
+} from 'react-components/tool/tool.actions';
 import { getLinkedGeoIds, getMapDimensions } from './tool-layers.fetch.saga';
 
 function* fetchLinkedGeoIds() {
@@ -15,7 +19,12 @@ function* fetchLinkedGeoIds() {
   }
 
   yield takeLatest(
-    [TOOL_LINKS__SET_SELECTED_NODES, TOOL_LINKS__CLEAR_SANKEY, TOOL_LINKS__SELECT_COLUMN],
+    [
+      TOOL_LINKS__SET_SELECTED_NODES,
+      TOOL_LINKS__CLEAR_SANKEY,
+      TOOL_LINKS__SELECT_COLUMN,
+      SET_SELECTED_NODES_BY_SEARCH
+    ],
     getGeoIds
   );
 }

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -223,12 +223,12 @@ const toolLinksReducer = {
   },
   [SET_SELECTED_NODES_BY_SEARCH](state, action) {
     return immer(state, draft => {
-      const { nodes } = action.payload;
-      const ids = nodes.map(n => n.id);
+      const { results } = action.payload;
+      const ids = results.map(n => n.id);
 
       const columns = Object.values(draft.data.columns || {});
-      nodes.forEach(node => {
-        const column = columns.find(c => c.name === node.nodeType);
+      results.forEach(result => {
+        const column = columns.find(c => c.name === result.nodeType);
         const { selectedColumnsIds } = draft;
         if (
           (column.isDefault === false && !selectedColumnsIds) ||

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -4,7 +4,8 @@ import {
   SELECT_RECOLOR_BY,
   SELECT_RESIZE_BY,
   SET_NODE_ATTRIBUTES,
-  SHOW_LINKS_ERROR
+  SHOW_LINKS_ERROR,
+  SET_SELECTED_NODES_BY_SEARCH
 } from 'react-components/tool/tool.actions';
 import {
   TOOL_LINKS__CLEAR_SANKEY,
@@ -213,6 +214,22 @@ const toolLinksReducer = {
         const column = draft.data.columns[node.columnId];
         return column.group !== columnIndex;
       });
+    });
+  },
+  [SET_SELECTED_NODES_BY_SEARCH](state, action) {
+    return immer(state, draft => {
+      const { ids } = action.payload;
+      const areNodesExpanded = draft.expandedNodesIds.length > 0;
+      if (
+        areNodesExpanded &&
+        draft.selectedNodesIds.length === 1 &&
+        draft.selectedNodesIds.includes(ids)
+      ) {
+        // we are unselecting the node that is currently expanded: shrink sankey and continue to unselecting node
+        draft.expandedNodesIds = [];
+      }
+
+      draft.selectedNodesIds = xor(draft.selectedNodesIds, ids);
     });
   },
   [TOOL_LINKS__SET_SELECTED_NODES](state, action) {

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -230,12 +230,16 @@ const toolLinksReducer = {
       results.forEach(result => {
         const column = columns.find(c => c.name === result.nodeType);
         const { selectedColumnsIds } = draft;
-        if (
+        const needsColumnChange =
           (column.isDefault === false && !selectedColumnsIds) ||
           (column.isDefault === false && !selectedColumnsIds[column.group]) ||
-          (selectedColumnsIds && selectedColumnsIds[column.group] !== column.id)
-        ) {
-          draft.selectedColumnsIds.splice(column.group, 1, column.id);
+          (selectedColumnsIds && selectedColumnsIds[column.group] !== column.id);
+        if (needsColumnChange) {
+          if (selectedColumnsIds) {
+            draft.selectedColumnsIds.splice(column.group, 1, column.id);
+          } else {
+            draft.selectedColumnsIds = [column.id];
+          }
         }
       });
 

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -238,7 +238,8 @@ const toolLinksReducer = {
           if (selectedColumnsIds) {
             draft.selectedColumnsIds.splice(column.group, 1, column.id);
           } else {
-            draft.selectedColumnsIds = [column.id];
+            draft.selectedColumnsIds = [];
+            draft.selectedColumnsIds[column.group] = column.id;
           }
         }
       });

--- a/frontend/scripts/react-components/tool/tool-search/tool-search-result/tool-search-result.component.jsx
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search-result/tool-search-result.component.jsx
@@ -64,31 +64,31 @@ function ToolSearchResult({
   return (
     <li {...itemProps} className={cx('c-search-result', { '-highlighted': isHighlighted })}>
       <div className="search-node-text-container">
-        <span className="search-node-type">{item.type}</span>
+        <span className="search-node-type">{item.nodeType}</span>
         <span className="search-node-name">
           <HighlightTextFragments text={item.name} highlight={value} />
         </span>
       </div>
       <div className="search-node-actions-container">
         {buttonList}
-        {item.profileType &&
-          item.type.split(' & ').map(type => (
+        {item.profile &&
+          item.nodeType.split(' & ').map(nodeType => (
             <LinkButton
               className="-medium-large"
-              key={item.name + type}
+              key={item.name + nodeType}
               to={{
                 type: 'profileNode',
                 payload: {
-                  profileType: item.profileType,
+                  profileType: item.profile,
                   query: {
                     contextId,
                     year: defaultYear,
-                    nodeId: (item[type.toLowerCase()] || item).id
+                    nodeId: (item[nodeType.toLowerCase()] || item).id
                   }
                 }
               }}
             >
-              {type} profile
+              {nodeType} profile
             </LinkButton>
           ))}
       </div>

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.component.jsx
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.component.jsx
@@ -143,7 +143,7 @@ export default class ToolSearch extends Component {
       nodes
     } = this.props;
 
-    const { inputValue: stateInput } = this.state;
+    const { inputValue } = this.state;
 
     if (isSearchOpen === false) {
       return (
@@ -166,10 +166,9 @@ export default class ToolSearch extends Component {
             itemToString={i => (i === null ? '' : i.name)}
             onSelect={this.onSelected}
             ref={this.setDownshiftRef}
-            selectedItem={stateInput}
             onStateChange={this.onDownshiftStateChange}
           >
-            {({ getInputProps, getItemProps, isOpen, inputValue, highlightedIndex }) => (
+            {({ getInputProps, getItemProps, isOpen, highlightedIndex }) => (
               <div className="search-container" onClick={e => e.stopPropagation()}>
                 <div className="search-bar">
                   <div style={{ overflow: selectedNodesIds.length > 3 ? 'auto' : 'inherit' }}>

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.component.jsx
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.component.jsx
@@ -87,7 +87,9 @@ export default class ToolSearch extends Component {
   onAddNode = (e, item) => {
     const { onAddNode, selectedNodesIds } = this.props;
     if (e) e.stopPropagation();
-    const ids = ToolSearch.getNodeIds(item).filter(id => !selectedNodesIds.includes(id));
+    const ids = ToolSearch.getNodeIds(item)
+      .filter(id => !selectedNodesIds.includes(id))
+      .map(id => ({ id, nodeType: item.nodeType }));
     onAddNode(ids);
     this.downshift.reset();
     this.input.focus();

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.component.jsx
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.component.jsx
@@ -87,10 +87,14 @@ export default class ToolSearch extends Component {
   onAddNode = (e, item) => {
     const { onAddNode, selectedNodesIds } = this.props;
     if (e) e.stopPropagation();
-    const ids = ToolSearch.getNodeIds(item)
+    const splittedIds = ToolSearch.getNodeIds(item);
+
+    // Select only the results in the IMPORTER_EXPORTER pair that are not already selected
+    const results = splittedIds
       .filter(id => !selectedNodesIds.includes(id))
       .map(id => ({ id, nodeType: item.nodeType }));
-    onAddNode(ids);
+
+    onAddNode(results);
     this.downshift.reset();
     this.input.focus();
   };

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
@@ -2,17 +2,18 @@ import { selectExpandedNode } from 'react-components/tool/tool.actions';
 import { setIsSearchOpen } from 'react-components/tool-links/tool-links.actions';
 import ToolSearch from 'react-components/tool/tool-search/tool-search.component';
 import { connect } from 'react-redux';
-import { getToolSearchNodes } from 'react-components/tool/tool-search/tool-search.selectors';
+import { getSearchResults } from 'react-components/tool/tool-search/tool-search.selectors';
+import { loadSearchResults } from 'actions/app.actions';
 
 const mapStateToProps = state => {
   const { selectedContext } = state.app;
   const { selectedNodesIds, isSearchOpen, isMapVisible } = state.toolLinks;
-  const searchNodes = getToolSearchNodes(state);
+  const searchResults = getSearchResults(state);
   return {
     selectedNodesIds,
     isSearchOpen,
     isMapVisible,
-    nodes: searchNodes,
+    nodes: searchResults,
     contextId: selectedContext && selectedContext.id,
     defaultYear: selectedContext && selectedContext.defaultYear
   };
@@ -20,7 +21,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = {
   onAddNode: selectExpandedNode,
-  setIsSearchOpen
+  setIsSearchOpen,
+  onInputValueChange: loadSearchResults
 };
 
 export default connect(

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
@@ -20,7 +20,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-  onAddNode: selectSearchNode,
+  onAddResult: selectSearchNode,
   setIsSearchOpen,
   onInputValueChange: loadSearchResults
 };

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.container.js
@@ -1,4 +1,4 @@
-import { selectExpandedNode } from 'react-components/tool/tool.actions';
+import { selectSearchNode } from 'react-components/tool/tool.actions';
 import { setIsSearchOpen } from 'react-components/tool-links/tool-links.actions';
 import ToolSearch from 'react-components/tool/tool-search/tool-search.component';
 import { connect } from 'react-redux';
@@ -20,7 +20,7 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
-  onAddNode: selectExpandedNode,
+  onAddNode: selectSearchNode,
   setIsSearchOpen,
   onInputValueChange: loadSearchResults
 };

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
@@ -1,31 +1,13 @@
 import { SET_SELECTED_NODES_BY_SEARCH } from 'react-components/tool/tool.actions';
 import { all, fork, takeLatest, select, put } from 'redux-saga/effects';
 import { getVisibleNodes } from 'react-components/tool/tool.selectors';
-import { expandSankey, selectColumn } from 'react-components/tool-links/tool-links.actions';
+import { expandSankey } from 'react-components/tool-links/tool-links.actions';
 
-function* selectSearchNodes() {
-  function* changeColumn(toolLinks, ids) {
-    const node = toolLinks.data.nodes[ids[0]];
-    const columnId = node?.columnId;
-    if (columnId) {
-      const nodeColumn = toolLinks.data.columns[columnId];
-      const selectedColumnsIds = toolLinks.selectedColumnsIds;
-      if (
-        (nodeColumn.isDefault === false && !selectedColumnsIds) ||
-        (nodeColumn.isDefault === false && !selectedColumnsIds[nodeColumn.group]) ||
-        (selectedColumnsIds && selectedColumnsIds[nodeColumn.group] !== columnId)
-      ) {
-        yield put(selectColumn(nodeColumn.group, columnId));
-      }
-    }
-  }
-
-  function* selectAndExpandNodes({ payload }) {
-    const { ids } = payload;
+function* checkExpandNode() {
+  function* performCheckexpandNode({ payload }) {
+    const { nodes } = payload;
+    const ids = nodes.map(n => n.id);
     const state = yield select();
-
-    yield changeColumn(state.toolLinks, ids);
-
     const visibleNodes = getVisibleNodes(state);
     const visibleNodesById = visibleNodes.reduce((acc, next) => ({ ...acc, [next.id]: true }), {});
     const hasInvisibleNodes = ids.some(id => !visibleNodesById[id]);
@@ -34,10 +16,10 @@ function* selectSearchNodes() {
     }
   }
 
-  yield takeLatest([SET_SELECTED_NODES_BY_SEARCH], selectAndExpandNodes);
+  yield takeLatest([SET_SELECTED_NODES_BY_SEARCH], performCheckexpandNode);
 }
 
 export default function* toolSearchSaga() {
-  const sagas = [selectSearchNodes];
+  const sagas = [checkExpandNode];
   yield all(sagas.map(saga => fork(saga)));
 }

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
@@ -5,8 +5,8 @@ import { expandSankey } from 'react-components/tool-links/tool-links.actions';
 
 function* checkExpandNode() {
   function* performCheckexpandNode({ payload }) {
-    const { nodes } = payload;
-    const ids = nodes.map(n => n.id);
+    const { results } = payload;
+    const ids = results.map(n => n.id);
     const state = yield select();
     const visibleNodes = getVisibleNodes(state);
     const visibleNodesById = visibleNodes.reduce((acc, next) => ({ ...acc, [next.id]: true }), {});

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
@@ -1,0 +1,25 @@
+import { SET_SELECTED_NODES_BY_SEARCH } from 'react-components/tool/tool.actions';
+import { all, fork, takeLatest, select, put } from 'redux-saga/effects';
+import { getVisibleNodes } from 'react-components/tool/tool.selectors';
+import { expandSankey } from 'react-components/tool-links/tool-links.actions';
+
+function* selectSearchNodes() {
+  function* selectAndExpandNodes({ payload }) {
+    const { ids } = payload;
+    const state = yield select(s => s);
+    const visibleNodes = getVisibleNodes(state);
+
+    const visibleNodesById = visibleNodes.reduce((acc, next) => ({ ...acc, [next.id]: true }), {});
+    const hasInvisibleNodes = ids.some(id => !visibleNodesById[id]);
+    if (hasInvisibleNodes) {
+      yield put(expandSankey());
+    }
+  }
+
+  yield takeLatest([SET_SELECTED_NODES_BY_SEARCH], selectAndExpandNodes);
+}
+
+export default function* toolSearchSaga() {
+  const sagas = [selectSearchNodes];
+  yield all(sagas.map(saga => fork(saga)));
+}

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
@@ -1,14 +1,32 @@
 import { SET_SELECTED_NODES_BY_SEARCH } from 'react-components/tool/tool.actions';
 import { all, fork, takeLatest, select, put } from 'redux-saga/effects';
 import { getVisibleNodes } from 'react-components/tool/tool.selectors';
-import { expandSankey } from 'react-components/tool-links/tool-links.actions';
+import { expandSankey, selectColumn } from 'react-components/tool-links/tool-links.actions';
 
 function* selectSearchNodes() {
+  function* changeColumn(toolLinks, ids) {
+    const node = toolLinks.data.nodes[ids[0]];
+    const columnId = node?.columnId;
+    if (columnId) {
+      const nodeColumn = toolLinks.data.columns[columnId];
+      const selectedColumnsIds = toolLinks.selectedColumnsIds;
+      if (
+        (nodeColumn.isDefault === false && !selectedColumnsIds) ||
+        (nodeColumn.isDefault === false && !selectedColumnsIds[nodeColumn.group]) ||
+        (selectedColumnsIds && selectedColumnsIds[nodeColumn.group] !== columnId)
+      ) {
+        yield put(selectColumn(nodeColumn.group, columnId));
+      }
+    }
+  }
+
   function* selectAndExpandNodes({ payload }) {
     const { ids } = payload;
-    const state = yield select(s => s);
-    const visibleNodes = getVisibleNodes(state);
+    const state = yield select();
 
+    yield changeColumn(state.toolLinks, ids);
+
+    const visibleNodes = getVisibleNodes(state);
     const visibleNodesById = visibleNodes.reduce((acc, next) => ({ ...acc, [next.id]: true }), {});
     const hasInvisibleNodes = ids.some(id => !visibleNodesById[id]);
     if (hasInvisibleNodes) {

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.saga.js
@@ -7,8 +7,7 @@ function* checkExpandNode() {
   function* performCheckexpandNode({ payload }) {
     const { results } = payload;
     const ids = results.map(n => n.id);
-    const state = yield select();
-    const visibleNodes = getVisibleNodes(state);
+    const visibleNodes = yield select(getVisibleNodes);
     const visibleNodesById = visibleNodes.reduce((acc, next) => ({ ...acc, [next.id]: true }), {});
     const hasInvisibleNodes = ids.some(id => !visibleNodesById[id]);
     if (hasInvisibleNodes) {

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.selectors.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.selectors.js
@@ -1,57 +1,9 @@
 import { createSelector } from 'reselect';
-import flatten from 'lodash/flatten';
-import groupBy from 'lodash/groupBy';
-import isNodeColumnVisible from 'utils/isNodeColumnVisible';
-import { getSelectedColumnsIds } from 'react-components/tool/tool.selectors';
+import fuzzySearch from 'utils/fuzzySearch';
 
-const getToolNodes = state => state.toolLinks && state.toolLinks.data.nodes;
-const getToolColumns = state => state.toolLinks && state.toolLinks.data.columns;
+const getAppSearch = state => state.app.search;
 
-const getAllToolSearchNodes = createSelector(
-  getToolNodes,
-  nodes =>
-    nodes &&
-    Object.values(nodes).filter(
-      node =>
-        node.hasFlows === true &&
-        node.isAggregated !== true &&
-        node.isUnknown !== true &&
-        node.isDomesticConsumption !== true
-    )
-);
-
-const getGroupedNodes = createSelector(
-  [getAllToolSearchNodes],
-  allNodes => Object.values(groupBy(allNodes, 'mainNodeId'))
-);
-
-export const getToolSearchNodes = createSelector(
-  [getGroupedNodes, getSelectedColumnsIds, getToolNodes, getToolColumns],
-  (groupedNodes, selectedColumnsIds, nodes, columns) => {
-    if (!nodes || !columns) {
-      return [];
-    }
-
-    const getNode = ([nA, nB]) => {
-      if (nB) {
-        if (
-          isNodeColumnVisible(columns[nA.columnId], selectedColumnsIds) &&
-          isNodeColumnVisible(columns[nB.columnId], selectedColumnsIds)
-        ) {
-          return {
-            id: `${nA.id}_${nB.id}`,
-            name: nA.name,
-            type: `${nA.type} & ${nB.type}`,
-            profileType: columns[nA.columnId].profileType,
-            [nA.type.toLowerCase()]: nA,
-            [nB.type.toLowerCase()]: nB
-          };
-        }
-        return [nA, nB];
-      }
-      return nA;
-    };
-
-    return flatten(groupedNodes.map(group => getNode(group)));
-  }
+export const getSearchResults = createSelector(
+  [getAppSearch],
+  search => fuzzySearch(search.term, search.results)
 );

--- a/frontend/scripts/react-components/tool/tool-search/tool-search.selectors.js
+++ b/frontend/scripts/react-components/tool/tool-search/tool-search.selectors.js
@@ -1,9 +1,41 @@
 import { createSelector } from 'reselect';
 import fuzzySearch from 'utils/fuzzySearch';
+import groupBy from 'lodash/groupBy';
+import flatten from 'lodash/flatten';
 
 const getAppSearch = state => state.app.search;
 
-export const getSearchResults = createSelector(
+const filterSearch = createSelector(
   [getAppSearch],
   search => fuzzySearch(search.term, search.results)
+);
+
+const getGroupedNodes = createSelector(
+  [filterSearch],
+  allNodes => Object.values(groupBy(allNodes, 'mainId'))
+);
+
+export const getSearchResults = createSelector(
+  [getGroupedNodes],
+  nodes => {
+    const getNode = ([nodeA, nodeB]) => {
+      if (nodeB) {
+        const nodeTypes = [nodeA, nodeB].map(n => n.nodeType);
+        if (nodeTypes.includes('IMPORTER') && nodeTypes.includes('EXPORTER')) {
+          return {
+            id: `${nodeA.id}_${nodeB.id}`,
+            name: nodeA.name,
+            nodeType: 'IMPORTER & EXPORTER',
+            profile: nodeA.profile,
+            [nodeA.nodeType.toLowerCase()]: nodeA,
+            [nodeB.nodeType.toLowerCase()]: nodeB
+          };
+        }
+        return [nodeA, nodeB];
+      }
+      return nodeA;
+    };
+
+    return flatten(nodes.map(groupedNodes => getNode(groupedNodes)));
+  }
 );

--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -335,10 +335,10 @@ export function selectExpandedNode(param) {
   };
 }
 
-export function selectSearchNode(nodes) {
+export function selectSearchNode(results) {
   return {
     type: SET_SELECTED_NODES_BY_SEARCH,
-    payload: { nodes }
+    payload: { results }
   };
 }
 

--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -40,6 +40,7 @@ export const TOGGLE_MAP = 'TOGGLE_MAP';
 export const SAVE_MAP_VIEW = 'SAVE_MAP_VIEW';
 export const SHOW_LINKS_ERROR = 'SHOW_LINKS_ERROR';
 export const RESET_TOOL_STATE = 'RESET_TOOL_STATE';
+export const SET_SELECTED_NODES_BY_SEARCH = 'SET_SELECTED_NODES_BY_SEARCH';
 
 const _setRecolorByAction = (recolorBy, state) => {
   let selectedRecolorBy;
@@ -331,6 +332,13 @@ export function selectExpandedNode(param) {
     } else {
       dispatch(selectNodes(ids));
     }
+  };
+}
+
+export function selectSearchNode(ids) {
+  return {
+    type: SET_SELECTED_NODES_BY_SEARCH,
+    payload: { ids }
   };
 }
 

--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -335,10 +335,10 @@ export function selectExpandedNode(param) {
   };
 }
 
-export function selectSearchNode(ids) {
+export function selectSearchNode(nodes) {
   return {
     type: SET_SELECTED_NODES_BY_SEARCH,
-    payload: { ids }
+    payload: { nodes }
   };
 }
 

--- a/frontend/scripts/react-components/tool/tool.selectors.js
+++ b/frontend/scripts/react-components/tool/tool.selectors.js
@@ -140,7 +140,6 @@ export const getVisibleNodesByColumn = createSelector(
 export const getSelectedNodesData = createSelector(
   [getSelectedNodesIds, getToolNodes],
   (selectedNodesIds, nodes) => {
-    console.log('nodes', nodes);
     if (nodes) {
       return selectedNodesIds.map(id => nodes[id]).filter(Boolean);
     }

--- a/frontend/scripts/react-components/tool/tool.selectors.js
+++ b/frontend/scripts/react-components/tool/tool.selectors.js
@@ -139,7 +139,13 @@ export const getVisibleNodesByColumn = createSelector(
 
 export const getSelectedNodesData = createSelector(
   [getSelectedNodesIds, getToolNodes],
-  (selectedNodesIds, nodes) => selectedNodesIds.map(id => nodes[id]).filter(Boolean)
+  (selectedNodesIds, nodes) => {
+    console.log('nodes', nodes);
+    if (nodes) {
+      return selectedNodesIds.map(id => nodes[id]).filter(Boolean);
+    }
+    return [];
+  }
 );
 
 export const getSelectedNodesGeoIds = createSelector(
@@ -191,7 +197,7 @@ export const getFilteredLinks = createSelector(
     getToolRecolorGroups
   ],
   (unmergedLinks, selectedNodesAtColumns, nodesColored, selectedNodesIds, recolorGroups) => {
-    if (selectedNodesIds.length === 0) {
+    if (selectedNodesIds.length === 0 || unmergedLinks === null) {
       return null;
     }
     const { nodesColoredBySelection } = nodesColored;

--- a/frontend/scripts/react-components/tool/tool.selectors.js
+++ b/frontend/scripts/react-components/tool/tool.selectors.js
@@ -139,7 +139,7 @@ export const getVisibleNodesByColumn = createSelector(
 
 export const getSelectedNodesData = createSelector(
   [getSelectedNodesIds, getToolNodes],
-  (selectedNodesIds, nodes) => selectedNodesIds.map(id => nodes[id])
+  (selectedNodesIds, nodes) => selectedNodesIds.map(id => nodes[id]).filter(Boolean)
 );
 
 export const getSelectedNodesGeoIds = createSelector(

--- a/frontend/scripts/reducers/helpers/filterLinks.js
+++ b/frontend/scripts/reducers/helpers/filterLinks.js
@@ -34,7 +34,7 @@ export default function(links, selectedNodesAtColumns, nodesColoredBySelection, 
     if (linkPasses) {
       const nodeIds = intersection(link.originalPath, nodesColoredBySelection);
       let newLink = link;
-      if (nodeIds && newLink) {
+      if (nodeIds && nodeIds[0] && newLink) {
         const nodeId = nodeIds[0];
         newLink = { ...link };
         newLink.recolorGroup = recolorGroups[nodeId];

--- a/frontend/scripts/sagas.js
+++ b/frontend/scripts/sagas.js
@@ -2,8 +2,9 @@ import { all, fork } from 'redux-saga/effects';
 import dashboardElement from 'react-components/dashboard-element/dashboard-element.saga';
 import toolLinks from 'react-components/tool-links/tool-links.saga';
 import toolLayers from 'react-components/tool-layers/tool-layers.saga';
+import toolSearch from 'react-components/tool/tool-search/tool-search.saga';
 
-const sagas = [dashboardElement, toolLinks, toolLayers];
+const sagas = [dashboardElement, toolLinks, toolLayers, toolSearch];
 
 export function* rootSaga() {
   yield all(sagas.map(saga => fork(saga)));


### PR DESCRIPTION
This PR refactors the search in the Sankey and map:

- Now we are using the backend search like in the homepage but filtering by context.
- Change of column and selecting a node from another column is also considered.
- Fixed some problem with the expand node on column change.

There are two cases that are still not working:

- The endpoint is returning all the years so sometimes even if we select some node it might not show in the actual year, but it will in the one that its available. We should filter the results or disable them according to the selected years

- When we select two nodes that don't have flows in common the second node won't load. 
  Try: ARAUPEL + AMINOLA. You will get the following error:
https://staging.trase.earth/api/v3/contexts/1/flows?start_year=2003&end_year=2017&include_columns=3%2C6%2C7%2C8&flow_quant=Volume&locked_nodes[]=28857&locked_nodes[]=36235&n_nodes=100&selected_nodes=28857%2C36235

In this case, we should show a banner to expand the nodes (They will then show) or to reset the Sankey options.