### PR TITLE
Add comparison title to charts with compared nodes

### DIFF
--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -287,3 +287,12 @@ export const PROFILE_TYPES = {
 };
 
 export const DEFAULT_DASHBOARD_UNIT_FORMAT = '.4~s';
+
+export const NODE_TYPE_PANELS = {
+  IMPORTER: 'companies',
+  EXPORTER: 'companies',
+  BIOME: 'sources',
+  STATE: 'sources',
+  MUNICIPALITY: 'sources',
+  COUNTRY: 'destinations'
+};


### PR DESCRIPTION
This PR adds a different title to the widgets that are filtered by nodes and don't show anymore the top N nodes:

This works in:  IMPORTER,  EXPORTER, BIOME,  STATE, MUNICIPALITY, and COUNTRY.

Maybe the top N chart will still be relevant so we might want to add it in other iteration.

Try:

1. Go to dashboard.
2. Select Cofco and Bunge as exporters.
3. Go to top 10 exporters chart.
4. It's only showing 2 exporters.

![image](https://user-images.githubusercontent.com/9701591/62083635-b62fde00-b257-11e9-921e-787d6e802e33.png)
