### PR TITLE
Removed instruction to refresh download_flows

### DIFF
--- a/app/models/api/v3/download_attribute.rb
+++ b/app/models/api/v3/download_attribute.rb
@@ -52,7 +52,6 @@ module Api
 
       def refresh_dependents
         Api::V3::Readonly::DownloadAttribute.refresh
-        Api::V3::Readonly::DownloadFlow.refresh(skip_dependencies: true)
       end
 
       def set_years


### PR DESCRIPTION
 download_flows should only be refreshed once during data import, and not from CMS callbacks; this was a leftover from a previous solution