### PR TITLE
Get random matching img for top profile

### DIFF
--- a/app/serializers/api/v3/top_profiles_serializer.rb
+++ b/app/serializers/api/v3/top_profiles_serializer.rb
@@ -15,7 +15,12 @@ module Api
       end
 
       def photo_url
-        object&.top_profile_image&.image&.url
+        if object.top_profile_image
+          object.top_profile_image.image.url
+        else
+          top_profile = Api::V3::TopProfile.includes(:context).find(object.id)
+          Api::V3::TopProfiles::GetMatchingImage.call(top_profile)
+        end
       end
     end
   end

--- a/app/services/api/v3/top_profiles/get_matching_image.rb
+++ b/app/services/api/v3/top_profiles/get_matching_image.rb
@@ -1,0 +1,37 @@
+# If no top profile image is assigned to top profile
+# this module will return matching image or nil if there are no matching images
+module Api
+  module V3
+    module TopProfiles
+      class GetMatchingImage
+        attr_reader :top_profile
+
+        class << self
+          def call(top_profile)
+            new(top_profile).call
+          end
+        end
+
+        def initialize(top_profile)
+          @top_profile = top_profile
+        end
+
+        def call
+          matching_images = Api::V3::TopProfileImage.
+            includes(:top_profiles).
+            where(
+              commodity_id: top_profile.context.commodity.id,
+              profile_type: top_profile.profile_type
+            )
+          return nil if matching_images.empty?
+          orphan_images = matching_images.
+            where(top_profiles: {top_profile_image: nil})
+          duplicates_inevitable = orphan_images.empty?
+          return matching_images.sample.image.url if duplicates_inevitable
+
+          orphan_images.sample.image.url
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
PT task: https://www.pivotaltracker.com/story/show/167162476

Added a service `GetMatchingImage` that first tries to find matching top profile images (same **commodity** and **profile_type**) - if it doesn't find anything, returns `nil`. We could have some predefined images for that if it's not a desired behaviour. Let me know in the comment.

If it has some matching images then it tries to find the ones that are not assigned to any top profile; if it does, it returns a random one, if not, it returns a random one from the matching images.

Everything happens on the fly, so there are no assignments in the DB. If we want to persist that, let me know in the comments as well.