### PR TITLE
Fixed join condition for recolour by flow values

### DIFF
--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -301,12 +301,16 @@ module Api
             where('flow_quants.value > 0')
           if @ncont_attribute
             ncont_attr_table = @ncont_attribute.flow_values_class.table_name
-            query = query.
-              joins("LEFT JOIN #{ncont_attr_table} ON #{ncont_attr_table}.flow_id = flows.id").
-              where(
-                "#{ncont_attr_table}.#{@ncont_attribute.attribute_id_name}" =>
-                  @ncont_attribute.original_id
-              )
+            ncont_attr_join_clause = ActiveRecord::Base.send(
+              :sanitize_sql_array,
+              [
+                "LEFT JOIN #{ncont_attr_table} ON \
+                #{ncont_attr_table}.flow_id = flows.id \
+                AND #{ncont_attr_table}.#{@ncont_attribute.attribute_id_name} = ?",
+                @ncont_attribute.original_id
+              ]
+            )
+            query = query.joins(ncont_attr_join_clause)
           end
           query
         end

--- a/spec/services/api/v3/flows/filter_spec.rb
+++ b/spec/services/api/v3/flows/filter_spec.rb
@@ -2,11 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::Flows::Filter do
   include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil recolor by attributes'
   include_context 'api v3 brazil flows quants'
 
   before(:each) do
     Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
     Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
   end
 
   let!(:api_v3_diamantino_node) {
@@ -98,6 +100,18 @@ RSpec.describe Api::V3::Flows::Filter do
           )
           filter.call
           expect(filter.active_nodes).to have_key(api_v3_diamantino_node.id)
+        end
+      end
+      context 'when recolor by attribute' do
+        it 'includes flows with null value of recolor by attribute' do
+          filter = Api::V3::Flows::Filter.new(
+            api_v3_context,
+            filter_params.merge(
+              ncont_attribute_id: api_v3_forest_500_recolor_by_attribute.readonly_attribute.id
+            )
+          )
+          filter.call
+          expect(filter.flows).to include(api_v3_diamantino_flow)
         end
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168238572

It's an interesting bug; recently we refactored the flows service slightly to allow passing resize / recolor attributes by attribute id, and as part of that we slightly modified the flows query, which caused the bug.

These 2 queries are not equivalent:

SELECT flows.id,ARRAY[flows.path[3], flows.path[6], flows.path[7], flows.path[8]] AS path,
flow_quants.value AS quant_value,flow_inds.value::DOUBLE PRECISION AS ind_value, NULL::TEXT AS qual_value 
FROM "flows"
INNER JOIN "flow_quants" ON "flow_quants"."flow_id" = "flows"."id" 
LEFT JOIN flow_inds ON flow_inds.flow_id = flows.id 
WHERE "flows"."context_id" = 1
AND (year >= '2017' AND year <= '2017')
AND "flow_quants"."quant_id" = 1
AND (flow_quants.value > 0) **AND "flow_inds"."ind_id" = 1**;

SELECT flows.id,ARRAY[flows.path[3], flows.path[6], flows.path[7], flows.path[8]] AS path,
flow_quants.value AS quant_value,flow_inds.value::DOUBLE PRECISION AS ind_value, NULL::TEXT AS qual_value
FROM "flows" INNER JOIN "flow_quants" ON "flow_quants"."flow_id" = "flows"."id"
LEFT JOIN flow_inds ON flow_inds.flow_id = flows.id **AND flow_inds.ind_id = 1**
WHERE "flows"."context_id" = 1
AND (year >= '2017' AND year <= '2017')
AND "flow_quants"."quant_id" = 1
AND (flow_quants.value > 0);

The first one will not return rows where flow_inds.ind_id is NULL, the the second one will. Those rows are the grey flows that went missing from the sankey.