### PR TITLE
Fix/nodes stats

### DIFF
--- a/app/controllers/api/v3/nodes_stats_controller.rb
+++ b/app/controllers/api/v3/nodes_stats_controller.rb
@@ -22,7 +22,9 @@ module Api
       def set_filter_params
         year_start = params[:start_year]
         @filter_params = {
-          attributes_ids: cs_string_to_int_array(params[:attributes_ids]),
+          attribute_id: params[:attribute_id],
+          other_attributes_ids:
+            cs_string_to_int_array(params[:other_attributes_ids]),
           node_type_id: params[:column_id],
           year_start: year_start,
           year_end: params[:end_year] || year_start,

--- a/app/services/api/v3/nodes_stats/response_builder.rb
+++ b/app/services/api/v3/nodes_stats/response_builder.rb
@@ -102,11 +102,11 @@ module Api
           end
         end
 
-        def find_nodes_stats(attribute=nil)
+        def find_nodes_stats(attribute = nil)
           options = {
             node_type_id: @node_type_id,
             year_start: @year_start,
-            year_end: @year_end,
+            year_end: @year_end
           }
 
           if @commodity_id
@@ -121,11 +121,11 @@ module Api
               )
           end
 
-          nodes_stats_attribute = attribute || @attribute
-          nodes_stats_limit = attribute ? 1 : @limit
-          nodes_stats_list.sorted_list(
-            nodes_stats_attribute.original_id, limit: nodes_stats_limit
-          )
+          if attribute
+            nodes_stats_list.sorted_list(attribute.original_id, limit: 1)
+          else
+            nodes_stats_list.sorted_list(@attribute.original_id, limit: @limit)
+          end
         end
       end
     end

--- a/app/services/api/v3/nodes_stats/response_builder.rb
+++ b/app/services/api/v3/nodes_stats/response_builder.rb
@@ -14,7 +14,7 @@ module Api
         end
 
         def call
-          initialize_nodes_stats
+          @nodes_stats = find_nodes_stats
 
           formatted_nodes_stats
         end
@@ -26,29 +26,8 @@ module Api
           @year_end = params[:year_end]&.to_i
           @limit = params[:limit]&.to_i || 10
           @node_type_id = params[:node_type_id]
-          @attributes_ids = params[:attributes_ids]
-        end
-
-        def initialize_nodes_stats
-          options = {
-            node_type_id: @node_type_id,
-            year_start: @year_start,
-            year_end: @year_end
-          }
-          if @commodity_id
-            nodes_stats_list =
-              Api::V3::Profiles::NodesStatsForCommodityList.new(
-                @commodity_id, options
-              )
-          else
-            nodes_stats_list =
-              Api::V3::Profiles::NodesStatsForContextsList.new(
-                @contexts_ids, options
-              )
-          end
-
-          @nodes_stats = nodes_stats_list.
-            sorted_list(@attributes.map(&:original_id), limit: @limit)
+          @attribute_id = params[:attribute_id]
+          @other_attributes_ids = params[:other_attributes_ids] || []
         end
 
         def initialize_errors
@@ -60,7 +39,12 @@ module Api
             raise 'Either commodity or contexts but not both'
           end
 
-          @attributes = @attributes_ids.map do |attribute_id|
+          @attribute = Api::V3::Readonly::Attribute.find_by(
+            id: @attribute_id, original_type: 'Quant'
+          )
+          raise "Attribute #{@attribute_id} not found" unless @attribute
+
+          @other_attributes = @other_attributes_ids.map do |attribute_id|
             attribute = Api::V3::Readonly::Attribute.find_by(
               id: attribute_id, original_type: 'Quant'
             )
@@ -78,32 +62,70 @@ module Api
           filter_values.map do |filter|
             {
               filter_name => filter,
-              attributes: @attributes.map do |attribute|
-                attribute_information(attribute)
+              top_nodes: @nodes_stats.map do |node_stats|
+                nodes_stats_information(node_stats)
               end
             }
           end
         end
 
-        def attribute_information(attribute)
-          targets = @nodes_stats.where(quant_id: attribute.original_id)
+        def nodes_stats_information(nodes_stats)
           {
-            id: attribute.id,
-            indicator: attribute.display_name,
-            unit: attribute.unit,
-            targets: nodes_stats_information(targets)
+            id: nodes_stats.node_id,
+            name: nodes_stats.name,
+            geo_id: nodes_stats.geo_id,
+            attribute: attribute_information(nodes_stats),
+            other_attributes: other_attributes_information
           }
         end
 
-        def nodes_stats_information(nodes_stats)
-          nodes_stats.map do |node_stats|
+        def attribute_information(nodes_stats)
+          {
+            id: @attribute.id,
+            indicator: @attribute.display_name,
+            unit: @attribute.unit,
+            value: nodes_stats.value,
+            height: nodes_stats.height
+          }
+        end
+
+        def other_attributes_information
+          @other_attributes.map do |attribute|
+            nodes_stats = find_nodes_stats(attribute).first
             {
-              id: node_stats['node_id'],
-              name: node_stats['name'],
-              value: node_stats['value'],
-              height: node_stats['height']
+              id: attribute.id,
+              name: attribute.display_name,
+              unit: attribute.unit,
+              value: nodes_stats.value,
+              height: nodes_stats.height
             }
           end
+        end
+
+        def find_nodes_stats(attribute=nil)
+          options = {
+            node_type_id: @node_type_id,
+            year_start: @year_start,
+            year_end: @year_end,
+          }
+
+          if @commodity_id
+            nodes_stats_list =
+              Api::V3::Profiles::NodesStatsForCommodityList.new(
+                @commodity_id, options
+              )
+          else
+            nodes_stats_list =
+              Api::V3::Profiles::NodesStatsForContextsList.new(
+                @contexts_ids, options
+              )
+          end
+
+          nodes_stats_attribute = attribute || @attribute
+          nodes_stats_limit = attribute ? 1 : @limit
+          nodes_stats_list.sorted_list(
+            nodes_stats_attribute.original_id, limit: nodes_stats_limit
+          )
         end
       end
     end

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -282,7 +282,13 @@ paths:
           required: false
           schema:
             type: integer
-        - name: attributes_ids
+        - name: attribute_id
+          in: query
+          description: Attribute id
+          required: false
+          schema:
+            type: string
+        - name: other_attributes_ids
           in: query
           description: List of attributes ids separated by comma
           required: false
@@ -297,7 +303,7 @@ paths:
                 type: object
                 properties:
                   data:
-                    $ref: "#/components/schemas/TopNodes"
+                    $ref: "#/components/schemas/NodesStats"
 
   /nodes/search:
     get:
@@ -2216,18 +2222,31 @@ components:
                 type: integer
               commodity_id:
                 type: integer
-              attributes:
+              top_nodes:
                 type: array
                 items:
                   type: object
                   properties:
                     id:
                       type: integer
-                    indicator:
+                    name:
                       type: string
-                    unit:
+                    geo_id:
                       type: string
-                    targets:
+                    attribute:
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                        name:
+                          type: string
+                        unit:
+                          type: string
+                        value:
+                          type: number
+                        height:
+                          type: number
+                    other_attributes:
                       type: array
                       items:
                         type: object
@@ -2235,6 +2254,8 @@ components:
                           id:
                             type: integer
                           name:
+                            type: string
+                          unit:
                             type: string
                           value:
                             type: number

--- a/spec/responses/api/v3/nodes_stats_spec.rb
+++ b/spec/responses/api/v3/nodes_stats_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe 'Nodes stats', type: :request do
         get '/api/v3/nodes_stats', params: {
           start_year: 2003,
           end_year: 2019,
-          attributes_ids: api_v3_volume.readonly_attribute.id.to_s,
+          attribute_id: api_v3_volume.readonly_attribute.id,
+          other_attributes_ids: api_v3_deforestation_v2.readonly_attribute.id,
           column_id: api_v3_country_node_type.id,
           contexts_ids: api_v3_context.id.to_s
         }
@@ -24,7 +25,7 @@ RSpec.describe 'Nodes stats', type: :request do
 
         parsed_response = JSON.parse(@response.body)
         nodes_ids =
-          parsed_response['data'].first['attributes'].first['targets'].map { |d| d['id'] }
+          parsed_response['data'].first['top_nodes'].map { |a| a['id'] }
         expect(nodes_ids).to eql([
           api_v3_country_of_destination1_node.id,
           api_v3_other_country_of_destination_node.id
@@ -37,7 +38,7 @@ RSpec.describe 'Nodes stats', type: :request do
         get '/api/v3/nodes_stats', params: {
           start_year: 2003,
           end_year: 2019,
-          attributes_ids: api_v3_volume.readonly_attribute.id,
+          attribute_id: api_v3_volume.readonly_attribute.id,
           column_id: api_v3_country_node_type.id,
           commodity_id: api_v3_soy.id
         }
@@ -47,7 +48,7 @@ RSpec.describe 'Nodes stats', type: :request do
 
         parsed_response = JSON.parse(@response.body)
         nodes_ids =
-          parsed_response['data'].first['attributes'].first['targets'].map { |d| d['id'] }
+          parsed_response['data'].first['top_nodes'].map { |a| a['id'] }
         expect(nodes_ids).to eql([
           api_v3_country_of_destination1_node.id,
           api_v3_other_country_of_destination_node.id

--- a/spec/services/api/v3/nodes_stats/response_builder_spec.rb
+++ b/spec/services/api/v3/nodes_stats/response_builder_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Api::V3::NodesStats::ResponseBuilder do
           nil,
           [api_v3_context.id],
           node_type_id: api_v3_country_node_type.id,
-          attributes_ids: [api_v3_volume.readonly_attribute.id],
+          attribute_id: api_v3_volume.readonly_attribute.id,
+          other_attributes_ids: [],
           year_start: 2015,
           year_end: 2015
         )
@@ -36,7 +37,8 @@ RSpec.describe Api::V3::NodesStats::ResponseBuilder do
             nil,
             [api_v3_context.id],
             node_type_id: api_v3_country_node_type.id,
-            attributes_ids: [api_v3_volume.readonly_attribute.id],
+            attribute_id: api_v3_volume.readonly_attribute.id,
+            other_attributes_ids: [],
             year_start: 2016,
             year_end: 2015
           )
@@ -53,7 +55,8 @@ RSpec.describe Api::V3::NodesStats::ResponseBuilder do
             api_v3_soy.id,
             [api_v3_context.id],
             node_type_id: api_v3_country_node_type.id,
-            attributes_ids: [api_v3_volume.readonly_attribute.id],
+            attribute_id: api_v3_volume.readonly_attribute.id,
+            other_attributes_ids: [],
             year_start: 2015,
             year_end: 2015
           )
@@ -63,17 +66,32 @@ RSpec.describe Api::V3::NodesStats::ResponseBuilder do
       end
     end
 
-    context 'when a qual or ind is used as attributes_ids' do
+    context 'when a qual or ind is used as attribute_id' do
       it 'raise an error' do
         expect {
           Api::V3::NodesStats::ResponseBuilder.new(
             nil,
             [api_v3_context.id],
             node_type_id: api_v3_country_node_type.id,
-            attributes_ids: [
-              api_v3_volume.readonly_attribute.id,
-              api_v3_biome.readonly_attribute.id
-            ],
+            attribute_id: api_v3_biome.readonly_attribute.id,
+            year_start: 2015,
+            year_end: 2015
+          )
+        }.to raise_error(
+          "Attribute #{api_v3_biome.readonly_attribute.id} not found"
+        )
+      end
+    end
+
+    context 'when a qual or ind is used as other_attributes_ids' do
+      it 'raise an error' do
+        expect {
+          Api::V3::NodesStats::ResponseBuilder.new(
+            nil,
+            [api_v3_context.id],
+            node_type_id: api_v3_country_node_type.id,
+            attribute_id: api_v3_volume.readonly_attribute.id,
+            other_attributes_ids: [api_v3_biome.readonly_attribute.id],
             year_start: 2015,
             year_end: 2015
           )

--- a/spec/support/schemas/v3_nodes_stats.json
+++ b/spec/support/schemas/v3_nodes_stats.json
@@ -31,82 +31,150 @@
               1
             ]
           },
-          "attributes": {
-            "$id": "/properties/data/items/properties/attributes",
+          "top_nodes": {
+            "$id": "/properties/data/items/properties/top_nodes",
             "type": "array",
             "items": {
-              "$id": "/properties/data/items/properties/attributes/items",
+              "$id": "/properties/data/items/properties/top_nodes/items",
               "type": "object",
               "properties": {
                 "id": {
-                  "$id": "/properties/data/items/properties/attributes/items/properties/id",
+                  "$id": "/properties/data/items/properties/top_nodes/items/properties/id",
                   "type": "string, integer",
-                  "title": "Id of the attribute",
-                  "description": "Id of the attribute of a top destination",
+                  "title": "Id of the node",
+                  "description": "Id of the node of a top destination",
                   "default": 0,
                   "examples": [
                     684
                   ]
                 },
-                "indicator": {
-                  "$id": "/properties/data/items/properties/attributes/items/properties/indicator",
+                "name": {
+                  "$id": "/properties/data/items/properties/top_nodes/items/properties/name",
                   "type": "string",
-                  "title": "The Indicator Schema",
-                  "description": "An explanation about the purpose of this instance.",
-                  "default": "",
+                  "title": "Name of the node",
+                  "description": "Name of the node of a top destination",
+                  "default": 0,
                   "examples": [
-                    "Trade volume"
+                    684
                   ]
                 },
-                "unit": {
-                  "$id": "/properties/data/items/properties/attributes/items/properties/unit",
-                  "type": "string",
-                  "title": "The Unit Schema",
-                  "description": "An explanation about the purpose of this instance.",
-                  "default": "",
+                "geo_id": {
+                  "$id": "/properties/data/items/properties/top_nodes/items/properties/geo_id",
+                  "type": "string, null",
+                  "title": "Geo id of the node",
+                  "description": "Geo id of the node of a top destination",
+                  "default": 0,
                   "examples": [
-                    "Tn"
+                    684
                   ]
                 },
-                "targets": {
-                  "$id": "/properties/data/items/properties/attributes/items/properties/targets",
+                "attribute": {
+                  "$id": "/properties/data/items/properties/top_nodes/items/properties/attribute",
+                  "type": "object",
+                  "title": "Geo id of the node",
+                  "description": "Geo id of the node of a top destination",
+                  "properties": {
+                    "id": {
+                      "$id": "/properties/data/items/properties/top_nodes/items/properties/attribute/properties/id",
+                      "type": "string, integer",
+                      "title": "Id of the attribute",
+                      "description": "Id of the attribute",
+                      "default": "",
+                      "examples": [
+                        "7"
+                      ]
+                    },
+                    "indicator": {
+                      "$id": "/properties/data/items/properties/top_nodes/items/properties/attribute/properties/indicator",
+                      "type": "string",
+                      "title": "Indicator of the attribute",
+                      "description": "Indicator of the attribute",
+                      "default": "",
+                      "examples": [
+                        "CHINA"
+                      ]
+                    },
+                    "unit": {
+                      "$id": "/properties/data/items/properties/top_nodes/items/properties/attribute/properties/unit",
+                      "type": "string",
+                      "title": "Unit of the attribute",
+                      "description": "Unit of the attribute",
+                      "default": 0,
+                      "examples": [
+                        41375772
+                      ]
+                    },
+                    "value": {
+                      "$id": "/properties/data/items/properties/top_nodes/items/properties/attribute/properties/value",
+                      "type": "number",
+                      "title": "Amount of the top destination",
+                      "description": "Amount of a top destination",
+                      "default": 0,
+                      "examples": [
+                        41375772
+                      ]
+                    },
+                    "height": {
+                      "$id": "/properties/data/items/properties/top_nodes/items/properties/attribute/properties/height",
+                      "type": "number",
+                      "title": "Percentage amount of the top destination",
+                      "description": "Percentage of the node of a top destination",
+                      "default": 0,
+                      "examples": [
+                        41375772
+                      ]
+                    }
+                  }
+                },
+                "other_attributes": {
+                  "$id": "/properties/data/items/properties/top_nodes/items/properties/other_attribute",
                   "type": "array",
                   "items": {
-                    "$id": "/properties/data/items/properties/attributes/items/properties/targets/items",
+                    "$id": "/properties/data/items/properties/top_nodes/items/properties/other_attributes/items",
                     "type": "object",
                     "properties": {
                       "id": {
-                        "$id": "/properties/data/items/properties/attributes/items/properties/targets/items/properties/id",
+                        "$id": "/properties/data/items/properties/top_nodes/items/properties/other_attributes/items/properties/id",
                         "type": "string, integer",
-                        "title": "Id of the node",
-                        "description": "Id of the node",
+                        "title": "Id of the attribute",
+                        "description": "Id of the attribute",
+                        "default": "",
+                        "examples": [
+                          "7"
+                        ]
+                      },
+                      "indicator": {
+                        "$id": "/properties/data/items/properties/top_nodes/items/properties/other_attributes/items/properties/indicator",
+                        "type": "string",
+                        "title": "Indicator of the attribute",
+                        "description": "Indicator of the attribute",
                         "default": "",
                         "examples": [
                           "CHINA"
                         ]
                       },
-                      "name": {
-                        "$id": "/properties/data/items/properties/attributes/items/properties/targets/items/properties/name",
+                      "unit": {
+                        "$id": "/properties/data/items/properties/top_nodes/items/properties/other_attributes/items/properties/unit",
                         "type": "string",
-                        "title": "Name of the top destination",
-                        "description": "Name of the node of a top destination",
-                        "default": "",
+                        "title": "Unit of the attribute",
+                        "description": "Unit of the attribute",
+                        "default": 0,
                         "examples": [
-                          "CHINA"
+                          41375772
                         ]
                       },
                       "value": {
-                        "$id": "/properties/data/items/properties/attributes/items/properties/targets/items/properties/value",
+                        "$id": "/properties/data/items/properties/top_nodes/items/properties/other_attributes/items/properties/value",
                         "type": "number",
-                        "title": "Volume amount of the top destination",
-                        "description": "Amount of the node of a top destination",
+                        "title": "Amount of the top destination",
+                        "description": "Amount of a top destination",
                         "default": 0,
                         "examples": [
                           41375772
                         ]
                       },
                       "height": {
-                        "$id": "/properties/data/items/properties/attributes/items/properties/targets/items/properties/height",
+                        "$id": "/properties/data/items/properties/top_nodes/items/properties/other_attributes/items/properties/height",
                         "type": "number",
                         "title": "Percentage amount of the top destination",
                         "description": "Percentage of the node of a top destination",


### PR DESCRIPTION
Change `nodes_stats` endpoint for accepting `attribute_id` and `other_attributes_ids`. `attribute_id` parameter is used for returning the top nodes stats for it. On the other side, `other_attributes_ids` parameter is used in case it is needed to get more attribute stats for those obtained though `attribute_id`. The format for the response has changed according to these parameters:
```
data: [
  {
    context_id: 1,
    top_nodes: [
      {
        geo_id: "CO"
        id: 56,
        name: "COLOMBIA",
        indicator: {
          id: 8,
          indicator: 'Trade volume',
          value: 899832,
          height: 0.5501823465065846,
          unit: 't',
        },
        other_indicators: [
          {
            attribute_id: 7,
            name: 'Deforestation',
            value: 128,
            height: 0.5501823465065846,
            unit: 't'
          },
          ...
        ]
      }
    ]
  }
]
```