### PR TITLE
Instruct pg_dump to ignore table partitions

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module TraseNewApi
     }
 
     config.active_record.schema_format = :sql
+    # do not dump partitions
+    ActiveRecord::SchemaDumper.ignore_tables = ['download_flows_*']
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do


### PR DESCRIPTION
Instructs pg_dump to omit download_flows partitions in structure.sql.