### PR TITLE
fix sankey geocolumn not loading

### DIFF
--- a/frontend/scripts/react-components/tool-links/tool-links.actions.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.actions.js
@@ -41,10 +41,10 @@ export function setToolColumns(columns) {
   };
 }
 
-export function setToolNodes(nodes, replaceData = false) {
+export function setToolNodes(nodes) {
   return {
     type: TOOL_LINKS__SET_NODES,
-    payload: { nodes, replaceData }
+    payload: { nodes }
   };
 }
 

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -107,7 +107,7 @@ export function* getToolColumnsData(selectedContext) {
   }
 }
 
-export function* getToolNodesByLink(selectedContext, { fetchAllNodes, replaceData }) {
+export function* getToolNodesByLink(selectedContext, { fetchAllNodes } = {}) {
   let nodesIds;
   let nodeTypesIds;
   if (!fetchAllNodes) {
@@ -138,7 +138,7 @@ export function* getToolNodesByLink(selectedContext, { fetchAllNodes, replaceDat
   const { source, fetchPromise } = fetchWithCancel(url);
   try {
     const { data } = yield call(fetchPromise);
-    yield put(setToolNodes(data.data, replaceData));
+    yield put(setToolNodes(data.data));
   } catch (e) {
     console.error('Error', e);
   } finally {

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -30,13 +30,13 @@ import * as ToolLinksUrlPropHandlers from 'react-components/tool-links/tool-link
 import toolLinksInitialState from './tool-links.initial-state';
 
 function setNodes(state, action) {
-  const { nodes, replaceData } = action.payload;
+  const { nodes } = action.payload;
   return immer(state, draft => {
     nodes.forEach(node => {
-      if (!draft.data.nodes || replaceData) {
+      if (!draft.data.nodes) {
         draft.data.nodes = {};
       }
-      if (!draft.data.nodesByColumnGeoId || replaceData) {
+      if (!draft.data.nodesByColumnGeoId) {
         draft.data.nodesByColumnGeoId = {};
       }
       if (!draft.data.nodes[node.id]) {

--- a/frontend/scripts/react-components/tool-links/tool-links.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.saga.js
@@ -28,7 +28,7 @@ import {
 } from './tool-links.fetch.saga';
 
 function* fetchToolColumns() {
-  function* performFetch(action) {
+  function* performFetch() {
     const state = yield select();
     const {
       location: { type: page }
@@ -38,12 +38,11 @@ function* fetchToolColumns() {
     if (page !== 'tool' || selectedContext === null) {
       return;
     }
-    const replaceData = [SET_CONTEXT, SET_CONTEXTS].includes(action.type);
     const task = yield fork(setLoadingSpinner, 750, setToolFlowsLoading(true));
     yield fork(getToolColumnsData, selectedContext);
     yield fork(getToolGeoColumnNodes, selectedContext);
     yield call(getToolLinksData);
-    yield call(getToolNodesByLink, selectedContext, { replaceData });
+    yield call(getToolNodesByLink, selectedContext);
 
     // TODO: remove this call, just here to split the refactor in stages
     yield put(loadMapVectorData());


### PR DESCRIPTION
The problem was that when changing context we called `getToolGeoColumnNodes` without `replaceData` and then we called `getToolNodesByLink` with `replaceData`. This effectively deleted the previously downloaded geoColumn nodes and added the rest of the nodes. The sankey worked without crashing due to selectors memoization.