### PR TITLE
Feature/logistics map tooltips and download

### DIFF
--- a/frontend/public/tooltips.json
+++ b/frontend/public/tooltips.json
@@ -24,9 +24,9 @@
     "soyProduction": "Production of soy in tonnes."
   },
   "logisticsMap": {
-    "crushing_facilities": "",
-    "refining_facilities": "",
-    "storage_facilities": "",
+    "crushing_facilities": "Crushing facilities as defined by the Brazilian Association of Vegetable Oil Industries (ABIOVE). The precise locations and capacity values were determined through additional research.",
+    "refining_facilities": "Refining facilities as defined by the Brazilian Association of Vegetable Oil Industries (ABIOVE). The precise locations were determined through additional research.",
+    "storage_facilities": "Storage facilities were determined by cross-referencing official tax registration data, export records and additional information on soy logistics hubs. Facilities which appear in the National Registry of Storage Units (CONAB SICARM) are defined as confirmed, while all others are unconfirmed.",
     "confirmed_slaughterhouse": "Slaughterhouses were classified by triangulating several datasets. Confirmed slaughterhouses are facilities that are listed as a point - of -slaughter in at least two of the following datasets: (1) Guia de Trânsito Animal(GTA) data on animal movements. (2) Government sanitary inspection. (3) Asset - level tax registrations provided by the National Registry of Legal Entities. For more details, please refer to the meta - data file.",
     "unconfirmed_slaughterhouse_multifunctional_facility": "Slaughterhouses were classified by triangulating several datasets. Unconfirmed slaughterhouses(multifunctional facilities) are facilities that are(i) listed as points - of -slaughter in tax registrations, (ii) don’ t appear in other datasets, and(iii) also have other activities than slaughter listed in their tax registration data(e.g.they may be listed as both points - of -slaughter and meat processing). For more details, please refer to the meta - data file.",
     "probable_slaughterhouse": "Slaughterhouses were classified by triangulating several datasets. Probable slaughterhouses are facilities that are either: (1) listed as a point - of -slaughter in GTAs, but not triangulated against other datasets. (2) listed in government sanitary inspection records as a slaughterhouse, but don’ t appear in our GTAs or asset - level tax registrations as slaughterhouses. For more details, please refer to the meta - data file.",

--- a/frontend/scripts/react-components/logistics-map/logistics-map-layers.js
+++ b/frontend/scripts/react-components/logistics-map/logistics-map-layers.js
@@ -86,8 +86,7 @@ export default {
       sql_config: [
         { type: 'and', key: 'inspection_level', name: 'inspection' },
         { type: 'and2', key: 'company', name: 'companies' }
-      ],
-      downloadUrl: `https://${CARTO_ACCOUNT}.carto.com/api/v2/sql?filename=confirmed_slaughterhouse&q=SELECT * FROM "${CARTO_ACCOUNT}".brazil_slaughterhouses_simple_2018_09_18 where subclass = 'CONFIRMED SLAUGHTERHOUSE'&format=csv`
+      ]
     },
     {
       version: '0.0.1',
@@ -109,8 +108,7 @@ export default {
       sql_config: [
         { type: 'and', key: 'inspection_level', name: 'inspection' },
         { type: 'and2', key: 'company', name: 'companies' }
-      ],
-      downloadUrl: `https://${CARTO_ACCOUNT}.carto.com/api/v2/sql?filename=probable_slaughterhouse&q=SELECT * FROM "${CARTO_ACCOUNT}".brazil_slaughterhouses_simple_2018_09_18 where subclass = 'PROBABLE SLAUGHTERHOUSE'&format=csv`
+      ]
     },
     {
       version: '0.0.1',
@@ -132,8 +130,7 @@ export default {
       sql_config: [
         { type: 'and', key: 'inspection_level', name: 'inspection' },
         { type: 'and2', key: 'company', name: 'companies' }
-      ],
-      downloadUrl: `https://${CARTO_ACCOUNT}.carto.com/api/v2/sql?filename=unconfirmed_slaughterhouse&q=SELECT * FROM "${CARTO_ACCOUNT}".brazil_slaughterhouses_simple_2018_09_18 where subclass = 'UNCONFIRMED SLAUGHTERHOUSE'&format=csv`
+      ]
     },
     {
       version: '0.0.1',
@@ -155,8 +152,14 @@ export default {
       sql_config: [
         { type: 'and', key: 'inspection_level', name: 'inspection' },
         { type: 'and2', key: 'company', name: 'companies' }
-      ],
-      downloadUrl: `https://${CARTO_ACCOUNT}.carto.com/api/v2/sql?filename=unconfirmed_slaughterhouse_multifunctional_facility&q=SELECT * FROM "${CARTO_ACCOUNT}".brazil_slaughterhouses_simple_2018_09_18 where subclass = 'UNCONFIRMED SLAUGHTERHOUSE (MULTIFUNCTIONAL FACILITY)'&format=csv`
+      ]
+    },
+    {
+      version: '0.0.1',
+      name: 'slaughterhouses download',
+      leyendName: 'slaughterhouses',
+      commodity: 'cattle',
+      downloadUrl: `https://${CARTO_ACCOUNT}.carto.com/api/v2/sql?filename=slaughterhouses&q=SELECT * FROM "${CARTO_ACCOUNT}".brazil_slaughterhouses_simple_2018_09_18&format=csv`
     }
   ],
   indonesia: [

--- a/frontend/scripts/react-components/logistics-map/logistics-map.selectors.js
+++ b/frontend/scripts/react-components/logistics-map/logistics-map.selectors.js
@@ -91,7 +91,7 @@ export const getLogisticsMapLayers = createSelector(
   [getActiveLayersIds, getActiveParams, getSelectedTemplates],
   (layersIds, activeParams, selectedTemplates) =>
     selectedTemplates
-      .filter(template => activeParams.commodity === template.commodity)
+      .filter(template => template.layers && activeParams.commodity === template.commodity)
       .map(template => ({
         name: template.leyendName,
         opacity: 1,
@@ -165,17 +165,19 @@ export const getCurrentSearchedCompanies = createSelector(
 export const getLogisticsMapDownloadUrls = createSelector(
   [getSelectedTemplates],
   selectedTemplates =>
-    selectedTemplates.reduce(
-      (acc, template) => ({
-        ...acc,
-        [template.commodity]: [
-          ...(acc[template.commodity] || []),
-          {
-            name: template.leyendName,
-            downloadUrl: template.downloadUrl
-          }
-        ]
-      }),
-      {}
-    )
+    selectedTemplates
+      .filter(template => template.downloadUrl)
+      .reduce(
+        (acc, template) => ({
+          ...acc,
+          [template.commodity]: [
+            ...(acc[template.commodity] || []),
+            {
+              name: template.leyendName,
+              downloadUrl: template.downloadUrl
+            }
+          ]
+        }),
+        {}
+      )
 );


### PR DESCRIPTION
This PR updates the text for the Soy tooltip metadata and merges all the slaughterhouses categories in one download. The soy downloads may remain separated as they are meaningfully different categories as stated by the client


![image](https://user-images.githubusercontent.com/9701591/61045107-773a0580-a3da-11e9-95eb-67e56cc06587.png)
![image](https://user-images.githubusercontent.com/9701591/61045118-7dc87d00-a3da-11e9-9690-3cc969cf989f.png)
