### PR TITLE
Allow filtering by nodes with same role and different node type in dashboards filter

### DIFF
--- a/app/services/api/v3/dashboards/base_filter.rb
+++ b/app/services/api/v3/dashboards/base_filter.rb
@@ -36,12 +36,26 @@ module Api
         end
 
         def apply_filters
+          adjust_node_filters
           filter_by_countries
           filter_by_commodities
           filter_by_nodes
           filter_by_node_types
           filter_by_profile_only
           filter_by_self
+        end
+
+        def adjust_node_filters
+          return unless @self_ids.any? && @node_types_ids.any?
+
+          # nodes that don't match selected node type
+          self_nodes_to_filter_by = Api::V3::Node.where(id: @self_ids).
+            reject do |node|
+              @node_types_ids.include? node.node_type_id
+            end
+          self_ids_to_filter_by = self_nodes_to_filter_by.map(&:id)
+          @self_ids -= self_ids_to_filter_by
+          @node_ids += self_ids_to_filter_by
         end
 
         def filter_by_countries

--- a/spec/services/api/v3/dashboards/filter_sources_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_sources_spec.rb
@@ -5,11 +5,39 @@ RSpec.describe Api::V3::Dashboards::FilterSources do
   include_context 'api v3 brazil soy goias flows'
   include_context 'api v3 paraguay flows'
 
-  describe :call_with_query_term do
-    before(:each) do
-      Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true)
-      Api::V3::Readonly::Dashboards::Source.refresh(sync: true)
+  before(:each) do
+    Api::V3::Readonly::Dashboards::FlowPath.refresh(sync: true)
+    Api::V3::Readonly::Dashboards::Source.refresh(sync: true)
+  end
+
+  describe :call do
+    context 'when self ids match selected node type' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterSources.new(
+          node_types_ids: [api_v3_biome_node_type.id],
+          sources_ids: [api_v3_biome_node.id]
+        )
+      }
+      it 'filters by self id' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_biome_node.name)
+      end
     end
+    context "when self ids don't match selected node type" do
+      let(:filter) {
+        Api::V3::Dashboards::FilterSources.new(
+          node_types_ids: [api_v3_municipality_node_type.id],
+          sources_ids: [api_v3_biome_node.id]
+        )
+      }
+      it 'filters by node id' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_municipality_abadia_de_goias.name)
+      end
+    end
+  end
+
+  describe :call_with_query_term do
     let(:filter) { Api::V3::Dashboards::FilterSources.new({}) }
 
     it 'exact match is on top' do


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167809756

The problem: you want to be able to filter nodes in the dashboards filtering panel by nodes selected on a different tab of the same panel, e.g. you select a biome on first tab and then go to municipalities tab. The reason this wasn't working before is because the node ids belonging to the category of the panel are treated differently than those passed as filters from different panels, which, when combined with the node type filter, produced an empty result. For example:
/sources?node_type_id=[id of municipality]&sources_ids=[id of a biome] - this would look for nodes with node type matching municipality and id matching the specified biome

The solution:  If the parameters include both node ids from same role, e.g. sources_ids sent to sources endpoint, and also a list of node type ids were passed, any sources_ids that don't match the node type ids are used as "neighbour filters" rather than "identity filters", so in the example above it would now return nodes with node type id matching municipality which are on same flow paths as the specified biome