### PR TITLE
Disable interaction for mobile in explore

### DIFF
--- a/frontend/scripts/react-components/profiles/top-destinations-chart.component.jsx
+++ b/frontend/scripts/react-components/profiles/top-destinations-chart.component.jsx
@@ -83,7 +83,7 @@ class TopDestinationsChart extends React.PureComponent {
       testId
     } = this.props;
     const { tooltipConfig } = this.state;
-    const heightStyle = isMobile ? { minHeigh: height } : { height };
+    const heightStyle = isMobile() ? { minHeigh: height } : { height };
     return (
       <React.Fragment>
         <UnitsTooltip show={!!tooltipConfig} {...tooltipConfig} />

--- a/frontend/scripts/react-components/profiles/top-destinations-chart.component.jsx
+++ b/frontend/scripts/react-components/profiles/top-destinations-chart.component.jsx
@@ -7,15 +7,12 @@ import DropdownTabSwitcher from 'react-components/profiles/dropdown-tab-switcher
 import UnitsTooltip from 'react-components/shared/units-tooltip/units-tooltip.component';
 import Heading from 'react-components/shared/heading/heading.component';
 import ProfileTitle from 'react-components/profiles/profile-title.component';
+import isMobile from 'utils/isMobile';
 
 const TranslatedLine = withTranslation(Line);
 
 class TopDestinationsChart extends React.PureComponent {
   state = { tooltipConfig: null };
-
-  static getIsMobile() {
-    return window.innerWidth <= 640; // value needs to match with entrypoints.scss variable
-  }
 
   onMouseMove = (location, x, y) => {
     const { summary } = this.props;
@@ -86,7 +83,7 @@ class TopDestinationsChart extends React.PureComponent {
       testId
     } = this.props;
     const { tooltipConfig } = this.state;
-    const heightStyle = TopDestinationsChart.getIsMobile() ? { minHeigh: height } : { height };
+    const heightStyle = isMobile ? { minHeigh: height } : { height };
     return (
       <React.Fragment>
         <UnitsTooltip show={!!tooltipConfig} {...tooltipConfig} />

--- a/frontend/scripts/react-components/shared/world-map/world-map.component.jsx
+++ b/frontend/scripts/react-components/shared/world-map/world-map.component.jsx
@@ -95,7 +95,7 @@ class WorldMap extends React.PureComponent {
 
   renderGeographies = (geographies, projection) => {
     const { flows, originGeoId } = this.state;
-    const mouseInteractionProps = isMobile
+    const mouseInteractionProps = isMobile()
       ? {}
       : {
           onMouseMove: this.onMouseMove,
@@ -121,7 +121,7 @@ class WorldMap extends React.PureComponent {
 
   renderLines = () => {
     const { originCoordinates, flows } = this.state;
-    const mouseInteractionProps = isMobile
+    const mouseInteractionProps = isMobile()
       ? {}
       : {
           onMouseMove: this.onMouseMove,

--- a/frontend/scripts/react-components/shared/world-map/world-map.component.jsx
+++ b/frontend/scripts/react-components/shared/world-map/world-map.component.jsx
@@ -12,6 +12,7 @@ import UnitsTooltip from 'react-components/shared/units-tooltip/units-tooltip.co
 import cx from 'classnames';
 import formatValue from 'utils/formatValue';
 import xor from 'lodash/xor';
+import isMobile from 'utils/isMobile';
 
 import 'scripts/react-components/shared/world-map/world-map.scss';
 
@@ -94,6 +95,12 @@ class WorldMap extends React.PureComponent {
 
   renderGeographies = (geographies, projection) => {
     const { flows, originGeoId } = this.state;
+    const mouseInteractionProps = isMobile
+      ? {}
+      : {
+          onMouseMove: this.onMouseMove,
+          onMouseLeave: this.onMouseLeave
+        };
     return geographies.map(
       geography =>
         geography.properties.iso2 !== 'AQ' && (
@@ -106,8 +113,7 @@ class WorldMap extends React.PureComponent {
             )}
             geography={geography}
             projection={projection}
-            onMouseMove={this.onMouseMove}
-            onMouseLeave={this.onMouseLeave}
+            {...mouseInteractionProps}
           />
         )
     );
@@ -115,7 +121,12 @@ class WorldMap extends React.PureComponent {
 
   renderLines = () => {
     const { originCoordinates, flows } = this.state;
-
+    const mouseInteractionProps = isMobile
+      ? {}
+      : {
+          onMouseMove: this.onMouseMove,
+          onMouseLeave: this.onMouseLeave
+        };
     return flows.map(flow => (
       <Line
         key={flow.geoId}
@@ -129,8 +140,7 @@ class WorldMap extends React.PureComponent {
         }}
         buildPath={WorldMap.buildCurves}
         strokeWidth={flow.strokeWidth}
-        onMouseMove={this.onMouseMove}
-        onMouseLeave={this.onMouseLeave}
+        {...mouseInteractionProps}
       />
     ));
   };

--- a/frontend/scripts/utils/isMobile.js
+++ b/frontend/scripts/utils/isMobile.js
@@ -1,0 +1,3 @@
+import { BREAKPOINTS } from 'constants';
+
+export default window.innerWidth <= BREAKPOINTS.small;

--- a/frontend/scripts/utils/isMobile.js
+++ b/frontend/scripts/utils/isMobile.js
@@ -1,3 +1,3 @@
 import { BREAKPOINTS } from 'constants';
 
-export default window.innerWidth <= BREAKPOINTS.small;
+export default () => window.innerWidth <= BREAKPOINTS.small;


### PR DESCRIPTION
Disable tooltips for mobile in explore component. This was made for mobile UX reasons, the size of the action tooltips was too little. Maybe in the future would be nice to have some list with the countries

Also, checking the size of the breakpoint I realise that this doesn't fit most of the mobile width. We shall review this breakpoints.

![image](https://user-images.githubusercontent.com/9701591/61549871-71cf6180-aa51-11e9-91b0-1eafa01dbcd3.png)
