### PR TITLE
Refreshing sankey_nodes_mv

### DIFF
--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -59,6 +59,7 @@ module Api
 
       def refresh_dependents
         Api::V3::Readonly::Context.refresh
+        Api::V3::Readonly::SankeyNode.refresh
       end
 
       def self.roles


### PR DESCRIPTION
sankey_nodes_mv needs to be refreshed following an update to context_node_type_properties