### PR TITLE
Fix: sankey flows merge

### DIFF
--- a/frontend/scripts/react-components/nav/filters-nav/filters-nav.selectors.js
+++ b/frontend/scripts/react-components/nav/filters-nav/filters-nav.selectors.js
@@ -73,6 +73,7 @@ export const getToolResizeByProps = createSelector(
       value: selectedResizeBy.name,
       label: selectedResizeBy.label || ''
     },
+    isDisabled: items.length === 1 && selectedResizeBy?.name === items[0].name,
     tooltip: tooltips && tooltips.sankey.nav.resizeBy.main,
     titleTooltip:
       tooltips && selectedResizeBy && tooltips.sankey.nav.resizeBy[selectedResizeBy.name]

--- a/frontend/scripts/react-components/shared/recolor-by/recolor-by.component.jsx
+++ b/frontend/scripts/react-components/shared/recolor-by/recolor-by.component.jsx
@@ -137,7 +137,9 @@ class RecolorBy extends Component {
       color,
       weight
     } = this.props;
-    const hasZeroOrSingleElement = recolorBys.length < 1;
+    const hasZeroOrSingleElement =
+      recolorBys.length === 0 ||
+      (recolorBys.length === 1 && recolorBys[0].value === selectedRecolorBy.value);
     return (
       <Dropdown
         size={size}

--- a/frontend/scripts/react-components/tool-links/tool-links.selectors.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.selectors.js
@@ -162,7 +162,7 @@ export const getMergedLinks = createSelector(
     }
 
     if (filteredLinks) {
-      return mergeLinks(filteredLinks);
+      return mergeLinks(filteredLinks, true);
     }
     return mergeLinks(unmergedLinks);
   }

--- a/frontend/scripts/react-components/tool/sankey/sankey.d3layout.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.d3layout.js
@@ -2,7 +2,7 @@
 import uniqBy from 'lodash/uniqBy';
 import wrapSVGText from 'utils/wrapSVGText';
 import { interpolateNumber as d3_interpolateNumber } from 'd3-interpolate';
-import { sortFlows } from 'react-components/tool/sankey/sankey.utils';
+import { sortFlows } from 'react-components/tool/sankey/sort-flows';
 import { NUM_COLUMNS, DETAILED_VIEW_MIN_NODE_HEIGHT, DETAILED_VIEW_SCALE } from 'scripts/constants';
 import { translateText } from 'utils/transifex';
 

--- a/frontend/scripts/react-components/tool/sankey/sankey.utils.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.utils.js
@@ -1,0 +1,115 @@
+import sortBy from 'lodash/sortBy';
+
+// we're using logarithms to sort the flows by quant size, but also group them by recolor group
+// the idea is that when we select a recolorby we want the flows that goes into a node to be shown grouped by recolorby.
+// To group them we create a logarithm base that equals to the recolor group.
+// Then to group flows within a group from larger to smaller, we use the quant size.
+// This can expressed as: Log(recolorGroup, quant size)
+const baseLog = (base, num) => Math.log(num) / Math.log(base);
+
+function sortFlowsBySelectedRecolorBy(link, defaultSort, recolorBy, logsDebug) {
+  // sorts alphabetically with quals, numerically with inds
+  // TODO for quals use the order presented in the color by menu
+  if (recolorBy.type === 'ind') {
+    if (link.recolorBy !== null) {
+      // We raise the base to a base^10base exponent to ensure that the jumps across bases are big enough.
+      // When the jumps across bases aren't big enough we have some flows that have a very small quant size
+      // leak into the next recolor group base.
+
+      // Because we're using logarithms, and recolor groups as bases, we need to ensure that the min value of the base is 2.
+      // That's why we're adding 2 to the originalRecolorGroupIndex.
+      const base = link.recolorBy + 2;
+      const value = baseLog(base ** (10 * base), defaultSort);
+      if (logsDebug) {
+        const logRow = {
+          value,
+          recolorBy: link.recolorBy,
+          link: `${link.sourceNodeName} - ${link.targetNodeName}`
+        };
+        logsDebug.push(logRow);
+      }
+      return -value;
+    }
+    // for flows with no recolorby (unknown) we take the last possible base and add a buffer
+    const baseBuffer = 100;
+    const lastPossibleBaseWithBuffer = parseInt(recolorBy.maxValue, 10) + baseBuffer;
+
+    const value = baseLog(
+      lastPossibleBaseWithBuffer ** (10 * lastPossibleBaseWithBuffer),
+      defaultSort
+    );
+    if (logsDebug) {
+      const logRow = {
+        value,
+        lastPossibleBaseWithBuffer,
+        link: `${link.sourceNodeName} - ${link.targetNodeName}`
+      };
+      logsDebug.push(logRow);
+    }
+    return -value;
+  }
+  if (recolorBy.type === 'qual') {
+    return link.recolorBy;
+  }
+  return defaultSort;
+}
+
+function sortFlowsBySelectionRecolorGroup(
+  link,
+  defaultSort,
+  { nodesColoredAtColumn, recolorGroupsOrderedByY },
+  logsDebug
+) {
+  // Because the recolorby is set by the column with more selected nodes (nodesColoredAtColumn),
+  // and each color represent the order in which you selected each node.
+  // We're only interested in sorting the flows that are before or after this column
+  if (
+    link.sourceColumnPosition >= nodesColoredAtColumn ||
+    link.targetColumnPosition < nodesColoredAtColumn
+  ) {
+    const originalRecolorGroupIndex = recolorGroupsOrderedByY.indexOf(link.recolorGroup);
+    const recolorGroupIndex = originalRecolorGroupIndex + 2;
+
+    const value = baseLog(recolorGroupIndex ** (10 * recolorGroupIndex), defaultSort);
+    if (logsDebug) {
+      const logRow = {
+        value,
+        originalRecolorGroupIndex,
+        recolorGroupIndex,
+        link: `${link.sourceNodeName} - ${link.targetNodeName}`
+      };
+      logsDebug.push(logRow);
+    }
+    return -value;
+  }
+  return defaultSort;
+}
+
+export function sortFlows(links, recolorBy, recolorGroupOptions) {
+  // for debugging purposes uncomment next line
+  const logsDebug = false; // [];
+
+  const sortedLinks = sortBy(links, link => {
+    // all flows from all columns are mixed in the same array,
+    // this is fine because the sankey knows in which segment and node to paint each.
+    // This allows us to sort by quant size, and lets us show the biggest flows at that top of each node.
+    const defaultSort = link.quant;
+
+    if (recolorBy) {
+      return sortFlowsBySelectedRecolorBy(link, defaultSort, recolorBy, logsDebug);
+    }
+
+    // this is used when selecting nodes and no recolorby is active
+    if (links[0] && links[0].recolorGroup !== undefined) {
+      return sortFlowsBySelectionRecolorGroup(link, defaultSort, recolorGroupOptions, logsDebug);
+    }
+    return defaultSort;
+  });
+
+  if (logsDebug && NODE_ENV_DEV) {
+    // eslint-disable-next-line
+    console.table(logsDebug);
+  }
+
+  return sortedLinks;
+}

--- a/frontend/scripts/react-components/tool/sankey/sort-flows.js
+++ b/frontend/scripts/react-components/tool/sankey/sort-flows.js
@@ -7,7 +7,7 @@ import sortBy from 'lodash/sortBy';
 // This can expressed as: Log(recolorGroup, quant size)
 const baseLog = (base, num) => Math.log(num) / Math.log(base);
 
-function sortFlowsBySelectedRecolorBy(link, defaultSort, recolorBy, logsDebug) {
+export function sortFlowsBySelectedRecolorBy(link, recolorBy, logsDebug) {
   // sorts alphabetically with quals, numerically with inds
   // TODO for quals use the order presented in the color by menu
   if (recolorBy.type === 'ind') {
@@ -19,7 +19,7 @@ function sortFlowsBySelectedRecolorBy(link, defaultSort, recolorBy, logsDebug) {
       // Because we're using logarithms, and recolor groups as bases, we need to ensure that the min value of the base is 2.
       // That's why we're adding 2 to the originalRecolorGroupIndex.
       const base = link.recolorBy + 2;
-      const value = baseLog(base ** (10 * base), defaultSort);
+      const value = baseLog(base ** (10 * base), link.quant);
       if (logsDebug) {
         const logRow = {
           value,
@@ -36,7 +36,7 @@ function sortFlowsBySelectedRecolorBy(link, defaultSort, recolorBy, logsDebug) {
 
     const value = baseLog(
       lastPossibleBaseWithBuffer ** (10 * lastPossibleBaseWithBuffer),
-      defaultSort
+      link.quant
     );
     if (logsDebug) {
       const logRow = {
@@ -51,12 +51,11 @@ function sortFlowsBySelectedRecolorBy(link, defaultSort, recolorBy, logsDebug) {
   if (recolorBy.type === 'qual') {
     return link.recolorBy;
   }
-  return defaultSort;
+  return link.quant;
 }
 
-function sortFlowsBySelectionRecolorGroup(
+export function sortFlowsBySelectionRecolorGroup(
   link,
-  defaultSort,
   { nodesColoredAtColumn, recolorGroupsOrderedByY },
   logsDebug
 ) {
@@ -70,7 +69,7 @@ function sortFlowsBySelectionRecolorGroup(
     const originalRecolorGroupIndex = recolorGroupsOrderedByY.indexOf(link.recolorGroup);
     const recolorGroupIndex = originalRecolorGroupIndex + 2;
 
-    const value = baseLog(recolorGroupIndex ** (10 * recolorGroupIndex), defaultSort);
+    const value = baseLog(recolorGroupIndex ** (10 * recolorGroupIndex), link.quant);
     if (logsDebug) {
       const logRow = {
         value,
@@ -82,7 +81,7 @@ function sortFlowsBySelectionRecolorGroup(
     }
     return -value;
   }
-  return defaultSort;
+  return link.quant;
 }
 
 export function sortFlows(links, recolorBy, recolorGroupOptions) {
@@ -93,17 +92,16 @@ export function sortFlows(links, recolorBy, recolorGroupOptions) {
     // all flows from all columns are mixed in the same array,
     // this is fine because the sankey knows in which segment and node to paint each.
     // This allows us to sort by quant size, and lets us show the biggest flows at that top of each node.
-    const defaultSort = link.quant;
 
     if (recolorBy) {
-      return sortFlowsBySelectedRecolorBy(link, defaultSort, recolorBy, logsDebug);
+      return sortFlowsBySelectedRecolorBy(link, recolorBy, logsDebug);
     }
 
     // this is used when selecting nodes and no recolorby is active
     if (links[0] && links[0].recolorGroup !== undefined) {
-      return sortFlowsBySelectionRecolorGroup(link, defaultSort, recolorGroupOptions, logsDebug);
+      return sortFlowsBySelectionRecolorGroup(link, recolorGroupOptions, logsDebug);
     }
-    return defaultSort;
+    return link.quant;
   });
 
   if (logsDebug && NODE_ENV_DEV) {

--- a/frontend/scripts/reducers/helpers/mergeLinks.js
+++ b/frontend/scripts/reducers/helpers/mergeLinks.js
@@ -7,14 +7,12 @@ export default function(links, userecolorGroups) {
     return [];
   }
 
-  for (let i = 0; i < links.length; i++) {
-    const link = links[i];
-
+  links.forEach(link => {
     let key = `${link.sourceNodeId}-${link.targetNodeId}`;
 
     if (link.recolorBy !== null) {
       key = `${key}--${link.recolorBy}`;
-    } else if (userecolorGroups === true) {
+    } else if (userecolorGroups) {
       key = `${key}-colourGroup${link.recolorGroup}`;
     }
 
@@ -26,7 +24,7 @@ export default function(links, userecolorGroups) {
       dict[key].height += link.height;
       dict[key].quant += link.quant;
     }
-  }
+  });
 
   return mergedLinks;
 }

--- a/frontend/scripts/tests/tool/sankey/sort-flows.test.js
+++ b/frontend/scripts/tests/tool/sankey/sort-flows.test.js
@@ -1,0 +1,157 @@
+import {
+  sortFlowsBySelectedRecolorBy,
+  sortFlowsBySelectionRecolorGroup
+} from 'react-components/tool/sankey/sort-flows';
+import sortBy from 'lodash/sortBy';
+
+describe('Sort flows when a recolor by is selected', () => {
+  it('orders flows using numeric values when recolorby is type ind', () => {
+    const linkA = {
+      quant: 44444,
+      recolorBy: null
+    };
+    const linkA2 = {
+      quant: 444,
+      recolorBy: null
+    };
+    const linkB = {
+      quant: 33333,
+      recolorBy: 6
+    };
+    const linkB2 = {
+      quant: 333,
+      recolorBy: 6
+    };
+    const linkC = {
+      quant: 11111,
+      recolorBy: 2
+    };
+    const linkC2 = {
+      quant: 111,
+      recolorBy: 2
+    };
+    const recolorBy = {
+      maxValue: '24',
+      type: 'ind'
+    };
+
+    const resultA = sortFlowsBySelectedRecolorBy(linkA, recolorBy);
+    const resultA2 = sortFlowsBySelectedRecolorBy(linkA2, recolorBy);
+    const resultB = sortFlowsBySelectedRecolorBy(linkB, recolorBy);
+    const resultB2 = sortFlowsBySelectedRecolorBy(linkB2, recolorBy);
+    const resultC = sortFlowsBySelectedRecolorBy(linkC, recolorBy);
+    const resultC2 = sortFlowsBySelectedRecolorBy(linkC2, recolorBy);
+
+    expect(sortBy([resultA, resultB, resultC, resultA2, resultB2, resultC2])).toEqual([
+      resultC,
+      resultC2,
+      resultB,
+      resultB2,
+      resultA,
+      resultA2
+    ]);
+  });
+
+  it('orders flows alphabetically based on the qual recolorBY', () => {
+    const linkA = {
+      quant: 44444,
+      recolorBy: 'AMAZONIA'
+    };
+    const linkA2 = {
+      quant: 444,
+      recolorBy: 'AMAZONIA'
+    };
+    const linkB = {
+      quant: 33333,
+      recolorBy: 'PANTANAL'
+    };
+    const linkB2 = {
+      quant: 333,
+      recolorBy: 'PANTANAL'
+    };
+    const linkC = {
+      quant: 11111,
+      recolorBy: 'CERRADO'
+    };
+    const linkC2 = {
+      quant: 111,
+      recolorBy: 'CERRADO'
+    };
+    const recolorBy = {
+      type: 'qual'
+    };
+    const resultA = sortFlowsBySelectedRecolorBy(linkA, recolorBy);
+    const resultA2 = sortFlowsBySelectedRecolorBy(linkA2, recolorBy);
+    const resultB = sortFlowsBySelectedRecolorBy(linkB, recolorBy);
+    const resultB2 = sortFlowsBySelectedRecolorBy(linkB2, recolorBy);
+    const resultC = sortFlowsBySelectedRecolorBy(linkC, recolorBy);
+    const resultC2 = sortFlowsBySelectedRecolorBy(linkC2, recolorBy);
+
+    expect(sortBy([resultA, resultB, resultC, resultA2, resultB2, resultC2])).toEqual([
+      resultA,
+      resultA2,
+      resultC,
+      resultC2,
+      resultB,
+      resultB2
+    ]);
+  });
+});
+
+describe('Sort flows when selection by is used', () => {
+  const linkA = {
+    quant: 44444,
+    recolorGroup: 1,
+    sourceColumnPosition: 0,
+    targetColumnPosition: 1
+  };
+  const linkA2 = {
+    quant: 444,
+    recolorGroup: 1,
+    sourceColumnPosition: 0,
+    targetColumnPosition: 1
+  };
+  const linkB = {
+    quant: 33333,
+    recolorGroup: 2,
+    sourceColumnPosition: 0,
+    targetColumnPosition: 1
+  };
+  const linkB2 = {
+    quant: 333,
+    recolorGroup: 2,
+    sourceColumnPosition: 0,
+    targetColumnPosition: 1
+  };
+  const linkC = {
+    quant: 11111,
+    recolorGroup: 3,
+    sourceColumnPosition: 0,
+    targetColumnPosition: 1
+  };
+  const linkC2 = {
+    quant: 111,
+    recolorGroup: 3,
+    sourceColumnPosition: 0,
+    targetColumnPosition: 1
+  };
+  const options = {
+    nodesColoredAtColumn: 2,
+    recolorGroupsOrderedByY: [2, 1, 3]
+  };
+  const resultA = sortFlowsBySelectionRecolorGroup(linkA, options);
+  const resultA2 = sortFlowsBySelectionRecolorGroup(linkA2, options);
+  const resultB = sortFlowsBySelectionRecolorGroup(linkB, options);
+  const resultB2 = sortFlowsBySelectionRecolorGroup(linkB2, options);
+  const resultC = sortFlowsBySelectionRecolorGroup(linkC, options);
+  const resultC2 = sortFlowsBySelectionRecolorGroup(linkC2, options);
+
+  expect(sortBy([resultA, resultB, resultC, resultA2, resultB2, resultC2])).toEqual([
+    resultB,
+    resultB2,
+    resultA,
+    resultA2,
+    resultC,
+    resultC2
+  ]);
+});


### PR DESCRIPTION
This PR fixes a regression where nodes after selection werent splitted like they should.
**Related pivotal task:** https://www.pivotaltracker.com/story/show/167195012

Also fixes the imfamous links sorting issue, where links didnt follow their original order across columns:
> the ordering of colors is different for incoming and outgoing flows, which breaks the continuity and defeats the purpose of using a flow diagram.

See before and after for links ordering solution:
**Before**
![Screen Shot 2019-07-12 at 16 19 58](https://user-images.githubusercontent.com/12124839/61145000-b2216380-a4d6-11e9-9226-e0b79af1c9a5.png)

**After**
![Screen Shot 2019-07-12 at 16 45 17](https://user-images.githubusercontent.com/12124839/61145013-ba799e80-a4d6-11e9-97b9-f2c92bd05a9d.png)
