### PR TITLE
When in comparison view return bar_chart type

### DIFF
--- a/app/services/api/v3/dashboards/parametrised_charts/flow_values_charts.rb
+++ b/app/services/api/v3/dashboards/parametrised_charts/flow_values_charts.rb
@@ -60,6 +60,14 @@ module Api
             )
           end
 
+          def comparison_view?
+            nodes.size > 1
+          end
+
+          def get_correct_chart_type(default_chart_type)
+            comparison_view? ? BAR_CHART : default_chart_type
+          end
+
           def initialize_node_types
             node_types_to_break_by =
               NodeTypesToBreakBy.new(@context, nodes)
@@ -87,7 +95,7 @@ module Api
           def single_year_no_ncont_overview
             {
               source: :single_year_no_ncont_overview,
-              type: DYNAMIC_SENTENCE,
+              type: get_correct_chart_type(DYNAMIC_SENTENCE),
               x: nil
             }
           end
@@ -95,15 +103,15 @@ module Api
           def single_year_no_ncont_node_type_view(node_type)
             {
               source: :single_year_no_ncont_node_type_view,
-              type: SingleYearCharts::ChartType.call(
-                data: SingleYearCharts::PrepareData.call(
-                  chart_params: @chart_params,
-                  top_n: TOP_N,
-                  node_type_idx: Api::V3::NodeType.node_index_for_id(@context, node_type.id),
-                  type: :no_ncont
-                ),
-                default_chart_type: HORIZONTAL_BAR_CHART
-              ),
+              type: get_correct_chart_type(SingleYearCharts::ChartType.call(
+                                             data: SingleYearCharts::PrepareData.call(
+                                               chart_params: @chart_params,
+                                               top_n: TOP_N,
+                                               node_type_idx: Api::V3::NodeType.node_index_for_id(@context, node_type.id),
+                                               type: :no_ncont
+                                             ),
+                                             default_chart_type: HORIZONTAL_BAR_CHART
+                                           )),
               x: :node_type,
               node_type_id: node_type.id
             }
@@ -120,7 +128,7 @@ module Api
           def single_year_ncont_overview
             {
               source: :single_year_ncont_overview,
-              type: DONUT_CHART,
+              type: get_correct_chart_type(DONUT_CHART),
               x: :ncont_attribute
             }
           end
@@ -128,7 +136,7 @@ module Api
           def single_year_ncont_node_type_view(node_type)
             {
               source: :single_year_ncont_node_type_view,
-              type: HORIZONTAL_STACKED_BAR_CHART,
+              type: get_correct_chart_type(HORIZONTAL_STACKED_BAR_CHART),
               x: :node_type,
               break_by: :ncont_attribute,
               node_type_id: node_type.id
@@ -154,7 +162,7 @@ module Api
           def multi_year_no_ncont_node_type_view(node_type)
             {
               source: :multi_year_no_ncont_node_type_view,
-              type: STACKED_BAR_CHART,
+              type: get_correct_chart_type(STACKED_BAR_CHART),
               x: :year,
               break_by: :node_type,
               node_type_id: node_type.id
@@ -211,7 +219,7 @@ module Api
           def multi_year_ncont_overview
             {
               source: :multi_year_ncont_overview,
-              type: STACKED_BAR_CHART,
+              type: get_correct_chart_type(STACKED_BAR_CHART),
               x: :year,
               break_by: :ncont_attribute
             }
@@ -220,7 +228,7 @@ module Api
           def multi_year_ncont_node_type_view(node_type)
             {
               source: :multi_year_ncont_overview,
-              type: STACKED_BAR_CHART,
+              type: get_correct_chart_type(STACKED_BAR_CHART),
               x: :year,
               break_by: :ncont_attribute,
               node_type_id: node_type.id

--- a/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
+++ b/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
@@ -270,13 +270,13 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
       [
         {
           source: :multi_year_ncont_overview,
-          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::BAR_CHART,
           x: :year,
           break_by: :ncont_attribute
         },
         {
           source: :multi_year_ncont_overview,
-          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::BAR_CHART,
           x: :year,
           break_by: :ncont_attribute,
           node_type_id: api_v3_exporter_node_type.id,
@@ -285,7 +285,7 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
         },
         {
           source: :multi_year_ncont_overview,
-          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::BAR_CHART,
           x: :year,
           break_by: :ncont_attribute,
           node_type_id: api_v3_exporter_node_type.id,
@@ -302,7 +302,7 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
       ].map do |node_type|
         {
           source: :multi_year_no_ncont_node_type_view,
-          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::BAR_CHART,
           x: :year,
           break_by: :node_type,
           node_type_id: node_type.id


### PR DESCRIPTION
PT task: https://www.pivotaltracker.com/story/show/167012059

When there are more than 1 node in the dashboard panel selected (comparison view) return `BAR_CHART` type.