### PR TITLE
Feature/context node type properties prefix

### DIFF
--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -27,8 +27,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
       input :is_choropleth_disabled, as: :boolean, required: true,
                                      hint: object.class.column_comment('is_choropleth_disabled')
       input :role, as: :select, collection: Api::V3::ContextNodeTypeProperty.roles, required: false
-      input :prefix, required: true, as: :string,
-                     hint: object.class.column_comment('prefix')
+      input :prefix, as: :string, hint: object.class.column_comment('prefix')
     end
     f.actions
   end

--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -2,7 +2,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
   menu parent: 'General', priority: 3
 
   permit_params :context_node_type_id, :column_group, :is_default,
-                :is_geo_column, :is_choropleth_disabled, :role
+                :is_geo_column, :is_choropleth_disabled, :role, :prefix
 
   after_action :clear_cache, only: [:create, :update, :destroy]
 
@@ -27,6 +27,8 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
       input :is_choropleth_disabled, as: :boolean, required: true,
                                      hint: object.class.column_comment('is_choropleth_disabled')
       input :role, as: :select, collection: Api::V3::ContextNodeTypeProperty.roles, required: false
+      input :prefix, required: true, as: :string,
+                     hint: object.class.column_comment('prefix')
     end
     f.actions
   end
@@ -40,6 +42,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
     column :is_geo_column
     column :is_choropleth_disabled
     column :role
+    column :prefix
     actions
   end
 
@@ -54,6 +57,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
       row :is_geo_column
       row :is_choropleth_disabled
       row :role
+      row :prefix
       row :created_at
       row :updated_at
     end

--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -9,6 +9,7 @@
 #  is_geo_column(When set, show nodes on map)                                              :boolean          default(FALSE), not null
 #  is_choropleth_disabled(When set, do not display the map choropleth)                     :boolean          default(FALSE), not null
 #  role                                                                                    :string
+#  prefix                                                                                  :text
 #
 # Indexes
 #
@@ -42,6 +43,7 @@ module Api
 
       belongs_to :context_node_type
 
+      validates :prefix, presence: true
       validates :context_node_type, presence: true, uniqueness: true
       validates :column_group, presence: true, inclusion: COLUMN_GROUP
       validates :is_default, inclusion: {in: [true, false]}

--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -43,7 +43,9 @@ module Api
 
       belongs_to :context_node_type
 
-      validates :prefix, presence: true
+      validates :prefix,
+                presence: true,
+                if: proc { |record| record.role.present? }
       validates :context_node_type, presence: true, uniqueness: true
       validates :column_group, presence: true, inclusion: COLUMN_GROUP
       validates :is_default, inclusion: {in: [true, false]}

--- a/app/services/api/v3/dashboards/filter_meta.rb
+++ b/app/services/api/v3/dashboards/filter_meta.rb
@@ -42,7 +42,8 @@ module Api
                 {
                   id: tab.node_type_id,
                   name: tab.node_type_name,
-                  profileType: tab.profile_type
+                  profileType: tab.profile_type,
+                  prefix: tab.property_prefix
                 }
               end
               section
@@ -59,11 +60,13 @@ module Api
             select(
               'node_types.name AS node_type_name',
               'node_types.id AS node_type_id',
-              'profiles.name AS profile_type'
+              'profiles.name AS profile_type',
+              'context_node_type_properties.prefix AS property_prefix'
             ).group(
               'node_types.name',
               'node_types.id',
-              'profiles.name'
+              'profiles.name',
+              'context_node_type_properties.prefix'
             )
 
           if @countries_ids.any?

--- a/db/migrate/20190807095141_add_prefix_to_context_node_type_properties.rb
+++ b/db/migrate/20190807095141_add_prefix_to_context_node_type_properties.rb
@@ -1,0 +1,5 @@
+class AddPrefixToContextNodeTypeProperties < ActiveRecord::Migration[5.2]
+  def change
+    add_column :context_node_type_properties, :prefix, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,7 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
@@ -1796,6 +1797,7 @@ CREATE TABLE public.context_node_type_properties (
     updated_at timestamp without time zone NOT NULL,
     is_choropleth_disabled boolean DEFAULT false NOT NULL,
     role character varying,
+    prefix text,
     CONSTRAINT context_node_type_properties_role_check CHECK (((role)::text = ANY (ARRAY[('source'::character varying)::text, ('exporter'::character varying)::text, ('importer'::character varying)::text, ('destination'::character varying)::text])))
 );
 
@@ -3819,9 +3821,9 @@ CREATE VIEW public.download_flows_v AS
         UNION ALL
          SELECT f_1.flow_id,
             f_1.quant_id,
-            'Quant'::text,
+            'Quant'::text AS text,
             f_1.value,
-            NULL::text,
+            NULL::text AS text,
             q.name,
             q.unit
            FROM (public.flow_quants f_1
@@ -8976,6 +8978,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190712115644'),
 ('20190716085538'),
 ('20190722152438'),
-('20190801121907');
+('20190801121907'),
+('20190807095141');
 
 

--- a/doc/swagger.yaml
+++ b/doc/swagger.yaml
@@ -961,6 +961,9 @@ paths:
                               profileType:
                                 type: string
                                 example: 'place'
+                              prefix:
+                                type: string
+                                example: 'imported from'
   /dashboards/parametrised_charts:
     get:
       tags:

--- a/lib/tasks/context_node_type_properties_prefixes.rake
+++ b/lib/tasks/context_node_type_properties_prefixes.rake
@@ -1,0 +1,21 @@
+namespace :context_node_type_properties do
+  desc 'Add default prefixed to existing context node type properties'
+  task add_prefixes: :environment do
+    [
+      {keys: %w[MUNICIPALITY DEPARTMENT STATE BIOME], prefix: 'produced in'},
+      {keys: %w[EXPORTER EXPORTER\ GROUP], prefix: 'exported by'},
+      {keys: %w[IMPORTER IMPORTER\ GROUP], prefix: 'imported by'},
+      {keys: %w[DISTRICT\ OF\ EXPORT PORT\ OF\ EXPORT PORT], prefix: 'exported from'},
+      {keys: %w[PORT\ OF\ IMPORT], prefix: 'imported from'}
+    ].each do |prefix|
+      ActiveRecord::Base.connection.exec_query("
+        UPDATE context_node_type_properties
+        SET prefix = '#{prefix[:prefix]}'
+        FROM context_node_types
+        INNER JOIN node_types ON node_types.id = context_node_types.node_type_id
+        WHERE context_node_types.id = context_node_type_properties.context_node_type_id AND
+              node_types.name IN(#{prefix[:keys].map { |key| "'#{key}'" }.join(', ')})
+      ")
+    end
+  end
+end

--- a/spec/factories/api/v3/api_v3_context_node_type_properties.rb
+++ b/spec/factories/api/v3/api_v3_context_node_type_properties.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     is_default { false }
     is_geo_column { true }
     is_choropleth_disabled { false }
-    prefix { |n| "prefix#{n}" }
+    sequence(:prefix) { |n| "prefix#{n}" }
   end
 end

--- a/spec/factories/api/v3/api_v3_context_node_type_properties.rb
+++ b/spec/factories/api/v3/api_v3_context_node_type_properties.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     is_default { false }
     is_geo_column { true }
     is_choropleth_disabled { false }
+    prefix { |n| "prefix#{n}" }
   end
 end

--- a/spec/models/api/v3/context_node_type_property_spec.rb
+++ b/spec/models/api/v3/context_node_type_property_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Api::V3::ContextNodeTypeProperty, type: :model do
     }
     let(:property_without_prefix) {
       FactoryBot.build(
-        :api_v3_context_node_type_property, prefix: nil
+        :api_v3_context_node_type_property, role: :exporter, prefix: nil
       )
     }
     it 'fails when context node type missing' do

--- a/spec/models/api/v3/context_node_type_property_spec.rb
+++ b/spec/models/api/v3/context_node_type_property_spec.rb
@@ -15,12 +15,21 @@ RSpec.describe Api::V3::ContextNodeTypeProperty, type: :model do
         context_node_type: api_v3_biome_context_node
       )
     }
+    let(:property_without_prefix) {
+      FactoryBot.build(
+        :api_v3_context_node_type_property, prefix: nil
+      )
+    }
     it 'fails when context node type missing' do
       expect(property_without_context_node_type).to have(2).
         errors_on(:context_node_type)
     end
     it 'fails when context node type taken' do
       expect(duplicate).to have(1).errors_on(:context_node_type)
+    end
+    it 'fails when prefix missing' do
+      expect(property_without_prefix).to have(1).
+        errors_on(:prefix)
     end
   end
 end

--- a/spec/services/api/v3/dashboards/filter_metas_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_metas_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::FilterMeta do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil soy goias flows'
+
+  describe 'call' do
+    let(:country) { Api::V3::Country.find_by(name: 'BRAZIL') }
+    let(:commodity) { Api::V3::Commodity.find_by(name: 'SOY') }
+    let(:filter) do
+      Api::V3::Dashboards::FilterMeta.new(
+        country_ids: [country.id],
+        commodity_ids: [commodity.id]
+      )
+    end
+    let(:meta) { filter.call[:data] }
+
+    it 'return sources, companies and destinations tabs' do
+      expect(meta).to include(a_hash_including(section: 'SOURCES'))
+      expect(meta).to include(a_hash_including(section: 'COMPANIES'))
+      expect(meta).to include(a_hash_including(section: 'DESTINATIONS'))
+    end
+
+    it 'return prefix on all tabs' do
+      %w[SOURCES COMPANIES DESTINATIONS].each do |type|
+        meta_type = meta.select { |m| m[:section] = type }.first
+        meta_type[:tabs].each { |tab| expect(tab).to include(:prefix) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add prefix field to context node type properties to set the linked text between nodes. There is a task which permits to set the default prefixes for the properties depending of the node type name:
```
RAILS_ENV={{env}} bundle exec rake context_node_type_properties:add_prefixes
```