### PR TITLE
Fix/improve geo columns loading

### DIFF
--- a/frontend/scripts/react-components/tool-links/tool-links.actions.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.actions.js
@@ -4,7 +4,6 @@ export const TOOL_LINKS__SET_FLOWS_LOADING = 'TOOL_LINKS__SET_FLOWS_LOADING';
 export const TOOL_LINKS__GET_COLUMNS = 'TOOL_LINKS__GET_COLUMNS';
 export const TOOL_LINKS__SET_COLUMNS = 'TOOL_LINKS__SET_COLUMNS';
 export const TOOL_LINKS__SET_NODES = 'TOOL_LINKS__SET_NODES';
-export const TOOL_LINKS__SET_MORE_NODES = 'TOOL_LINKS__SET_MORE_NODES';
 export const TOOL_LINKS__SET_LINKS = 'TOOL_LINKS__SET_LINKS';
 export const TOOL_LINKS__SELECT_VIEW = 'TOOL_LINKS__SELECT_VIEW';
 export const TOOL_LINKS__SET_IS_SEARCH_OPEN = 'TOOL_LINKS__SET_IS_SEARCH_OPEN';
@@ -44,13 +43,6 @@ export function setToolColumns(columns) {
 export function setToolNodes(nodes) {
   return {
     type: TOOL_LINKS__SET_NODES,
-    payload: { nodes }
-  };
-}
-
-export function setMoreToolNodes(nodes) {
-  return {
-    type: TOOL_LINKS__SET_MORE_NODES,
     payload: { nodes }
   };
 }

--- a/frontend/scripts/react-components/tool-links/tool-links.actions.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.actions.js
@@ -40,10 +40,10 @@ export function setToolColumns(columns) {
   };
 }
 
-export function setToolNodes(nodes) {
+export function setToolNodes(nodes, replaceData = false) {
   return {
     type: TOOL_LINKS__SET_NODES,
-    payload: { nodes }
+    payload: { nodes, replaceData }
   };
 }
 

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -177,7 +177,11 @@ export function* getMoreToolNodesByLink(selectedContext, fetchAllNodes) {
 }
 
 export function* getToolGeoColumnNodes(selectedContext) {
-  const geoColumnId = selectedContext.defaultColumns[0].id;
+  const selectedColumnsIds = yield select(getSelectedColumnsIds);
+
+  // TODO: this is not the best way to read the geoColumn,
+  //  the backend should provide it within contexts.defaultColumns
+  const geoColumnId = selectedColumnsIds[0];
   const params = { context_id: selectedContext.id, node_types_ids: geoColumnId };
   const url = getURLFromParams(GET_ALL_NODES_URL, params);
   const { source, fetchPromise } = fetchWithCancel(url);

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -177,11 +177,7 @@ export function* getMoreToolNodesByLink(selectedContext, fetchAllNodes) {
 }
 
 export function* getToolGeoColumnNodes(selectedContext) {
-  const selectedColumnsIds = yield select(getSelectedColumnsIds);
-
-  // TODO: this is not the best way to read the geoColumn,
-  //  the backend should provide it within contexts.defaultColumns
-  const geoColumnId = selectedColumnsIds[0];
+  const geoColumnId = selectedContext.defaultColumns[0].id;
   const params = { context_id: selectedContext.id, node_types_ids: geoColumnId };
   const url = getURLFromParams(GET_ALL_NODES_URL, params);
   const { source, fetchPromise } = fetchWithCancel(url);

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -115,7 +115,7 @@ export function* getToolNodesByLink(selectedContext, { fetchAllNodes, replaceDat
       data: { links, nodes }
     } = yield select(state => state.toolLinks);
     const nodesInLinkPaths = Object.values(links).flatMap(link => link.path);
-    const existingNodes = new Set(Object.keys(nodes));
+    const existingNodes = new Set(Object.keys(nodes || {}));
     const difference = new Set(nodesInLinkPaths.filter(x => !existingNodes.has(`${x}`)));
 
     if (difference.size === 0) {

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -18,7 +18,6 @@ import {
   setToolColumns,
   setToolLinks,
   setToolNodes,
-  setMoreToolNodes,
   setNoLinksFound,
   setMissingLockedNodes
 } from './tool-links.actions';
@@ -108,33 +107,10 @@ export function* getToolColumnsData(selectedContext) {
   }
 }
 
-export function* getToolNodesByLink(selectedContext) {
-  const {
-    data: { links }
-  } = yield select(state => state.toolLinks);
-
-  const nodesIds = Array.from(new Set(Object.values(links).flatMap(link => link.path))).join(',');
-  const params = { context_id: selectedContext.id, nodes_ids: nodesIds };
-  const url = getURLFromParams(GET_ALL_NODES_URL, params);
-  const { source, fetchPromise } = fetchWithCancel(url);
-  try {
-    const { data } = yield call(fetchPromise);
-    yield put(setToolNodes(data.data));
-  } catch (e) {
-    console.error('Error', e);
-  } finally {
-    if (yield cancelled()) {
-      if (NODE_ENV_DEV) console.error('Cancelled');
-      if (source) {
-        source.cancel();
-      }
-    }
-  }
-}
-
-export function* getMoreToolNodesByLink(selectedContext, fetchAllNodes) {
+export function* getToolNodesByLink(selectedContext, fetchAllNodes) {
   let nodesIds;
   let nodeTypesIds;
+
   if (!fetchAllNodes) {
     const {
       data: { links, nodes }
@@ -163,7 +139,7 @@ export function* getMoreToolNodesByLink(selectedContext, fetchAllNodes) {
   const { source, fetchPromise } = fetchWithCancel(url);
   try {
     const { data } = yield call(fetchPromise);
-    yield put(setMoreToolNodes(data.data));
+    yield put(setToolNodes(data.data));
   } catch (e) {
     console.error('Error', e);
   } finally {
@@ -187,7 +163,7 @@ export function* getToolGeoColumnNodes(selectedContext) {
   const { source, fetchPromise } = fetchWithCancel(url);
   try {
     const { data } = yield call(fetchPromise);
-    yield put(setMoreToolNodes(data.data));
+    yield put(setToolNodes(data.data));
   } catch (e) {
     console.error('Error', e);
   } finally {

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -107,10 +107,9 @@ export function* getToolColumnsData(selectedContext) {
   }
 }
 
-export function* getToolNodesByLink(selectedContext, fetchAllNodes) {
+export function* getToolNodesByLink(selectedContext, { fetchAllNodes, replaceData }) {
   let nodesIds;
   let nodeTypesIds;
-
   if (!fetchAllNodes) {
     const {
       data: { links, nodes }
@@ -139,7 +138,7 @@ export function* getToolNodesByLink(selectedContext, fetchAllNodes) {
   const { source, fetchPromise } = fetchWithCancel(url);
   try {
     const { data } = yield call(fetchPromise);
-    yield put(setToolNodes(data.data));
+    yield put(setToolNodes(data.data, replaceData));
   } catch (e) {
     console.error('Error', e);
   } finally {

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -34,13 +34,13 @@ import * as ToolLinksUrlPropHandlers from 'react-components/tool-links/tool-link
 import toolLinksInitialState from './tool-links.initial-state';
 
 function setNodes(state, action) {
-  const { nodes } = action.payload;
+  const { nodes, replaceData } = action.payload;
   return immer(state, draft => {
     nodes.forEach(node => {
-      if (!draft.data.nodes) {
+      if (!draft.data.nodes || replaceData) {
         draft.data.nodes = {};
       }
-      if (!draft.data.nodesByColumnGeoId) {
+      if (!draft.data.nodesByColumnGeoId || replaceData) {
         draft.data.nodesByColumnGeoId = {};
       }
       if (!draft.data.nodes[node.id]) {

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -8,7 +8,6 @@ import {
   TOOL_LINKS__CLEAR_SANKEY,
   TOOL_LINKS__HIGHLIGHT_NODE,
   TOOL_LINKS__SET_NODES,
-  TOOL_LINKS__SET_MORE_NODES,
   TOOL_LINKS__SET_FLOWS_LOADING,
   TOOL_LINKS__SET_COLUMNS,
   TOOL_LINKS__SET_LINKS,
@@ -34,7 +33,7 @@ import { deserialize } from 'react-components/shared/url-serializer/url-serializ
 import * as ToolLinksUrlPropHandlers from 'react-components/tool-links/tool-links.serializers';
 import toolLinksInitialState from './tool-links.initial-state';
 
-function setMoreNodes(state, action) {
+function setNodes(state, action) {
   const { nodes } = action.payload;
   return immer(state, draft => {
     nodes.forEach(node => {
@@ -142,22 +141,9 @@ const toolLinksReducer = {
       // TODO: if any selectedNode, make those columns visible (selected)
     });
   },
+  [TOOL_LINKS__SET_NODES]: setNodes,
 
-  [TOOL_LINKS__SET_NODES](state, action) {
-    const { nodes } = action.payload;
-    return immer(state, draft => {
-      draft.data.nodes = {};
-      draft.data.nodesByColumnGeoId = {};
-      nodes.forEach(node => {
-        draft.data.nodes[node.id] = node;
-        draft.data.nodesByColumnGeoId[`${node.columnId}-${node.geoId}`] = node.id;
-      });
-    });
-  },
-
-  [TOOL_LINKS__SET_MORE_NODES]: setMoreNodes,
-
-  [TOOL_LINKS__SET_MISSING_LOCKED_NODES]: setMoreNodes,
+  [TOOL_LINKS__SET_MISSING_LOCKED_NODES]: setNodes,
 
   [TOOL_LINKS__SET_LINKS](state, action) {
     return immer(state, draft => {

--- a/frontend/scripts/react-components/tool-links/tool-links.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.saga.js
@@ -12,7 +12,6 @@ import {
   TOOL_LINKS__COLLAPSE_SANKEY,
   TOOL_LINKS__CLEAR_SANKEY,
   TOOL_LINKS__SET_NODES,
-  TOOL_LINKS__SET_MORE_NODES,
   TOOL_LINKS__SET_SELECTED_RESIZE_BY,
   TOOL_LINKS__SET_SELECTED_RECOLOR_BY,
   TOOL_LINKS__SET_SELECTED_BIOME_FILTER,
@@ -25,8 +24,7 @@ import {
   getToolLinksData,
   getToolNodesByLink,
   getMissingLockedNodes,
-  getToolGeoColumnNodes,
-  getMoreToolNodesByLink
+  getToolGeoColumnNodes
 } from './tool-links.fetch.saga';
 
 function* fetchToolColumns() {
@@ -94,7 +92,7 @@ function* fetchLinks() {
     const fetchAllNodes = action.type === TOOL_LINKS__SELECT_VIEW && action.payload.detailedView;
     const task = yield fork(setLoadingSpinner, 2000, setToolFlowsLoading(true));
     yield call(getToolLinksData);
-    yield call(getMoreToolNodesByLink, selectedContext, fetchAllNodes);
+    yield call(getToolNodesByLink, selectedContext, fetchAllNodes);
     if (task.isRunning()) {
       yield cancel(task);
     } else {
@@ -161,7 +159,7 @@ function* fetchMissingLockedNodes() {
     }
   }
 
-  yield takeLatest([TOOL_LINKS__SET_NODES, TOOL_LINKS__SET_MORE_NODES], performFetch);
+  yield takeLatest([TOOL_LINKS__SET_NODES], performFetch);
 }
 
 export default function* toolLinksSaga() {

--- a/frontend/scripts/react-components/tool-links/tool-links.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.saga.js
@@ -43,9 +43,9 @@ function* fetchToolColumns() {
 
     const task = yield fork(setLoadingSpinner, 750, setToolFlowsLoading(true));
     yield fork(getToolColumnsData, selectedContext);
+    yield fork(getToolGeoColumnNodes, selectedContext);
     yield call(getToolLinksData);
     yield call(getToolNodesByLink, selectedContext);
-    yield call(getToolGeoColumnNodes, selectedContext);
 
     // TODO: remove this call, just here to split the refactor in stages
     yield put(loadMapVectorData());

--- a/frontend/scripts/react-components/tool-links/tool-links.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.saga.js
@@ -28,7 +28,7 @@ import {
 } from './tool-links.fetch.saga';
 
 function* fetchToolColumns() {
-  function* performFetch() {
+  function* performFetch(action) {
     const state = yield select();
     const {
       location: { type: page }
@@ -38,12 +38,12 @@ function* fetchToolColumns() {
     if (page !== 'tool' || selectedContext === null) {
       return;
     }
-
+    const replaceData = [SET_CONTEXT, SET_CONTEXTS].includes(action.type);
     const task = yield fork(setLoadingSpinner, 750, setToolFlowsLoading(true));
     yield fork(getToolColumnsData, selectedContext);
     yield fork(getToolGeoColumnNodes, selectedContext);
     yield call(getToolLinksData);
-    yield call(getToolNodesByLink, selectedContext);
+    yield call(getToolNodesByLink, selectedContext, { replaceData });
 
     // TODO: remove this call, just here to split the refactor in stages
     yield put(loadMapVectorData());
@@ -92,7 +92,7 @@ function* fetchLinks() {
     const fetchAllNodes = action.type === TOOL_LINKS__SELECT_VIEW && action.payload.detailedView;
     const task = yield fork(setLoadingSpinner, 2000, setToolFlowsLoading(true));
     yield call(getToolLinksData);
-    yield call(getToolNodesByLink, selectedContext, fetchAllNodes);
+    yield call(getToolNodesByLink, selectedContext, { fetchAllNodes });
     if (task.isRunning()) {
       yield cancel(task);
     } else {

--- a/frontend/scripts/react-components/tool-links/tool-links.selectors.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.selectors.js
@@ -10,6 +10,7 @@ import sortVisibleNodes from 'reducers/helpers/sortVisibleNodes';
 import getVisibleNodesUtil from 'reducers/helpers/getVisibleNodes';
 import { getSelectedColumnsIds, getSelectedNodesData } from 'react-components/tool/tool.selectors';
 import { getSelectedContext } from 'reducers/app.selectors';
+import { NUM_COLUMNS } from 'constants';
 
 const getToolLinks = state => state.toolLinks.data.links;
 const getToolNodes = state => state.toolLinks.data.nodes;
@@ -72,7 +73,9 @@ export const getVisibleNodes = createSelector(
     if (!links || !nodes || !selectedColumnsIds) {
       return null;
     }
-    return getVisibleNodesUtil(links, nodes, selectedColumnsIds);
+    const visibleNodes = getVisibleNodesUtil(links, nodes, selectedColumnsIds);
+    const visibleColumns = new Set(visibleNodes.map(node => node.columnId));
+    return visibleColumns.size === NUM_COLUMNS ? visibleNodes : null;
   }
 );
 

--- a/frontend/scripts/react-components/tool-links/tool-links.selectors.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.selectors.js
@@ -54,20 +54,15 @@ export const getSelectedRecolorBy = createSelector(
 );
 
 export const getSelectedBiomeFilter = createSelector(
-  [getToolBiomeFilterName, getSelectedContext, getToolNodes],
-  (selectedBiomeFilterName, selectedContext, nodes) => {
+  [getToolBiomeFilterName, getSelectedContext],
+  (selectedBiomeFilterName, selectedContext) => {
     if (!selectedBiomeFilterName || !selectedContext || selectedContext.filterBy.length === 0) {
       return null;
     }
 
-    const biomeFilter = selectedContext.filterBy[0].nodes.find(
+    return selectedContext.filterBy[0].nodes.find(
       filterBy => filterBy.name === selectedBiomeFilterName
     );
-
-    // TODO add the geoId from the backend
-    const biomeFilterNode = biomeFilter && nodes && nodes[biomeFilter.nodeId];
-
-    return { ...biomeFilter, geoId: biomeFilterNode && biomeFilterNode.geoId };
   }
 );
 

--- a/frontend/scripts/react-components/tool/map/map.component.js
+++ b/frontend/scripts/react-components/tool/map/map.component.js
@@ -323,6 +323,7 @@ export default class MapComponent {
   }
 
   _createCartoLayer(layerData /* , i */) {
+    // TODO: layerData doesn't always have layergroupid so the fetch fails
     const baseUrl = `${CARTO_BASE_URL}${layerData.layergroupid}/{z}/{x}/{y}`;
     const layerUrl = `${baseUrl}.png`;
     // eslint-disable-next-line new-cap


### PR DESCRIPTION
This PR improves geo columns loading using 'fork' instead of 'cal'l for parallel loading. 

Also:
- Removes some unnecessary geoId logic as we have it now in the contexts.
- Don't render until we have the nodes for the four columns
- Merges getToolNodes with getMoreToolNodes: The logic in getMoreToolNodes was already taking into account the first case and we needed some checking for duplicates in the first case
 