### PR TITLE
Top Profiles: Return last available year of data per node

### DIFF
--- a/app/admin/api/v3/top_profile.rb
+++ b/app/admin/api/v3/top_profile.rb
@@ -27,7 +27,7 @@ ActiveAdmin.register Api::V3::TopProfile, as: 'Top Profile' do
     def derive_top_profile_details(top_profile)
       profile_type = top_profile.node.node_type.context_node_types.find_by(context_id: top_profile.context_id).profile.name
       top_profile.profile_type = profile_type
-      year = top_profile.context.years.max
+      year = Api::V3::Readonly::Node.find(top_profile.node.id).years.max
       top_profile.year = year
       service = "Api::V3::#{profile_type.pluralize.capitalize}::BasicAttributes".constantize
       top_profile.summary = service.new(

--- a/app/admin/api/v3/top_profile.rb
+++ b/app/admin/api/v3/top_profile.rb
@@ -25,14 +25,7 @@ ActiveAdmin.register Api::V3::TopProfile, as: 'Top Profile' do
     end
 
     def derive_top_profile_details(top_profile)
-      profile_type = top_profile.node.node_type.context_node_types.find_by(context_id: top_profile.context_id).profile.name
-      top_profile.profile_type = profile_type
-      year = Api::V3::Readonly::Node.find(top_profile.node.id).years.max
-      top_profile.year = year
-      service = "Api::V3::#{profile_type.pluralize.capitalize}::BasicAttributes".constantize
-      top_profile.summary = service.new(
-        top_profile.context, top_profile.node, year
-      ).call[:summary]
+      Api::V3::TopProfiles::DeriveTopProfileDetails.call(top_profile)
     end
   end
 

--- a/app/services/api/v3/top_profiles/derive_top_profile_details.rb
+++ b/app/services/api/v3/top_profiles/derive_top_profile_details.rb
@@ -1,0 +1,42 @@
+module Api
+  module V3
+    module TopProfiles
+      class DeriveTopProfileDetails
+        attr_reader :top_profile
+
+        class << self
+          def call(top_profile)
+            new(top_profile).call
+          end
+        end
+
+        def initialize(top_profile)
+          @top_profile = top_profile
+        end
+
+        def call
+          top_profile.profile_type = profile_type
+          top_profile.year = year
+          service = "Api::V3::#{profile_type.pluralize.capitalize}::BasicAttributes".constantize
+          top_profile.summary = service.new(
+            top_profile.context, node, year
+          ).call[:summary]
+        end
+
+        private
+
+        def node
+          top_profile.node
+        end
+
+        def profile_type
+          node.node_type.context_node_types.find_by(context_id: top_profile.context_id).profile.name
+        end
+
+        def year
+          Api::V3::Readonly::Node.find(node.id).years.max
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/top_profiles/derive_top_profile_details.rb
+++ b/app/services/api/v3/top_profiles/derive_top_profile_details.rb
@@ -15,15 +15,27 @@ module Api
         end
 
         def call
+          assign_profile_type
+          assign_year
+          assign_summary
+        end
+
+        private
+
+        def assign_profile_type
           top_profile.profile_type = profile_type
+        end
+
+        def assign_year
           top_profile.year = year
+        end
+
+        def assign_summary
           service = "Api::V3::#{profile_type.pluralize.capitalize}::BasicAttributes".constantize
           top_profile.summary = service.new(
             top_profile.context, node, year
           ).call[:summary]
         end
-
-        private
 
         def node
           top_profile.node

--- a/app/services/api/v3/top_profiles/derive_top_profile_details.rb
+++ b/app/services/api/v3/top_profiles/derive_top_profile_details.rb
@@ -43,12 +43,16 @@ module Api
           top_profile.node
         end
 
+        def readonly_node
+          Api::V3::Readonly::Node.find(node.id)
+        end
+
         def profile_type
-          node.node_type.context_node_types.find_by(context_id: top_profile.context_id).profile.name
+          readonly_node.profile
         end
 
         def year
-          Api::V3::Readonly::Node.find(node.id).years.max
+          readonly_node.years.max
         end
       end
     end

--- a/app/services/api/v3/top_profiles/derive_top_profile_details.rb
+++ b/app/services/api/v3/top_profiles/derive_top_profile_details.rb
@@ -1,3 +1,5 @@
+# Module responsible for deriving details from top profile
+# and assigning them to the new record
 module Api
   module V3
     module TopProfiles

--- a/spec/controllers/admin/top_profiles_controller_spec.rb
+++ b/spec/controllers/admin/top_profiles_controller_spec.rb
@@ -1,14 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe Admin::TopProfilesController, type: :controller do
+  render_views
   let(:user) { FactoryBot.create(:user) }
   before { sign_in user }
   before :each do
     allow(controller).to receive(:derive_top_profile_details).and_return(true)
   end
+
   let(:context) { FactoryBot.create(:api_v3_context) }
+  let(:node) { FactoryBot.create(:api_v3_node) }
+  let(:top_profile) { FactoryBot.create(:api_v3_top_profile) }
 
   describe 'POST create' do
+    subject { Api::V3::TopProfile.new(context: context, node: node) }
+
+    let(:top_profile) {
+      FactoryBot.create(
+        :api_v3_top_profile, context: context, node: FactoryBot.create(:api_v3_node)
+      )
+    }
     let(:valid_attributes) {
       {context_id: context.id, node_id: FactoryBot.create(:api_v3_node).id}
     }
@@ -17,6 +28,21 @@ RSpec.describe Admin::TopProfilesController, type: :controller do
         context_id: context.id, api_v3_top_profile: valid_attributes
       }
       expect(response).to redirect_to(admin_context_top_profiles_path(context))
+    end
+
+    it 'renders index' do
+      get :index, params: { context_id: context.id, id: top_profile.id }
+      expect(response).to render_template(:index)
+    end
+
+    it 'renders show' do
+      get :show, params: {context_id: context.id, id: top_profile.id}
+      expect(response).to render_template(:show)
+    end
+
+    it 'renders index' do
+      get :new, params: { context_id: context.id }
+      expect(response).to render_template(:new)
     end
   end
 

--- a/spec/services/api/v3/top_profiles/derive_top_profile_details_spec.rb
+++ b/spec/services/api/v3/top_profiles/derive_top_profile_details_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::TopProfiles::DeriveTopProfileDetails do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil exporter actor profile'
+
+  describe :call do
+    before(:each) do
+      Api::V3::Readonly::Node.refresh(sync: true)
+      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
+    end
+
+    let!(:top_profile) { FactoryBot.create(:api_v3_top_profile, context: api_v3_context, node: api_v3_exporter1_node) }
+    let!(:subject) { Api::V3::TopProfiles::DeriveTopProfileDetails.call(top_profile) }
+
+    it 'assigns profile type to top profile record' do
+      expect(
+        top_profile.profile_type
+      ).to eq(Api::V3::Readonly::Node.find(api_v3_exporter1_node.id).profile)
+    end
+
+    it 'assigns year to top profile record' do
+      expect(
+        top_profile.year
+      ).to eq(Api::V3::Readonly::Node.find(api_v3_exporter1_node.id).years.max)
+    end
+
+    it 'assigns summary to top profile record' do
+      expect(
+        top_profile.summary
+      ).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
PT task: https://www.pivotaltracker.com/story/show/167063535
Top Profiles: Return last available year of data per node and not per context. Use `nodes_mv` for that purpose.