### PR TITLE
Allow managing Top Profiles in the CMS

### DIFF
--- a/app/admin/api/v3/context.rb
+++ b/app/admin/api/v3/context.rb
@@ -1,0 +1,42 @@
+ActiveAdmin.register Api::V3::Context, as: 'Context' do
+  menu priority: 2
+
+  config.filters = false
+
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+
+    def scoped_collection
+      super.includes(:country)
+      super.includes(:commodity)
+    end
+  end
+
+  index do
+    columns do
+      column do
+        panel 'Contexts' do
+          ul do
+            Api::V3::Readonly::Context.all.map do |context|
+              li link_to([context.country_name, context.commodity_name].join(' / '), admin_context_path(context.id))
+            end
+          end
+        end
+      end
+    end
+  end
+
+  show do
+    attributes_table do
+      row('Country') { |property| property.country&.name }
+      row('Commodity') { |property| property.commodity&.name }
+      row :created_at
+      row :updated_at
+      row('Top profiles') { |property| link_to('Top profiles', admin_context_top_profiles_path(context_id: property.id)) }
+    end
+  end
+end

--- a/app/admin/api/v3/top_profile.rb
+++ b/app/admin/api/v3/top_profile.rb
@@ -3,6 +3,20 @@ ActiveAdmin.register Api::V3::TopProfile, as: 'Top Profile' do
   permit_params :context_id, :node_id
   config.filters = false
 
+  controller do
+    def create
+      super do |success, _failure|
+        success.html { redirect_to admin_context_top_profiles_path(parent) }
+      end
+    end
+
+    def update
+      super do |success, _failure|
+        success.html { redirect_to admin_context_top_profiles_path(parent) }
+      end
+    end
+  end
+
   index do
     column('Node name') { |property| property&.node&.name }
     actions

--- a/app/admin/api/v3/top_profile.rb
+++ b/app/admin/api/v3/top_profile.rb
@@ -1,0 +1,33 @@
+ActiveAdmin.register Api::V3::TopProfile, as: 'Top Profile' do
+  belongs_to :context, class_name: 'Api::V3::Context'
+  permit_params :context_id, :node_id
+  config.filters = false
+
+  index do
+    column('Node name') { |property| property&.node&.name }
+    actions
+  end
+
+  form do |f|
+    context_id = params[:context_id].to_i
+    profiles_for_specified_context =
+      Api::V3::Profile.joins(:context_node_type).where(context_node_types: {context_id: context_id})
+    node_type_ids = profiles_for_specified_context.pluck(:node_type_id)
+    node_type_names = Api::V3::NodeType.where(id: node_type_ids).pluck(:name)
+    available_nodes = Api::V3::Readonly::Node.where(context_id: context_id, node_type: node_type_names)
+    f.semantic_errors
+    inputs do
+      input :node, as: :select, required: true,
+                   collection: available_nodes
+    end
+    f.actions
+  end
+
+  show do
+    attributes_table do
+      row('Country') { |property| property&.context&.country&.name }
+      row('Commodity') { |property| property&.context&.commodity&.name }
+      row('Node name') { |property| property&.node&.name }
+    end
+  end
+end

--- a/app/admin/api/v3/top_profile.rb
+++ b/app/admin/api/v3/top_profile.rb
@@ -14,7 +14,10 @@ ActiveAdmin.register Api::V3::TopProfile, as: 'Top Profile' do
       Api::V3::Profile.joins(:context_node_type).where(context_node_types: {context_id: context_id})
     node_type_ids = profiles_for_specified_context.pluck(:node_type_id)
     node_type_names = Api::V3::NodeType.where(id: node_type_ids).pluck(:name)
-    available_nodes = Api::V3::Readonly::Node.where(context_id: context_id, node_type: node_type_names)
+    available_nodes = Api::V3::Readonly::Node.
+      where(context_id: context_id, node_type: node_type_names).
+      select_options
+
     f.semantic_errors
     inputs do
       input :node, as: :select, required: true,

--- a/app/models/api/v3/context.rb
+++ b/app/models/api/v3/context.rb
@@ -34,6 +34,7 @@ module Api
       has_many :map_attribute_groups
       has_many :map_attributes, through: :map_attribute_groups
       has_many :flows
+      has_many :top_profiles
 
       has_many :ind_context_properties
       has_many :quant_context_properties

--- a/app/models/api/v3/node.rb
+++ b/app/models/api/v3/node.rb
@@ -35,6 +35,7 @@ module Api
 
       has_many :dashboard_template_sources
       has_many :dashboard_templates, through: :dashboard_template_sources
+      has_many :top_profiles
 
       scope :place_nodes, -> {
         includes(:node_type).where(

--- a/app/models/api/v3/readonly/node.rb
+++ b/app/models/api/v3/readonly/node.rb
@@ -42,6 +42,12 @@ module Api
             )
           }
         }
+
+        def self.select_options
+          select(:id, :name, :node_type).order(:name).map do |node|
+            ["#{node.name} (#{node.node_type})", node.id]
+          end
+        end
       end
     end
   end

--- a/app/models/api/v3/top_profile.rb
+++ b/app/models/api/v3/top_profile.rb
@@ -1,0 +1,8 @@
+module Api
+  module V3
+    class TopProfile < BlueTable
+      belongs_to :context
+      belongs_to :node
+    end
+  end
+end

--- a/app/models/api/v3/top_profile.rb
+++ b/app/models/api/v3/top_profile.rb
@@ -19,9 +19,16 @@
 
 module Api
   module V3
-    class TopProfile < BlueTable
+    class TopProfile < YellowTable
       belongs_to :context
       belongs_to :node
+
+      def self.blue_foreign_keys
+        [
+          {name: :context_id, table_class: Api::V3::Context},
+          {name: :node_id, table_class: Api::V3::Node}
+        ]
+      end
     end
   end
 end

--- a/app/models/api/v3/top_profile.rb
+++ b/app/models/api/v3/top_profile.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: top_profiles
+#
+#  id         :bigint(8)        not null, primary key
+#  context_id :bigint(8)        not null
+#  node_id    :bigint(8)        not null
+#
+# Indexes
+#
+#  index_top_profiles_on_context_id  (context_id)
+#  index_top_profiles_on_node_id     (node_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (context_id => contexts.id)
+#  fk_rails_...  (node_id => nodes.id)
+#
+
 module Api
   module V3
     class TopProfile < BlueTable

--- a/app/services/api/v3/import/tables.rb
+++ b/app/services/api/v3/import/tables.rb
@@ -48,6 +48,7 @@ module Api
             table_class: Api::V3::Node,
             yellow_tables: [
               Api::V3::NodeProperty,
+              Api::V3::TopProfile,
               Api::V3::DashboardTemplateSource,
               Api::V3::DashboardTemplateCompany,
               Api::V3::DashboardTemplateDestination

--- a/db/migrate/20190618131945_create_top_profiles.rb
+++ b/db/migrate/20190618131945_create_top_profiles.rb
@@ -1,0 +1,8 @@
+class CreateTopProfiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :top_profiles do |t|
+      t.references :context, foreign_key: true, null: false
+      t.references :node, foreign_key: true, null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5292,6 +5292,36 @@ CREATE TABLE public.schema_migrations (
 
 
 --
+-- Name: top_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.top_profiles (
+    id bigint NOT NULL,
+    context_id bigint NOT NULL,
+    node_id bigint NOT NULL
+);
+
+
+--
+-- Name: top_profiles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.top_profiles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: top_profiles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.top_profiles_id_seq OWNED BY public.top_profiles.id;
+
+
+--
 -- Name: ckeditor_assets id; Type: DEFAULT; Schema: content; Owner: -
 --
 
@@ -5814,6 +5844,13 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: top_profiles id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.top_profiles ALTER COLUMN id SET DEFAULT nextval('public.top_profiles_id_seq'::regclass);
 
 
 --
@@ -6910,6 +6947,14 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
+-- Name: top_profiles top_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.top_profiles
+    ADD CONSTRAINT top_profiles_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: idx_ckeditor_assetable; Type: INDEX; Schema: content; Owner: -
 --
 
@@ -7554,6 +7599,20 @@ CREATE INDEX ind_country_properties_ind_id_idx ON public.ind_country_properties 
 
 
 --
+-- Name: index_top_profiles_on_context_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_top_profiles_on_context_id ON public.top_profiles USING btree (context_id);
+
+
+--
+-- Name: index_top_profiles_on_node_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_top_profiles_on_node_id ON public.top_profiles USING btree (node_id);
+
+
+--
 -- Name: map_attributes_mv_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7811,6 +7870,14 @@ CREATE INDEX sankey_nodes_mv_node_type_id_idx ON public.sankey_nodes_mv USING bt
 
 ALTER TABLE ONLY content.staff_members
     ADD CONSTRAINT fk_rails_6ad8424ffc FOREIGN KEY (staff_group_id) REFERENCES content.staff_groups(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: top_profiles fk_rails_02381b1a96; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.top_profiles
+    ADD CONSTRAINT fk_rails_02381b1a96 FOREIGN KEY (context_id) REFERENCES public.contexts(id);
 
 
 --
@@ -8422,6 +8489,14 @@ ALTER TABLE ONLY public.download_quals
 
 
 --
+-- Name: top_profiles fk_rails_eb02423c0e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.top_profiles
+    ADD CONSTRAINT fk_rails_eb02423c0e FOREIGN KEY (node_id) REFERENCES public.nodes(id);
+
+
+--
 -- Name: contexts fk_rails_eea78f436e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8527,6 +8602,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190520093639'),
 ('20190528091308'),
 ('20190529153223'),
-('20190530140625');
+('20190530140625'),
+('20190618131945');
 
 

--- a/spec/controllers/admin/contexts_controller_spec.rb
+++ b/spec/controllers/admin/contexts_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Admin::ContextsController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  describe 'GET index' do
+    it 'returns 200' do
+      get :index
+      expect(response).to be_success
+    end
+  end
+end

--- a/spec/controllers/admin/top_profiles_controller_spec.rb
+++ b/spec/controllers/admin/top_profiles_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Admin::TopProfilesController, type: :controller do
+  let(:user) { FactoryBot.create(:user) }
+  before { sign_in user }
+  let(:context) { FactoryBot.create(:api_v3_context) }
+
+  describe 'POST create' do
+    let(:valid_attributes) {
+      {context_id: context.id, node_id: FactoryBot.create(:api_v3_node).id }
+    }
+    it 'redirects to index' do
+      post :create, params: {
+        context_id: context.id, api_v3_top_profile: valid_attributes
+      }
+      expect(response).to redirect_to(admin_context_top_profiles_path(context))
+    end
+  end
+
+  describe 'PUT update' do
+    let(:top_profile) {
+      FactoryBot.create(
+        :api_v3_top_profile, context: context, node: FactoryBot.create(:api_v3_node)
+      )
+    }
+    let(:valid_attributes) {
+      {context_id: context.id, node_id: FactoryBot.create(:api_v3_node).id }
+    }
+    it 'redirects to index' do
+      put :update, params: {
+        context_id: context.id, id: top_profile.id, api_v3_top_profile: valid_attributes
+      }
+      expect(response).to redirect_to(admin_context_top_profiles_path(context))
+    end
+  end
+end

--- a/spec/factories/api/v3/api_v3_top_profile.rb
+++ b/spec/factories/api/v3/api_v3_top_profile.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :api_v3_top_profile, class: 'Api::V3::TopProfile' do
+    association :context, factory: :api_v3_context
+    association :node, factory: :api_v3_node
+  end
+end


### PR DESCRIPTION
PT task: https://www.pivotaltracker.com/n/projects/1637931/stories/166730157

* Add top_profiles table to the DB: associations with context and node
* Add associations to context and node models
* Add CMS pages for context and top profiles
* Filter available nodes for top profiles

1. New `Contexts` tab in the CMS (it's not nested)
2. Index page show dot-listed contexts with links to the details about a single context (looks like `Dashboard` index)
3. Context details include a link to `Top Profiles`
4. Top Profiles are listed for that specific context
5. Add page for Top Profile is filtering the available nodes (these which have profile pages defined in that context)
6. I used materialized views, turned off the filters in the CMS and used scoped collection in the `Context` for performance reasons.

**Note**:
This PR is missing specs but I thought I'm gonna open it anyway in case there are some business requirements I missed that can be caught on this stage.
