### PR TITLE
Fix pasture area format

### DIFF
--- a/app/services/api/v3/places/basic_attributes.rb
+++ b/app/services/api/v3/places/basic_attributes.rb
@@ -167,7 +167,10 @@ module Api
           commodity_attributes = {header_attributes: {}}
 
           initialize_pasture_area
-          commodity_attributes[:pasture_area] = @pasture_area if @pasture_area
+          if @pasture_area
+            commodity_attributes[:header_attributes][:pasture_area] =
+              header_attributes('pasture_area')
+          end
           initialize_area
           if @area
             commodity_attributes[:area] = @area


### PR DESCRIPTION
Returning pasture_area in the new header_attributes format
