### PR TITLE
Feature/filter combination

### DIFF
--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
@@ -60,7 +60,7 @@ module Api
             without_string_values = @data.map(&reject_strings)
             total_values = get_total_values(without_string_values)
 
-            @meta[:aggregates] = {total_value: total_values.except(:x)} # x is a year
+            @meta[:aggregates] = {total_value: total_values&.except(:x)} # x is a year
 
             {data: @data, meta: @meta}
           end

--- a/app/services/api/v3/dashboards/filter_companies.rb
+++ b/app/services/api/v3/dashboards/filter_companies.rb
@@ -9,8 +9,33 @@ module Api
           super(params)
         end
 
-        def call_with_query_term(query_term)
-          super(query_term, {include_country_id: true})
+        def call
+          return @query if @node_ids.none?
+
+          @query = Api::V3::Readonly::Dashboards::Company.
+            select(
+              'companies.id',
+              'companies.name',
+              'companies.node_type',
+              'companies.node_type_id',
+              'companies.country_id',
+              'companies.profile',
+              'companies.commodity_id'
+            ).
+            from("(#{@query.to_sql}) AS companies").
+            joins('INNER JOIN contexts ON contexts.country_id = companies.country_id AND
+                                          contexts.commodity_id = companies.commodity_id').
+            joins("INNER JOIN flows ON flows.context_id = contexts.id AND
+                                       flows.path @> ARRAY[#{@node_ids.join(', ')}, companies.id]").
+            group(
+              'companies.id',
+              'companies.name',
+              'companies.node_type',
+              'companies.node_type_id',
+              'companies.country_id',
+              'companies.profile',
+              'companies.commodity_id'
+            )
         end
 
         private
@@ -22,16 +47,25 @@ module Api
               :name,
               :node_type,
               :node_type_id,
-              :country_id
+              :country_id,
+              :profile,
+              :commodity_id
             ).
             group(
               :id,
               :name,
               :node_type,
               :node_type_id,
-              :country_id
+              :country_id,
+              :profile,
+              :commodity_id
             ).
             order(:name)
+
+            if @node_ids.any?
+              @query = @query.
+                having("COUNT(DISTINCT dashboards_companies_mv.node_id) = #{@node_ids.size}")
+            end
         end
       end
     end

--- a/app/services/api/v3/dashboards/filter_companies.rb
+++ b/app/services/api/v3/dashboards/filter_companies.rb
@@ -62,10 +62,10 @@ module Api
             ).
             order(:name)
 
-            if @node_ids.any?
-              @query = @query.
-                having("COUNT(DISTINCT dashboards_companies_mv.node_id) = #{@node_ids.size}")
-            end
+          return if @node_ids.none?
+
+          @query = @query.
+            having("COUNT(DISTINCT dashboards_companies_mv.node_id) = #{@node_ids.size}")
         end
       end
     end

--- a/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
       )
     end
 
+    context 'when filter with node_ids' do
+      it 'returns companies with the specified nodes' do
+        get :index, params: {
+          countries_ids: [api_v3_brazil.id].join(','),
+          sources_ids: [api_v3_biome_node.id].join(','),
+          destinations_ids: [api_v3_country_of_destination1_node.id].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+        )
+      end
+    end
+
     let(:per_page) { 1 }
 
     it 'accepts per_page' do


### PR DESCRIPTION
`dashboards_companies_mv` table contains exporter and importer nodes related on the path for each flow. When the table is filtered though `nodes_ids`, it checks that importer/exporter nodes are related to the specified nodes (sources, destinations...) but it doesn't check that they appear on the same flow path. Possible solutions:

1. Add `flow_path` to `dashboards_companies_mv` table to check if `nodes_ids` appear on the same flow. It reduces the complexity of the query but it increase the size of the table a lot (from 262152 to 3011191 rows).

2. Add joins clauses with the `contexts` and `flows` tables to the existing query to check the flow paths with the nodes. The problem with this solution is that it increases the query time a lot (around 9 seconds for each query).

3. Add joins clauses with the `contexts` and `flows` tables but using a subquery with the default filters on `dashboards_companies_mv` table. This is the used solution.