### PR TITLE
Feature/pick dashboard step

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.component.jsx
@@ -55,6 +55,7 @@ class DashboardElement extends React.PureComponent {
         onContinue={onContinue}
         dirtyBlocks={dirtyBlocks}
         onBack={showBackButton ? () => setStep(step - 1) : undefined}
+        setStep={setStep}
       />
     );
   }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.component.jsx
@@ -56,6 +56,7 @@ class DashboardElement extends React.PureComponent {
         dirtyBlocks={dirtyBlocks}
         onBack={showBackButton ? () => setStep(step - 1) : undefined}
         setStep={setStep}
+        closeModal={closeModal}
       />
     );
   }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.component.jsx
@@ -45,7 +45,7 @@ class DashboardElement extends React.PureComponent {
     const { step, setStep, editMode, closeModal, dirtyBlocks } = this.props;
     const showBackButton = step > DASHBOARD_STEPS.sources;
     const onContinue = step === DASHBOARD_STEPS.companies ? closeModal : () => setStep(step + 1);
-    if (step === DASHBOARD_STEPS.welcome) {
+    if (step === DASHBOARD_STEPS.welcome && !editMode) {
       return <DashboardWelcome onContinue={() => setStep(step + 1)} />;
     }
     return (
@@ -146,7 +146,7 @@ class DashboardElement extends React.PureComponent {
                         color="gray"
                         variant="icon"
                         className="dashboard-edit-button"
-                        onClick={() => reopenPanel(DASHBOARD_STEPS.sources)}
+                        onClick={() => reopenPanel()}
                       >
                         <svg className="icon icon-pen">
                           <use xlinkHref="#icon-pen" />

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.container.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.container.jsx
@@ -7,7 +7,8 @@ import {
   getDirtyBlocks,
   getDynamicSentence,
   getDashboardFiltersProps,
-  getDashboardGroupedCharts
+  getDashboardGroupedCharts,
+  getEditMode
 } from 'react-components/dashboard-element/dashboard-element.selectors';
 import { getPanelId } from 'utils/dashboardPanel';
 import {
@@ -26,7 +27,8 @@ const mapStateToProps = state => {
     groupedCharts: getDashboardGroupedCharts(state),
     filters: getDashboardFiltersProps(state),
     dynamicSentenceParts: getDynamicSentence(state),
-    showModalOnStart: !(dirtyBlocks.countries && dirtyBlocks.commodities)
+    showModalOnStart: !(dirtyBlocks.countries && dirtyBlocks.commodities),
+    editMode: getEditMode(state)
   };
 };
 
@@ -55,7 +57,8 @@ class DashboardElementContainer extends React.Component {
     setSelectedYears: PropTypes.func.isRequired,
     setSelectedResizeBy: PropTypes.func.isRequired,
     setSelectedRecolorBy: PropTypes.func.isRequired,
-    setDashboardActivePanel: PropTypes.func.isRequired
+    setDashboardActivePanel: PropTypes.func.isRequired,
+    editMode: PropTypes.bool
   };
 
   hasVisitedBefore = {
@@ -70,7 +73,6 @@ class DashboardElementContainer extends React.Component {
 
   state = {
     modalOpen: this.props.showModalOnStart,
-    editMode: false,
     step: this.hasVisitedBefore.get() ? DASHBOARD_STEPS.sources : DASHBOARD_STEPS.welcome
   };
 
@@ -96,13 +98,14 @@ class DashboardElementContainer extends React.Component {
 
   reopenPanel = step => {
     this.props.editDashboard();
-    this.setState({ step, editMode: true, modalOpen: true });
+    this.setState({ step, modalOpen: true });
   };
 
   updateStep = step => this.setState({ step });
 
   render() {
-    const { step, modalOpen, editMode } = this.state;
+    const { editMode } = this.props;
+    const { step, modalOpen } = this.state;
     const {
       groupedCharts,
       goToRoot,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.container.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.container.jsx
@@ -96,9 +96,9 @@ class DashboardElementContainer extends React.Component {
     this.setState({ modalOpen: false });
   };
 
-  reopenPanel = step => {
+  reopenPanel = () => {
     this.props.editDashboard();
-    this.setState({ step, modalOpen: true });
+    this.setState({ step: 0, modalOpen: true });
   };
 
   updateStep = step => this.setState({ step });

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -21,11 +21,13 @@ import {
   DASHBOARD_ELEMENT__SET_SELECTED_RESIZE_BY,
   DASHBOARD_ELEMENT__SET_CHARTS,
   DASHBOARD_ELEMENT__SET_CONTEXT_DEFAULT_FILTERS,
-  DASHBOARD_ELEMENT__SET_CHARTS_LOADING
+  DASHBOARD_ELEMENT__SET_CHARTS_LOADING,
+  DASHBOARD_ELEMENT__EDIT_DASHBOARD
 } from './dashboard-element.actions';
 
 const initialState = {
   loading: false,
+  editMode: false,
   data: {
     countries: [],
     companies: {},
@@ -94,6 +96,9 @@ const dashboardElementReducer = {
       activePanelId,
       [prevPanelName]: prevPanelState
     };
+  },
+  [DASHBOARD_ELEMENT__EDIT_DASHBOARD](state) {
+    return { ...state, editMode: true };
   },
   [DASHBOARD_ELEMENT__SET_PANEL_PAGE](state, action) {
     const { activePanelId } = state;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -85,12 +85,13 @@ const dashboardElementReducer = {
     const { activePanelId } = action.payload;
     const prevActivePanelId = state.activePanelId;
     const prevPanelName = `${prevActivePanelId}Panel`;
-    const prevPanelState = prevActivePanelId
-      ? {
-          ...state[prevPanelName],
-          page: initialState[prevPanelName].page
-        }
-      : undefined;
+    const prevPanelState =
+      prevActivePanelId && prevActivePanelId !== 'welcome'
+        ? {
+            ...state[prevPanelName],
+            page: initialState[prevPanelName].page
+          }
+        : undefined;
     return {
       ...state,
       activePanelId,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -75,7 +75,9 @@ export function* fetchDataOnPanelChange() {
   while (true) {
     const activePanel = yield take(DASHBOARD_ELEMENT__SET_ACTIVE_PANEL);
     const { activePanelId } = activePanel.payload;
-    if (activePanelId === 'welcome') return;
+    if (activePanelId === 'welcome') {
+      return;
+    }
     const newPanelState = yield select(state => state.dashboardElement);
     const changes = hasChanged(newPanelState);
     if (changes) {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -75,6 +75,7 @@ export function* fetchDataOnPanelChange() {
   while (true) {
     const activePanel = yield take(DASHBOARD_ELEMENT__SET_ACTIVE_PANEL);
     const { activePanelId } = activePanel.payload;
+    if (activePanelId === 'welcome') return;
     const newPanelState = yield select(state => state.dashboardElement);
     const changes = hasChanged(newPanelState);
     if (changes) {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
@@ -145,6 +145,7 @@ export const getIsDisabled = createSelector(
   (dynamicSentence, step) => {
     if (dynamicSentence.length === 0 || typeof step === 'undefined') return true;
     const currentPanel = getPanelName(step);
+    if (currentPanel === 'welcome') return false;
     const currentSentencePart = dynamicSentence.find(p => p.panel === currentPanel);
     if (!currentSentencePart.optional && !currentSentencePart.value) return true;
     return false;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
@@ -145,7 +145,9 @@ export const getIsDisabled = createSelector(
   (dynamicSentence, step) => {
     if (dynamicSentence.length === 0 || typeof step === 'undefined') return true;
     const currentPanel = getPanelName(step);
-    if (currentPanel === 'welcome') return false;
+    if (currentPanel === 'welcome') {
+      return false;
+    }
     const currentSentencePart = dynamicSentence.find(p => p.panel === currentPanel);
     if (!currentSentencePart.optional && !currentSentencePart.value) return true;
     return false;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
@@ -2,10 +2,12 @@ import { createSelector, createStructuredSelector } from 'reselect';
 import isEmpty from 'lodash/isEmpty';
 import intersection from 'lodash/intersection';
 import range from 'lodash/range';
+import capitalize from 'lodash/capitalize';
 import { getPanelId as getPanelName } from 'utils/dashboardPanel';
 import { makeGetResizeByItems, makeGetRecolorByItems } from 'selectors/indicators.selectors';
 import { makeGetAvailableYears } from 'selectors/years.selectors';
 
+export const getEditMode = state => state.dashboardElement.editMode;
 const getCountriesPanel = state => state.dashboardElement.countriesPanel;
 const getSourcesPanel = state => state.dashboardElement.sourcesPanel;
 const getDestinationsPanel = state => state.dashboardElement.destinationsPanel;
@@ -51,7 +53,8 @@ export const getDynamicSentence = createSelector(
     getSourcesPanel,
     getDestinationsPanel,
     getCompaniesPanel,
-    getCommoditiesPanel
+    getCommoditiesPanel,
+    getEditMode
   ],
   (
     dirtyBlocks,
@@ -59,7 +62,8 @@ export const getDynamicSentence = createSelector(
     sourcesPanel,
     destinationsPanel,
     companiesPanel,
-    commoditiesPanel
+    commoditiesPanel,
+    editMode
   ) => {
     if (Object.values(dirtyBlocks).every(block => !block)) {
       return [];
@@ -88,14 +92,18 @@ export const getDynamicSentence = createSelector(
     };
 
     const sourcesValue = getActivePanelItem('sources') || getActivePanelItem('countries');
+    const commoditiesPanelSentence = `${getActivePanelItem('commodities') ? '' : 'commodities'}`;
+    const commoditiesPrefix = editMode
+      ? capitalize(commoditiesPanelSentence)
+      : `Your dashboard will include ${commoditiesPanelSentence}`;
+    const capitalizeCommodities = editMode ? { transform: 'capitalize' } : {};
     return [
       {
         panel: 'commodities',
         id: 'commodities',
-        prefix: `Your dashboard will include ${
-          getActivePanelItem('commodities') ? '' : 'commodities'
-        }`,
-        value: getActivePanelItem('commodities')
+        prefix: commoditiesPrefix,
+        value: getActivePanelItem('commodities'),
+        ...capitalizeCommodities
       },
       {
         panel: 'sources',

--- a/frontend/scripts/react-components/dashboard-element/dashboard-modal-footer/dashboard-modal-footer.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-modal-footer/dashboard-modal-footer.component.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import TagsGroup from 'react-components/shared/tags-group';
 import Button from 'react-components/shared/button/button.component';
 import Text from 'react-components/shared/text/text.component';
-
+import { DASHBOARD_STEPS } from 'constants';
 import './dashboard-modal-footer.scss';
 
 function DashboardModalFooter(props) {
@@ -27,7 +27,6 @@ function DashboardModalFooter(props) {
     }
     onContinue();
   }, [isLastStep, goToDashboard, onContinue, dirtyBlocks, dynamicSentenceParts]);
-
   return (
     <div className="c-dashboard-modal-footer">
       <TagsGroup
@@ -36,6 +35,7 @@ function DashboardModalFooter(props) {
         clearPanel={clearPanel}
         step={step}
         placement="top-end"
+        readOnly={step === DASHBOARD_STEPS.welcome}
       />
       <div className="dashboard-modal-actions">
         {onBack && (

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -190,6 +190,7 @@ class DashboardPanel extends Component {
               label => ({ label })
             )}
             activeStep={step - 1}
+            onSelectStep={() => {}}
           />
           <Heading className="dashboard-panel-title notranslate" align="center" size="lg">
             {editMode ? translateText('Edit options') : this.renderTitleSentence()}

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -180,9 +180,20 @@ class DashboardPanel extends Component {
       dirtyBlocks,
       dynamicSentenceParts,
       step,
-      isDisabled
+      isDisabled,
+      closeModal
     } = this.props;
-    const selectStepProp = editMode ? { onSelectStep: selectedStep => setStep(selectedStep) } : {};
+
+    const handleGoToDashboard = () => {
+      goToDashboard();
+      closeModal();
+    };
+
+    const mandatoryFieldsSelected = dirtyBlocks.countries && dirtyBlocks.commodities;
+    const selectStepProp =
+      editMode && mandatoryFieldsSelected
+        ? { onSelectStep: selectedStep => setStep(selectedStep) }
+        : {};
     return (
       <div className="c-dashboard-panel">
         <div ref={this.containerRef} className="dashboard-panel-content">
@@ -199,12 +210,12 @@ class DashboardPanel extends Component {
           {this.renderPanel()}
         </div>
         <DashboardModalFooter
-          isLastStep={step === DASHBOARD_STEPS.companies}
+          isLastStep={step === DASHBOARD_STEPS.companies || (editMode && mandatoryFieldsSelected)}
           onContinue={onContinue}
           onBack={onBack}
           backText="Back"
           dirtyBlocks={dirtyBlocks}
-          goToDashboard={goToDashboard}
+          goToDashboard={handleGoToDashboard}
           removeSentenceItem={setActiveItems}
           clearPanel={panelName => clearActiveItems(panelName)}
           dynamicSentenceParts={dynamicSentenceParts}
@@ -245,7 +256,8 @@ DashboardPanel.propTypes = {
   countriesPanel: PropTypes.object.isRequired,
   destinationsPanel: PropTypes.object.isRequired,
   step: PropTypes.number.isRequired,
-  isDisabled: PropTypes.bool.isRequired
+  isDisabled: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired
 };
 
 export default DashboardPanel;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -7,8 +7,8 @@ import CommoditiesPanel from 'react-components/dashboard-element/dashboard-panel
 import DashboardModalFooter from 'react-components/dashboard-element/dashboard-modal-footer/dashboard-modal-footer.component';
 import addApostrophe from 'utils/addApostrophe';
 import { DASHBOARD_STEPS } from 'constants';
-import { getPanelId as getPanelName, singularize } from 'utils/dashboardPanel';
-import Heading from 'react-components/shared/heading/heading.component';
+import { getPanelLabel, singularize } from 'utils/dashboardPanel';
+import Heading from 'react-components/shared/heading';
 import StepsTracker from 'react-components/shared/steps-tracker/steps-tracker.component';
 import { translateText } from 'utils/transifex';
 
@@ -148,22 +148,34 @@ class DashboardPanel extends Component {
       return (
         <>
           {translateText('Choose one ')}{' '}
-          <span className="dashboard-panel-sentence" data-test="dashboard-panel-sentence">
-            {translateText(singularize(getPanelName(step)))}
-          </span>
+          <Heading
+            size="lg"
+            as="span"
+            className="dashboard-panel-sentence"
+            data-test="dashboard-panel-sentence"
+          >
+            {translateText(singularize(getPanelLabel(step)))}
+          </Heading>
         </>
       );
     }
     return (
       <>
+        {[DASHBOARD_STEPS.companies, DASHBOARD_STEPS.destinations].includes(step) ? (
+          <Heading size="lg" as="span" weight="bold">{`${translateText('(Optional)')} `}</Heading>
+        ) : (
+          ''
+        )}
         {translateText('Choose one or several')}
-        <span className="dashboard-panel-sentence" data-test="dashboard-panel-sentence">
+        <Heading
+          size="lg"
+          as="span"
+          className="dashboard-panel-sentence"
+          data-test="dashboard-panel-sentence"
+        >
           {' '}
-          {translateText(getPanelName(step))}
-        </span>
-        {[DASHBOARD_STEPS.companies, DASHBOARD_STEPS.destinations].includes(step)
-          ? ` ${translateText('(Optional)')}`
-          : ''}
+          {translateText(getPanelLabel(step))}
+        </Heading>
       </>
     );
   }
@@ -205,7 +217,7 @@ class DashboardPanel extends Component {
             {...selectStepProp}
           />
           <Heading className="dashboard-panel-title notranslate" align="center" size="lg">
-            {editMode ? translateText('Edit options') : this.renderTitleSentence()}
+            {this.renderTitleSentence()}
           </Heading>
           {this.renderPanel()}
         </div>

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -208,7 +208,7 @@ class DashboardPanel extends Component {
     } = this.props;
 
     const handleGoToDashboard = () => {
-      goToDashboard();
+      goToDashboard({ dirtyBlocks, dynamicSentenceParts });
       closeModal();
     };
 

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -175,13 +175,14 @@ class DashboardPanel extends Component {
       setActiveItems,
       onContinue,
       onBack,
+      setStep,
       goToDashboard,
       dirtyBlocks,
       dynamicSentenceParts,
       step,
       isDisabled
     } = this.props;
-
+    const selectStepProp = editMode ? { onSelectStep: selectedStep => setStep(selectedStep) } : {};
     return (
       <div className="c-dashboard-panel">
         <div ref={this.containerRef} className="dashboard-panel-content">
@@ -190,7 +191,7 @@ class DashboardPanel extends Component {
               label => ({ label })
             )}
             activeStep={step - 1}
-            onSelectStep={() => {}}
+            {...selectStepProp}
           />
           <Heading className="dashboard-panel-title notranslate" align="center" size="lg">
             {editMode ? translateText('Edit options') : this.renderTitleSentence()}
@@ -231,6 +232,7 @@ DashboardPanel.propTypes = {
   dynamicSentenceParts: PropTypes.array,
   onContinue: PropTypes.func.isRequired,
   onBack: PropTypes.func,
+  setStep: PropTypes.func.isRequired,
   setActiveTab: PropTypes.func.isRequired,
   setActiveItems: PropTypes.func.isRequired,
   setActiveItem: PropTypes.func.isRequired,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -144,6 +144,17 @@ class DashboardPanel extends Component {
 
   renderTitleSentence() {
     const { step } = this.props;
+    if (step === DASHBOARD_STEPS.welcome) {
+      return (
+        <>
+          {translateText('Choose the ')}
+          <Heading size="lg" as="span" weight="bold" className="dashboard-panel-sentence">
+            {translateText('step ')}
+          </Heading>
+          {translateText('you want to edit')}
+        </>
+      );
+    }
     if (step === DASHBOARD_STEPS.sources || step === DASHBOARD_STEPS.commodities) {
       return (
         <>
@@ -206,6 +217,8 @@ class DashboardPanel extends Component {
       editMode && mandatoryFieldsSelected
         ? { onSelectStep: selectedStep => setStep(selectedStep) }
         : {};
+    // if (step === DASHBOARD_STEPS.welcome) return 'Hola';
+
     return (
       <div className="c-dashboard-panel">
         <div ref={this.containerRef} className="dashboard-panel-content">

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.component.jsx
@@ -172,10 +172,8 @@ class DashboardPanel extends Component {
     }
     return (
       <>
-        {[DASHBOARD_STEPS.companies, DASHBOARD_STEPS.destinations].includes(step) ? (
+        {[DASHBOARD_STEPS.companies, DASHBOARD_STEPS.destinations].includes(step) && (
           <Heading size="lg" as="span" weight="bold">{`${translateText('(Optional)')} `}</Heading>
-        ) : (
-          ''
         )}
         {translateText('Choose one or several')}
         <Heading
@@ -217,7 +215,6 @@ class DashboardPanel extends Component {
       editMode && mandatoryFieldsSelected
         ? { onSelectStep: selectedStep => setStep(selectedStep) }
         : {};
-    // if (step === DASHBOARD_STEPS.welcome) return 'Hola';
 
     return (
       <div className="c-dashboard-panel">

--- a/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.component.jsx
+++ b/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.component.jsx
@@ -10,16 +10,11 @@ function StepsTracker(props) {
 
   const ItemComponent = itemProps =>
     onSelectStep && !itemProps.isActive ? (
-      <a
-        role="button"
-        tabIndex={-1}
-        onClick={() => onSelectStep(itemProps.stepIndex + 1)}
-        {...itemProps}
-      >
+      <button onClick={() => onSelectStep(itemProps.stepIndex + 1)} className={itemProps.className}>
         {itemProps.children}
-      </a>
+      </button>
     ) : (
-      <div {...itemProps}>{itemProps.children}</div>
+      <div className={itemProps.className}>{itemProps.children}</div>
     );
 
   return (

--- a/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.component.jsx
+++ b/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.component.jsx
@@ -9,11 +9,11 @@ function StepsTracker(props) {
   const { steps, activeStep, onSelectStep } = props;
 
   const ItemComponent = itemProps =>
-    onSelectStep ? (
+    onSelectStep && !itemProps.isActive ? (
       <a
         role="button"
         tabIndex={-1}
-        onClick={() => onSelectStep(itemProps.step.label)}
+        onClick={() => onSelectStep(itemProps.stepIndex + 1)}
         {...itemProps}
       >
         {itemProps.children}
@@ -26,17 +26,18 @@ function StepsTracker(props) {
     <div className="c-steps-tracker">
       {steps.map((step, i) => {
         const isDone = i < activeStep;
+        const isActive = i === activeStep;
         return (
           <div
             key={step.label}
             className={cx('steps-tracker-item-wrapper', {
               '-pending': !onSelectStep && i > activeStep,
               '-done': isDone,
-              '-selectable': !isDone && onSelectStep,
-              '-active': i === activeStep
+              '-selectable': onSelectStep,
+              '-active': isActive
             })}
           >
-            <ItemComponent step={step} className="steps-tracker-item">
+            <ItemComponent stepIndex={i} isActive={isActive} className="steps-tracker-item">
               <div className="steps-tracker-label">
                 <Text as="span" variant="mono" transform="uppercase" weight="bold">
                   {step.label}

--- a/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.component.jsx
+++ b/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.component.jsx
@@ -6,38 +6,58 @@ import Text from 'react-components/shared/text';
 import 'react-components/shared/steps-tracker/steps-tracker.scss';
 
 function StepsTracker(props) {
-  const { steps, activeStep } = props;
+  const { steps, activeStep, onSelectStep } = props;
+
+  const ItemComponent = itemProps =>
+    onSelectStep ? (
+      <a
+        role="button"
+        tabIndex={-1}
+        onClick={() => onSelectStep(itemProps.step.label)}
+        {...itemProps}
+      >
+        {itemProps.children}
+      </a>
+    ) : (
+      <div {...itemProps}>{itemProps.children}</div>
+    );
+
   return (
     <div className="c-steps-tracker">
-      {steps.map((step, i) => (
-        <div
-          key={step.label}
-          className={cx('steps-tracker-item-wrapper', {
-            '-active': i === activeStep,
-            '-done': i < activeStep,
-            '-pending': i > activeStep
-          })}
-        >
-          <div className="steps-tracker-item">
-            <div className="steps-tracker-label">
-              <Text as="span" variant="mono" transform="uppercase" weight="bold">
-                {step.label}
-              </Text>
-            </div>
-            <div className="steps-tracker-circle">
-              <span className="steps-tracker-circle-dot" />
-            </div>
+      {steps.map((step, i) => {
+        const isDone = i < activeStep;
+        return (
+          <div
+            key={step.label}
+            className={cx('steps-tracker-item-wrapper', {
+              '-pending': !onSelectStep && i > activeStep,
+              '-done': isDone,
+              '-selectable': !isDone && onSelectStep,
+              '-active': i === activeStep
+            })}
+          >
+            <ItemComponent step={step} className="steps-tracker-item">
+              <div className="steps-tracker-label">
+                <Text as="span" variant="mono" transform="uppercase" weight="bold">
+                  {step.label}
+                </Text>
+              </div>
+              <div className="steps-tracker-circle">
+                <span className="steps-tracker-circle-dot" />
+              </div>
+            </ItemComponent>
+            {i < steps.length - 1 && <div className="steps-tracker-segment" />}
           </div>
-          {i < steps.length - 1 && <div className="steps-tracker-segment" />}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
 
 StepsTracker.propTypes = {
   steps: PropTypes.array.isRequired,
-  activeStep: PropTypes.number.isRequired
+  activeStep: PropTypes.number.isRequired,
+  onSelectStep: PropTypes.func
 };
 
 export default StepsTracker;

--- a/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.scss
+++ b/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.scss
@@ -26,8 +26,17 @@ $circle-dot-size: $circle-size / 2;
         border: 2px solid $charcoal-grey;
       }
 
-      .steps-tracker-segment {
-        opacity: 0.4;
+      &:not(.-selectable) {
+        .steps-tracker-segment {
+          opacity: 0.4;
+        }
+      }
+
+      .steps-tracker-circle {
+        &::before,
+        &::after {
+          display: none;
+        }
       }
     }
 
@@ -66,13 +75,38 @@ $circle-dot-size: $circle-size / 2;
       }
     }
 
+    &.-selectable {
+      .steps-tracker-circle {
+        &::before,
+        &::after {
+          height: 2px;
+        }
+      }
+
+      &:last-child {
+        .steps-tracker-circle::after {
+          display: none;
+        }
+      }
+    }
+
   }
 
   .steps-tracker-item {
     position: relative;
+    display: block;
     width: $circle-size;
     padding: $label-height 0 0;
     height: $item-height;
+    outline: none;
+    cursor: pointer;
+
+    &:hover {
+      .steps-tracker-circle-dot {
+        height: $circle-dot-size + 4px;
+        width: $circle-dot-size + 4px;
+      }
+    }
   }
 
   .steps-tracker-label  {

--- a/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.scss
+++ b/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.scss
@@ -76,10 +76,12 @@ $circle-dot-size: $circle-size / 2;
     }
 
     &.-selectable {
-      .steps-tracker-circle {
-        &::before,
-        &::after {
-          height: 2px;
+      &:not(.-done) {
+        .steps-tracker-circle {
+          &::before,
+          &::after {
+            height: 2px;
+          }
         }
       }
 
@@ -90,32 +92,42 @@ $circle-dot-size: $circle-size / 2;
       }
     }
 
-  }
+    .steps-tracker-item {
+      position: relative;
+      display: block;
+      width: $circle-size;
+      padding: $label-height 0 0;
+      height: $item-height;
+    }
 
-  .steps-tracker-item {
-    position: relative;
-    display: block;
-    width: $circle-size;
-    padding: $label-height 0 0;
-    height: $item-height;
-    outline: none;
-    cursor: pointer;
+    .steps-tracker-label  {
+      position: absolute;
+      left: 50%;
+      top: 0;
+      transform: translateX(-50%);
+      height: $label-height;
+      white-space: nowrap;
+    }
 
-    &:hover {
-      .steps-tracker-circle-dot {
-        height: $circle-dot-size + 4px;
-        width: $circle-dot-size + 4px;
+    &.-selectable:not(.-active) {
+      .steps-tracker-item {
+        cursor: pointer;
+        outline: none;
+
+        &:hover {
+          .steps-tracker-circle-dot {
+            height: $circle-dot-size + 4px;
+            width: $circle-dot-size + 4px;
+          }
+
+          .steps-tracker-label  {
+            > span {
+              font-size: $font-size-x-regular + 1px;
+            }
+          }
+        }
       }
     }
-  }
-
-  .steps-tracker-label  {
-    position: absolute;
-    left: 50%;
-    top: 0;
-    transform: translateX(-50%);
-    height: $label-height;
-    white-space: nowrap;
   }
 
   .steps-tracker-circle {

--- a/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.scss
+++ b/frontend/scripts/react-components/shared/steps-tracker/steps-tracker.scss
@@ -85,6 +85,12 @@ $circle-dot-size: $circle-size / 2;
         }
       }
 
+      &:first-child {
+        .steps-tracker-circle::before {
+          display: none;
+        }
+      }
+
       &:last-child {
         .steps-tracker-circle::after {
           display: none;

--- a/frontend/scripts/react-components/shared/tags-group/tags-group.scss
+++ b/frontend/scripts/react-components/shared/tags-group/tags-group.scss
@@ -8,7 +8,7 @@
   .tags-group-item {
     display: inline-flex;
     position: relative;
-    height: 30px;
+    min-height: 30px;
     padding: 0 6px 0 0;
 
     &.-with-cross {

--- a/frontend/scripts/tests/puppeteer/dashboards.test.e2e.js
+++ b/frontend/scripts/tests/puppeteer/dashboards.test.e2e.js
@@ -86,7 +86,7 @@ describe('Dashboards flow', () => {
       dashboardPanelSentenceSelector,
       el => el.textContent
     );
-    expect(destinationsSectionTitle).toMatch('destinations');
+    expect(destinationsSectionTitle).toMatch('import countries');
     const destinationsButtonsSelector = '[data-test=grid-list-item-button]';
     await page.waitForSelector(destinationsButtonsSelector);
     const destinationsButtons = await page.$$(destinationsButtonsSelector);

--- a/frontend/scripts/utils/dashboardPanel.js
+++ b/frontend/scripts/utils/dashboardPanel.js
@@ -4,6 +4,9 @@ import { DASHBOARD_STEPS } from 'constants';
 const PANEL_IDS = invert(DASHBOARD_STEPS);
 export const getPanelId = step => PANEL_IDS[step];
 
+export const getPanelLabel = step =>
+  step === DASHBOARD_STEPS.destinations ? 'import countries' : PANEL_IDS[step];
+
 export const singularize = panelName => {
   const irregularInflections = {
     commodities: 'commodity'


### PR DESCRIPTION
This PR adds the buttons to pick a step on the dashboard editing process:

- Fix header and footer text
- Show buttons instead of simple dots in the dashboard edit
- Change button to go to the dashboard in edit mode

Note: The edit mode always shows the 'Go to dashboard' button until we remove one of the mandatory options. Then we need the linear flow again.

![image](https://user-images.githubusercontent.com/9701591/61866383-59d66280-aed5-11e9-9aa1-042455a5c4cc.png)

Extra: Fix a problem with dashboard sentence widget:
  - Try: soy produced in Brazilexported by 3S COMERCIAL IMPORTADORA E EXPORTADORA- 

Before: 

![image](https://user-images.githubusercontent.com/9701591/61866825-36f87e00-aed6-11e9-8947-05c4fda0e0ac.png)

After: 
![image](https://user-images.githubusercontent.com/9701591/61866923-60b1a500-aed6-11e9-8390-3253b6636372.png)

