### PR TITLE
Take list of years from the context-specific readonly node

### DIFF
--- a/app/controllers/api/v3/profile_metadata_controller.rb
+++ b/app/controllers/api/v3/profile_metadata_controller.rb
@@ -19,13 +19,17 @@ module Api
 
         serialized_available_years =
           ActiveModelSerializers::SerializableResource.new(
-            @node,
+            @readonly_node,
             root: 'data',
             serializer: Api::V3::ProfileMetadata::AvailableYearsSerializer,
             key_transform: :underscore
           ).serializable_hash
 
-        render json: {data: serialized_profile_metadata[:data].merge(serialized_available_years[:data])}
+        render json: {
+          data: serialized_profile_metadata[:data].merge(
+            serialized_available_years[:data]
+          )
+        }
       end
 
       private
@@ -33,10 +37,11 @@ module Api
       def load_node
         ensure_required_param_present(:id)
 
-        node_in_mv = Api::V3::Readonly::Node.
+        @node = Api::V3::Node.find(params[:id])
+
+        @readonly_node = Api::V3::Readonly::Node.
           where(context_id: @context.id, profile: %w[actor place]).
-          find(params[:id])
-        @node = Api::V3::Node.find(node_in_mv.id)
+          find(@node.id)
       end
     end
   end

--- a/app/serializers/api/v3/profile_metadata/available_years_serializer.rb
+++ b/app/serializers/api/v3/profile_metadata/available_years_serializer.rb
@@ -5,7 +5,7 @@ module Api
         attributes :available_years
 
         def available_years
-          object.readonly_attribute&.years
+          object.years
         end
       end
     end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168375254

The problem was that the list of available years was taken from the wrong "readonly node"