### PR TITLE
Use flexbox to mantain the whole title always visible

### DIFF
--- a/frontend/scripts/react-components/shared/animated-card/animated-card.component.jsx
+++ b/frontend/scripts/react-components/shared/animated-card/animated-card.component.jsx
@@ -31,30 +31,31 @@ function AnimatedCard(props) {
         tx-content={translateUrl ? 'translate_urls' : undefined}
         {...linkProps}
       >
-        <ImgBackground as="figure" alt={title} className="card-image" src={imageUrl} />
-        <figcaption className="card-content">
-          <div className="card-details-container">
+        <div className="card-details-container">
+          <ImgBackground as="figure" alt={title} className="card-image" src={[imageUrl]} />
+          <figcaption className="card-details-title">
             <Heading as="h4" variant="mono" color="pink" size="sm" weight="bold">
               {category}
             </Heading>
             <Heading as="h3" color="grey" size="lg" weight="bold">
               {title}
             </Heading>
-            <div className="cards-details-text-container">
+          </figcaption>
+          <div className="cards-details-text-container">
+            <div className="cards-text">
               <Text
                 as="span"
                 color="grey"
                 size="lg"
                 weight="light"
                 transform="capitalize"
-                className="card-title"
                 lineHeight="lg"
               >
                 {parseHtml ? <div dangerouslySetInnerHTML={{ __html: subtitle }} /> : subtitle}
               </Text>
             </div>
           </div>
-        </figcaption>
+        </div>
       </Link>
     </div>
   );

--- a/frontend/scripts/react-components/shared/animated-card/animated-card.scss
+++ b/frontend/scripts/react-components/shared/animated-card/animated-card.scss
@@ -46,6 +46,11 @@ $slide-height: 430px;
         transition: max-height 350ms ease-out;
         will-change: max-height;
 
+        @media screen and (max-width: $breakpoint-foundation-small - 1) {
+          max-height: 100%;
+          margin-bottom: 20px;
+        }
+
         .cards-text {
           overflow: auto;
         }

--- a/frontend/scripts/react-components/shared/animated-card/animated-card.scss
+++ b/frontend/scripts/react-components/shared/animated-card/animated-card.scss
@@ -1,8 +1,6 @@
 @import 'styles/settings';
 
 $slide-height: 430px;
-$content-height-collapsed: 82px;
-$card-min-height: 200px;
 
 .c-animated-card {
   .card-link {
@@ -15,50 +13,47 @@ $card-min-height: 200px;
     box-shadow: $box-shadow;
     overflow: hidden;
 
-    .card-image {
-      position: relative;
-      height: calc(100% - #{$content-height-collapsed});
-      width: 100%;
-      background-size: cover;
-      background-repeat: no-repeat;
-      background-position: center;
-      transition: height 350ms ease-out;
-      will-change: height;
-    }
-
-    .card-content {
+    .card-details-container {
+      display: flex;
+      flex-direction: column;
       position: absolute;
       bottom: 0;
       width: 100%;
-      min-height: $card-min-height;
-      max-height: 100%;
-      padding: 20px;
+      height: $slide-height;
+      max-height: $slide-height;
       background-color: $light-gray;
-      transform: translateY(calc(100% - #{$content-height-collapsed}));
-      transition: transform 350ms ease-out;
+      overflow: auto;
 
-      @media screen and (max-width: $breakpoint-foundation-small) {
-        height: $slide-height;
-        max-height: $slide-height;
+
+      .card-image {
+        position: relative;
+        width: 100%;
+        background-size: cover;
+        background-repeat: no-repeat;
+        background-position: center;
+        flex: 1;
       }
 
-      .card-details-container {
-        overflow: hidden;
-      }
-
-      .card-title {
-        margin-top: 5px;
+      .card-details-title {
+        padding: 20px;
+        flex: 0;
       }
 
       .cards-details-text-container {
-        max-height: calc(#{$slide-height} - #{$content-height-collapsed});
-        overflow: auto;
+        flex: 0;
+        max-height: 0;
+        padding: 0 20px;
+        transition: max-height 350ms ease-out;
+        will-change: max-height;
+
+        .cards-text {
+          overflow: auto;
+        }
       }
     }
 
     &:hover {
       .card-image {
-        height: calc(100% - #{$card-min-height});
         &::after {
           content: '';
           position: absolute;
@@ -68,8 +63,9 @@ $card-min-height: 200px;
         }
       }
 
-      .card-content {
-        transform: translateY(0);
+      .cards-details-text-container {
+        max-height: 100%;
+        margin-bottom: 20px;
       }
     }
   }


### PR DESCRIPTION
This PR refactors AnimatedCard component to use flexbox and avoid having a min-height
In this way, we can always see the full title of the profile no matter how long it is.

![image](https://user-images.githubusercontent.com/9701591/61065218-8bdec380-a403-11e9-823d-e82eae4306e9.png)
![image](https://user-images.githubusercontent.com/9701591/61065234-926d3b00-a403-11e9-8f40-b25782343bfd.png)
