### PR TITLE
In comparison view dont include other in legend

### DIFF
--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
@@ -117,7 +117,11 @@ module Api
           end
 
           def top_nodes_break_by_values
-            top_nodes.map { |r| r['name'] } + [OTHER]
+            selected_nodes = @chart_parameters.sources_ids + @chart_parameters.companies_ids + @chart_parameters.destinations_ids
+            selected_node_types = selected_nodes.map { |id| Api::V3::Node.includes(:node_type).find(id).node_type.id }
+            is_current_node_type_in_selected_node_types = selected_node_types.include?(@node_type_idx)
+            array = is_current_node_type_in_selected_node_types ? [] : [OTHER]
+            top_nodes.map { |r| r['name'] } + array
           end
 
           def top_nodes_break_by_values_map


### PR DESCRIPTION
PT task: https://www.pivotaltracker.com/story/show/167065042
For selected nodes don't include `OTHER` in the legend.

Before:
![image](https://user-images.githubusercontent.com/6136899/61235304-205f6380-a72d-11e9-9cef-188b74007e8e.png)

After:
![image](https://user-images.githubusercontent.com/6136899/61235315-2a816200-a72d-11e9-8c1c-b34c64a377cc.png)

Note that on the attached second screen we're displaying `OTHER` in the legend of `Top 10 Importers` because no importer was selected before.

To test this scenario:
First pick `Brazil`, then from optional regions: `Brasnorte` and `Campos de Julio` --> `SOY` --> nothing --> from exporters tab `Bunge` and `Amaggi`