### PR TITLE
fixes jump when scrolling of gridlist

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.fetch.saga.js
@@ -156,7 +156,7 @@ export function* getMoreDashboardPanelData(dashboardElement, optionsType) {
   if (params.node_types_ids === null) {
     return;
   }
-  const task = yield fork(setLoadingSpinner, 350, setDashboardPanelLoadingItems(true));
+  yield put(setDashboardPanelLoadingItems(true));
   const url = getURLFromParams(GET_DASHBOARD_OPTIONS_URL, params);
   const { source, fetchPromise } = fetchWithCancel(url);
   try {
@@ -167,14 +167,8 @@ export function* getMoreDashboardPanelData(dashboardElement, optionsType) {
         key: optionsType
       })
     );
-    if (task.isRunning()) {
-      task.cancel();
-    }
   } catch (e) {
     console.error('Error', e);
-    if (task.isRunning()) {
-      task.cancel();
-    }
   } finally {
     if (yield cancelled()) {
       if (NODE_ENV_DEV) console.error('Cancelled', url);
@@ -182,7 +176,7 @@ export function* getMoreDashboardPanelData(dashboardElement, optionsType) {
         source.cancel();
       }
     }
-    yield call(setLoadingSpinner, 750, setDashboardPanelLoadingItems(false));
+    yield call(setLoadingSpinner, 150, setDashboardPanelLoadingItems(false));
   }
 }
 

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -271,22 +271,27 @@ const dashboardElementReducer = {
         state.tabs[panel] && state.tabs[panel].find(tab => tab.id === activeItem.nodeTypeId);
       const activeTab = activeTabObj?.id || null;
 
+      if (panel === 'sources') {
+        if (activeTab !== state.sourcesActiveTab) {
+          draft.pages[panel] = initialState.pages[panel];
+        }
+        draft.sourcesActiveTab = activeTab;
+      }
+      if (panel === 'companies') {
+        if (activeTab !== state.companiesActiveTab) {
+          draft.pages[panel] = initialState.pages[panel];
+        }
+        draft.companiesActiveTab = activeTab;
+      }
+
       const data = state.data[panel] || [];
-      const dataMap = data.reduce((acc, next) => ({ ...acc, [next.id]: true }), {});
+      const existsInData = data.find(item => item.id === activeItem.id);
       let together = data;
-      if (!dataMap[activeItem.id]) {
+      if (!existsInData) {
         together = [activeItem, ...data];
       }
 
       draft.data[panel] = together;
-
-      if (panel === 'sources') {
-        draft.sourcesActiveTab = activeTab;
-      }
-      if (panel === 'companies') {
-        draft.companiesActiveTab = activeTab;
-      }
-      draft.pages[panel] = initialState.pages[panel];
       draft.searchResults = [];
 
       const firstItem =

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.reducer.js
@@ -258,9 +258,6 @@ const dashboardElementReducer = {
         draft.companiesActiveTab = activeTab;
       }
       draft.pages[panel] = initialState.pages[panel];
-
-      // TODO test this
-      // draft[panel] = [];
     });
   },
   [DASHBOARD_ELEMENT__SET_ACTIVE_ITEMS_WITH_SEARCH](state, action) {
@@ -272,13 +269,13 @@ const dashboardElementReducer = {
       const activeTab = activeTabObj?.id || null;
 
       if (panel === 'sources') {
-        if (activeTab !== state.sourcesActiveTab) {
+        if (activeTab !== state.sourcesActiveTab && state.sourcesActiveTab) {
           draft.pages[panel] = initialState.pages[panel];
         }
         draft.sourcesActiveTab = activeTab;
       }
       if (panel === 'companies') {
-        if (activeTab !== state.companiesActiveTab) {
+        if (activeTab !== state.companiesActiveTab && state.companiesActiveTab) {
           draft.pages[panel] = initialState.pages[panel];
         }
         draft.companiesActiveTab = activeTab;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.saga.js
@@ -84,10 +84,11 @@ export function* fetchMissingDashboardPanelItems() {
     }
 
     if (
-      (dashboardElement.data.sources.length === 0 && dashboardElement.sources.length > 0) ||
-      (dashboardElement.data.destinations.length === 0 &&
-        dashboardElement.destinations.length > 0) ||
-      (dashboardElement.data.companies.length === 0 && dashboardElement.companies.length > 0)
+      selectedContext &&
+      ((dashboardElement.data.sources.length === 0 && dashboardElement.sources.length > 0) ||
+        (dashboardElement.data.destinations.length === 0 &&
+          dashboardElement.destinations.length > 0) ||
+        (dashboardElement.data.companies.length === 0 && dashboardElement.companies.length > 0))
     ) {
       tasks.push(call(getMissingDashboardPanelItems, dashboardElement, selectedContext));
     }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-element.selectors.js
@@ -443,10 +443,30 @@ const getURLDashboardSelectedResizeBy = createSelector(
   }
 );
 
+const getURLParamsIfContext = (params, context) => {
+  if (!context) {
+    return null;
+  }
+  return params;
+};
+
+const getURLSources = createSelector(
+  [getSources, getDashboardsContext],
+  getURLParamsIfContext
+);
+const getURLCompanies = createSelector(
+  [getCompanies, getDashboardsContext],
+  getURLParamsIfContext
+);
+const getURLDestinations = createSelector(
+  [getDestinations, getDashboardsContext],
+  getURLParamsIfContext
+);
+
 export const getDashboardElementUrlProps = createStructuredSelector({
-  sources: getSources,
-  companies: getCompanies,
-  destinations: getDestinations,
+  sources: getURLSources,
+  companies: getURLCompanies,
+  destinations: getURLDestinations,
   selectedCountryId: getSelectedCountryId,
   selectedCommodityId: getSelectedCommodityId,
   selectedYears: getURLDashboardSelectedYears,

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/companies-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/companies-panel.component.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SearchInput from 'react-components/shared/search-input/search-input.component';
 import GridList from 'react-components/shared/grid-list/grid-list.component';
+import { useFirstItem } from 'react-components/shared/grid-list/grid-list.hooks';
 import GridListItem from 'react-components/shared/grid-list-item/grid-list-item.component';
 import Tabs from 'react-components/shared/tabs/tabs.component';
+
 import 'react-components/dashboard-element/dashboard-panel/companies-panel.scss';
 
 function CompaniesPanel(props) {
@@ -23,6 +25,9 @@ function CompaniesPanel(props) {
     activeNodeTypeTab,
     actionComponent
   } = props;
+
+  const itemToScrollTo = useFirstItem(companies);
+
   return (
     <div className="c-companies-panel">
       <SearchInput
@@ -55,6 +60,7 @@ function CompaniesPanel(props) {
             getMoreItems={getMoreItems}
             page={page}
             loading={loading}
+            itemToScrollTo={itemToScrollTo}
           >
             {itemProps => (
               <GridListItem

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/destinations-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/destinations-panel.component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SearchInput from 'react-components/shared/search-input/search-input.component';
 import GridList from 'react-components/shared/grid-list/grid-list.component';
+import { useFirstItem } from 'react-components/shared/grid-list/grid-list.hooks';
 import GridListItem from 'react-components/shared/grid-list-item/grid-list-item.component';
 
 function DestinationsPanel(props) {
@@ -16,6 +17,9 @@ function DestinationsPanel(props) {
     onSelectDestinationValue,
     getMoreItems
   } = props;
+
+  const itemToScrollTo = useFirstItem(destinations);
+
   return (
     <React.Fragment>
       <SearchInput
@@ -38,6 +42,7 @@ function DestinationsPanel(props) {
         page={page}
         getMoreItems={getMoreItems}
         loading={loading}
+        itemToScrollTo={itemToScrollTo}
       >
         {itemProps => (
           <GridListItem

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/sources-panel.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/sources-panel.component.jsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import SearchInput from 'react-components/shared/search-input/search-input.component';
 import GridList from 'react-components/shared/grid-list/grid-list.component';
+import { useFirstItem } from 'react-components/shared/grid-list/grid-list.hooks';
 import GridListItem from 'react-components/shared/grid-list-item/grid-list-item.component';
 import Tabs from 'react-components/shared/tabs/tabs.component';
 import Text from 'react-components/shared/text/text.component';
 import capitalize from 'lodash/capitalize';
 import Accordion from '../../shared/accordion/accordion.component';
+
 import 'react-components/dashboard-element/dashboard-panel/sources-panel.scss';
 
 function SourcesPanel(props) {
@@ -31,6 +33,7 @@ function SourcesPanel(props) {
   } = props;
   const [sourcesOpen, changeSourcesOpen] = useState(sourcesRequired);
   const toggleSourcesOpen = () => changeSourcesOpen(!sourcesOpen);
+  const itemToScrollTo = useFirstItem(sources);
 
   const showJurisdictions = activeCountryItems.length > 0 && tabs.length > 0;
   const activeCountryName = activeCountryItems.length > 0 && capitalize(activeCountryItems[0].name);
@@ -92,6 +95,7 @@ function SourcesPanel(props) {
               page={page}
               getMoreItems={getMoreItems}
               loading={loading}
+              itemToScrollTo={itemToScrollTo}
             >
               {itemProps => (
                 <GridListItem

--- a/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
+++ b/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
@@ -27,40 +27,17 @@ class GridList extends React.Component {
     page: 1
   };
 
-  listRef = React.createRef();
-
-  debouncedGetMoreItemsCb = debounce(this.props.getMoreItems, 150);
-
-  componentDidUpdate(prevProps) {
-    const { items, columnCount } = this.props;
-    if (prevProps.items.length > 0 && items.length !== prevProps.items.length) {
-      const prevLastRow = prevProps.items[prevProps.items.length - 1];
-      const currentFirstRowIndex = items.findIndex(i => i.id === (prevLastRow && prevLastRow.id));
-      const buffer = 1;
-      const rowIndex = Math.ceil(parseInt(currentFirstRowIndex / columnCount, 10)) - buffer;
-
-      this.listRef.current.scrollToItem({
-        rowIndex,
-        columnIndex: 0,
-        align: 'start'
-      });
-    }
-  }
+  debouncedGetMoreItemsCb = debounce(this.props.getMoreItems, 350);
 
   getMoreItems = ({ scrollTop, scrollUpdateWasRequested, verticalScrollDirection }) => {
     const { items, height, rowHeight, page, columnCount } = this.props;
-    const current = parseInt((scrollTop + height) / rowHeight, 10);
+    const current = Math.ceil((scrollTop + height) / rowHeight, 10);
     const buffer = 1;
-    const pageEnd = parseInt(items.length / columnCount, 10);
+    const pageEnd = Math.ceil(items.length / columnCount, 10);
     const reachedPageEnd = current === pageEnd;
     const reachedPageEndWithBuffer =
       current === pageEnd - buffer && page > GridList.defaultProps.page;
 
-    // TODO: add backwards support
-    // const reachedPageStart = current === columnCount;
-    // if (reachedPageStart && !scrollUpdateWasRequested && page > 0 && verticalScrollDirection === 'backward') {
-    //   getMoreItems(page - 1, 'backwards');
-    // }
     if (
       (reachedPageEnd || reachedPageEndWithBuffer) &&
       !scrollUpdateWasRequested &&
@@ -105,7 +82,6 @@ class GridList extends React.Component {
     return (
       <div className="c-grid-list">
         <FixedSizeGrid
-          ref={this.listRef}
           className={className}
           height={height}
           width={width}

--- a/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
+++ b/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
@@ -52,6 +52,28 @@ function useGroupedItems({ groupBy, columnCount, items }) {
   }, [groupBy, columnCount, items]);
 }
 
+function useScrollToItemId({ itemToScrollTo, columnCount, items }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (itemToScrollTo?.id && ref.current) {
+      const currentFirstRowIndex = items.findIndex(i => i.id === itemToScrollTo.id);
+      if (currentFirstRowIndex !== -1) {
+        const rowIndex = Math.ceil(currentFirstRowIndex / columnCount);
+
+        ref.current.scrollToItem({
+          rowIndex,
+          columnIndex: 0,
+          align: 'start'
+        });
+      }
+    }
+    // we dont want to scroll to item, every time the items change
+    // eslint-disable-next-line
+  }, [itemToScrollTo, columnCount]);
+
+  return ref;
+}
+
 function GridList(props) {
   const {
     items,
@@ -63,26 +85,12 @@ function GridList(props) {
     width,
     columnWidth,
     children,
-    loading,
-    itemToScrollTo
+    loading
   } = props;
 
   const groupedItems = useGroupedItems(props);
   const onScrollCb = useMoreItems(props);
-  const fixedSizeGridRef = useRef(null);
-
-  useEffect(() => {
-    if (itemToScrollTo?.id && fixedSizeGridRef.current) {
-      const currentFirstRowIndex = items.findIndex(i => i.id === itemToScrollTo.id);
-      const rowIndex = Math.ceil(currentFirstRowIndex / columnCount);
-
-      fixedSizeGridRef.current.scrollToItem({
-        rowIndex,
-        columnIndex: 0,
-        align: 'start'
-      });
-    }
-  }, [itemToScrollTo, columnCount, items]);
+  const fixedSizeGridRef = useScrollToItemId(props);
 
   return (
     <div className="c-grid-list">
@@ -119,7 +127,7 @@ GridList.propTypes = {
   groupBy: PropTypes.string,
   className: PropTypes.string,
   getMoreItems: PropTypes.func, // eslint-disable-line
-  itemToScrollTo: PropTypes.object,
+  itemToScrollTo: PropTypes.object, // eslint-disable-line
   items: PropTypes.array.isRequired,
   width: PropTypes.number.isRequired,
   children: PropTypes.func.isRequired,

--- a/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
+++ b/frontend/scripts/react-components/shared/grid-list/grid-list.component.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { FixedSizeGrid } from 'react-window';
 import debounce from 'lodash/debounce';
@@ -6,50 +6,37 @@ import ShrinkingSpinner from '../shrinking-spinner/shrinking-spinner.component';
 
 import './grid-list.scss';
 
-class GridList extends React.Component {
-  static propTypes = {
-    page: PropTypes.number,
-    loading: PropTypes.bool,
-    groupBy: PropTypes.string,
-    className: PropTypes.string,
-    getMoreItems: PropTypes.func,
-    items: PropTypes.array.isRequired,
-    width: PropTypes.number.isRequired,
-    children: PropTypes.func.isRequired,
-    height: PropTypes.number.isRequired,
-    rowHeight: PropTypes.number.isRequired,
-    columnWidth: PropTypes.number.isRequired,
-    columnCount: PropTypes.number.isRequired
-  };
+function useMoreItems({ getMoreItems, rowHeight, height, columnCount, items, page }) {
+  const debouncedGetMoreItemsCb = useCallback(debounce(getMoreItems, 350), [getMoreItems]);
 
-  static defaultProps = {
-    getMoreItems: () => {},
-    page: 1
-  };
+  return useCallback(
+    ({ scrollTop, scrollUpdateWasRequested, verticalScrollDirection }) => {
+      const current = Math.ceil((scrollTop + height) / rowHeight);
+      const buffer = 1;
+      const pageEnd = Math.ceil(items.length / columnCount);
+      const reachedPageEnd = current === pageEnd;
+      const reachedPageEndWithBuffer = current === pageEnd - buffer && page > 1;
 
-  debouncedGetMoreItemsCb = debounce(this.props.getMoreItems, 350);
+      if (
+        (reachedPageEnd || reachedPageEndWithBuffer) &&
+        !scrollUpdateWasRequested &&
+        verticalScrollDirection === 'forward'
+      ) {
+        debouncedGetMoreItemsCb(page + 1, 'forward');
+      }
+    },
+    [height, rowHeight, items.length, columnCount, page, debouncedGetMoreItemsCb]
+  );
+}
 
-  getMoreItems = ({ scrollTop, scrollUpdateWasRequested, verticalScrollDirection }) => {
-    const { items, height, rowHeight, page, columnCount } = this.props;
-    const current = Math.ceil((scrollTop + height) / rowHeight, 10);
-    const buffer = 1;
-    const pageEnd = Math.ceil(items.length / columnCount, 10);
-    const reachedPageEnd = current === pageEnd;
-    const reachedPageEndWithBuffer =
-      current === pageEnd - buffer && page > GridList.defaultProps.page;
-
-    if (
-      (reachedPageEnd || reachedPageEndWithBuffer) &&
-      !scrollUpdateWasRequested &&
-      verticalScrollDirection === 'forward'
-    ) {
-      this.debouncedGetMoreItemsCb(page + 1, 'forward');
+function useGroupedItems({ groupBy, columnCount, items }) {
+  return useMemo(() => {
+    if (!groupBy) {
+      return null;
     }
-  };
 
-  getGroupedItems() {
-    const { groupBy, items, columnCount } = this.props;
     const grouped = [];
+
     items.forEach(item => {
       const index = grouped.length;
       if (item[groupBy]) {
@@ -62,50 +49,89 @@ class GridList extends React.Component {
       }
     });
     return grouped;
-  }
-
-  render() {
-    const {
-      className,
-      height,
-      width,
-      columnWidth,
-      rowHeight,
-      items,
-      columnCount,
-      children,
-      groupBy,
-      loading
-    } = this.props;
-    const groupedItems = groupBy && this.getGroupedItems();
-
-    return (
-      <div className="c-grid-list">
-        <FixedSizeGrid
-          className={className}
-          height={height}
-          width={width}
-          columnWidth={columnWidth}
-          rowHeight={rowHeight}
-          itemData={groupedItems || items}
-          rowCount={Math.ceil((groupedItems || items).length / columnCount)}
-          columnCount={columnCount}
-          onScroll={this.getMoreItems}
-        >
-          {({ rowIndex, columnIndex, style, data }) => {
-            const item = data[rowIndex * columnCount + columnIndex];
-            if (typeof item === 'undefined' || !children) return null;
-            return children({ item, style, isGroup: item && !!item[groupBy] });
-          }}
-        </FixedSizeGrid>
-        {loading && (
-          <div className="grid-list-loading-container">
-            <ShrinkingSpinner className="-small -dark grid-list-spinner" />
-          </div>
-        )}
-      </div>
-    );
-  }
+  }, [groupBy, columnCount, items]);
 }
+
+function GridList(props) {
+  const {
+    items,
+    height,
+    rowHeight,
+    columnCount,
+    groupBy,
+    className,
+    width,
+    columnWidth,
+    children,
+    loading,
+    itemToScrollTo
+  } = props;
+
+  const groupedItems = useGroupedItems(props);
+  const onScrollCb = useMoreItems(props);
+  const fixedSizeGridRef = useRef(null);
+
+  useEffect(() => {
+    if (itemToScrollTo?.id && fixedSizeGridRef.current) {
+      const currentFirstRowIndex = items.findIndex(i => i.id === itemToScrollTo.id);
+      const rowIndex = Math.ceil(currentFirstRowIndex / columnCount);
+
+      fixedSizeGridRef.current.scrollToItem({
+        rowIndex,
+        columnIndex: 0,
+        align: 'start'
+      });
+    }
+  }, [itemToScrollTo, columnCount, items]);
+
+  return (
+    <div className="c-grid-list">
+      <FixedSizeGrid
+        ref={fixedSizeGridRef}
+        className={className}
+        height={height}
+        width={width}
+        columnWidth={columnWidth}
+        rowHeight={rowHeight}
+        itemData={groupedItems || items}
+        rowCount={Math.ceil((groupedItems || items).length / columnCount)}
+        columnCount={columnCount}
+        onScroll={onScrollCb}
+      >
+        {({ rowIndex, columnIndex, style, data }) => {
+          const item = data[rowIndex * columnCount + columnIndex];
+          if (typeof item === 'undefined' || !children) return null;
+          return children({ item, style, isGroup: item && !!item[groupBy] });
+        }}
+      </FixedSizeGrid>
+      {loading && (
+        <div className="grid-list-loading-container">
+          <ShrinkingSpinner className="-small -dark grid-list-spinner" />
+        </div>
+      )}
+    </div>
+  );
+}
+
+GridList.propTypes = {
+  page: PropTypes.number, // eslint-disable-line
+  loading: PropTypes.bool,
+  groupBy: PropTypes.string,
+  className: PropTypes.string,
+  getMoreItems: PropTypes.func, // eslint-disable-line
+  itemToScrollTo: PropTypes.object,
+  items: PropTypes.array.isRequired,
+  width: PropTypes.number.isRequired,
+  children: PropTypes.func.isRequired,
+  height: PropTypes.number.isRequired,
+  rowHeight: PropTypes.number.isRequired,
+  columnWidth: PropTypes.number.isRequired,
+  columnCount: PropTypes.number.isRequired
+};
+
+GridList.defaultProps = {
+  getMoreItems: () => {},
+  page: 1
+};
 
 export default GridList;

--- a/frontend/scripts/react-components/shared/grid-list/grid-list.hooks.js
+++ b/frontend/scripts/react-components/shared/grid-list/grid-list.hooks.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 export function useFirstItem(items) {
   const [firstItem, setFirstItem] = useState(items[0]);
   useEffect(() => {
-    if (firstItem !== items) {
+    if (firstItem !== items[0]) {
       setFirstItem(items[0]);
     }
   }, [firstItem, items]);

--- a/frontend/scripts/react-components/shared/grid-list/grid-list.hooks.js
+++ b/frontend/scripts/react-components/shared/grid-list/grid-list.hooks.js
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react';
+
+export function useFirstItem(items) {
+  const [firstItem, setFirstItem] = useState(items[0]);
+  useEffect(() => {
+    if (firstItem !== items) {
+      setFirstItem(items[0]);
+    }
+  }, [firstItem, items]);
+
+  return firstItem;
+}

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.fetch.saga.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.fetch.saga.js
@@ -106,7 +106,7 @@ export function* getProfilesData(panelName, activeTab = null) {
 export function* getMoreProfilesData(profileSelector, panelName, activeTab = null) {
   const { page } = profileSelector.panels[panelName];
   const params = yield getProfilesParams(panelName, { page });
-  const task = yield fork(setLoadingSpinner, 350, setProfilesLoadingItems(true, panelName));
+  yield put(setProfilesLoadingItems(true, panelName));
   const url = getURLFromParams(GET_DASHBOARD_OPTIONS_URL, { ...params, profile_only: true });
   const { source, fetchPromise } = fetchWithCancel(url);
   try {
@@ -119,9 +119,6 @@ export function* getMoreProfilesData(profileSelector, panelName, activeTab = nul
         data: data.data
       }
     });
-    if (task.isRunning()) {
-      task.cancel();
-    }
   } catch (e) {
     console.error('Error', e);
   } finally {
@@ -131,7 +128,7 @@ export function* getMoreProfilesData(profileSelector, panelName, activeTab = nul
         source.cancel();
       }
     }
-    yield call(setLoadingSpinner, 750, setProfilesLoadingItems(false, panelName));
+    yield call(setLoadingSpinner, 150, setProfilesLoadingItems(false, panelName));
   }
 }
 

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profiles-companies-panel.component.jsx
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profiles-companies-panel.component.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import SearchInput from 'react-components/shared/search-input/search-input.component';
 import GridList from 'react-components/shared/grid-list/grid-list.component';
+import { useFirstItem } from 'react-components/shared/grid-list/grid-list.hooks';
 import GridListItem from 'react-components/shared/grid-list-item/grid-list-item.component';
 import Tabs from 'react-components/shared/tabs/tabs.component';
 import 'react-components/dashboard-element/dashboard-panel/companies-panel.scss';
@@ -23,6 +24,9 @@ function ProfilesCompaniesPanel(props) {
     activeNodeTypeTab,
     actionComponent
   } = props;
+
+  const itemToScrollTo = useFirstItem(companies);
+
   return (
     <div className="c-companies-panel">
       <SearchInput
@@ -55,6 +59,7 @@ function ProfilesCompaniesPanel(props) {
             getMoreItems={getMoreItems}
             page={page}
             loading={loading}
+            itemToScrollTo={itemToScrollTo}
           >
             {itemProps => (
               <GridListItem

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profiles-sources-panel.component.jsx
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profiles-sources-panel.component.jsx
@@ -2,10 +2,12 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import SearchInput from 'react-components/shared/search-input/search-input.component';
 import GridList from 'react-components/shared/grid-list/grid-list.component';
+import { useFirstItem } from 'react-components/shared/grid-list/grid-list.hooks';
 import GridListItem from 'react-components/shared/grid-list-item/grid-list-item.component';
 import Tabs from 'react-components/shared/tabs/tabs.component';
 import capitalize from 'lodash/capitalize';
 import Accordion from 'react-components/shared/accordion/accordion.component';
+
 import 'react-components/dashboard-element/dashboard-panel/sources-panel.scss';
 
 function ProfilesSourcesPanel(props) {
@@ -31,6 +33,7 @@ function ProfilesSourcesPanel(props) {
 
   const [sourcesOpen, changeSourcesOpen] = useState(sourcesRequired);
   const toggleSourcesOpen = () => changeSourcesOpen(!sourcesOpen);
+  const itemToScrollTo = useFirstItem(sources);
 
   const showJurisdictions = activeCountryItems && tabs.length > 0;
   const activeCountryName = activeCountryItems && capitalize(activeCountryItems[0].name);
@@ -91,6 +94,7 @@ function ProfilesSourcesPanel(props) {
               page={page}
               getMoreItems={getMoreItems}
               loading={loading}
+              itemToScrollTo={itemToScrollTo}
             >
               {itemProps => (
                 <GridListItem

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.reducer.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.reducer.js
@@ -237,6 +237,7 @@ const profileRootReducer = {
       if (panel === 'companies') {
         if (clearActiveTabData && draft.data[panel][selectedCountryId]) {
           draft.data[panel][selectedCountryId][prevTab] = null;
+          draft.panels[panel].page = initialState.panels[panel].page;
         }
         if (!draft.data[panel][selectedCountryId]) {
           draft.data[panel][selectedCountryId] = {};
@@ -245,6 +246,7 @@ const profileRootReducer = {
       } else if (activeTab) {
         if (clearActiveTabData) {
           draft.data[panel][prevTab] = null;
+          draft.panels[panel].page = initialState.panels[panel].page;
         }
         draft.data[panel][activeTab] = together;
       } else {
@@ -253,7 +255,6 @@ const profileRootReducer = {
 
       draft.panels[panel].activeTab = activeTab;
       draft.panels[panel].searchResults = [];
-      draft.panels[panel].page = initialState.panels[panel].page;
     });
   }
 };


### PR DESCRIPTION
I removed the jump ahead feature and fixed some bugs that surfaced while doing so.

1. We we're resetting the page to the initial state every time we selected an item through the search bar. This made it impossible to load the following items.

2. We were requesting the sources in the url when landing on the app, this failed when the user hadn't selected a commodity because we didnt have a context id yet. Now, we dont serialise the sources until we have selected a country and a commodity.