### PR TITLE
Feature/excluded nodes in parametrised charts endpoint

### DIFF
--- a/app/controllers/concerns/api/v3/dashboards/chart_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/chart_params.rb
@@ -23,6 +23,9 @@ module Api
             sources_ids: cs_string_to_int_array(params[:sources_ids]),
             companies_ids: cs_string_to_int_array(params[:companies_ids]),
             destinations_ids: cs_string_to_int_array(params[:destinations_ids]),
+            excluded_sources_ids: cs_string_to_int_array(params[:excluded_sources_ids]),
+            excluded_companies_ids: cs_string_to_int_array(params[:excluded_companies_ids]),
+            excluded_destinations_ids: cs_string_to_int_array(params[:excluded_destinations_ids]),
             node_type_id: string_to_int(params[:node_type_id]),
             top_n: string_to_int(params[:top_n]),
             single_filter_key: params[:single_filter_key]

--- a/app/services/api/v3/dashboards/chart_parameters/flow_values.rb
+++ b/app/services/api/v3/dashboards/chart_parameters/flow_values.rb
@@ -10,6 +10,9 @@ module Api
                       :sources_ids,
                       :companies_ids,
                       :destinations_ids,
+                      :excluded_sources_ids,
+                      :excluded_companies_ids,
+                      :excluded_destinations_ids,
                       :node_type,
                       :top_n,
                       :single_filter_key
@@ -20,6 +23,9 @@ module Api
           # @option params [Array<Integer>] sources_ids
           # @option params [Array<Integer>] companies_ids
           # @option params [Array<Integer>] destinations_ids
+          # @option params [Array<Integer>] excluded_sources_ids,
+          # @option params [Array<Integer>] excluded_companies_ids,
+          # @option params [Array<Integer>] excluded_destinations_ids,
           # @option params [Integer] node_type_id
           # @option params [Integer] top_n
           # @option params [String] single_filter_key
@@ -32,6 +38,9 @@ module Api
             @sources_ids = params[:sources_ids] || []
             @companies_ids = params[:companies_ids] || []
             @destinations_ids = params[:destinations_ids] || []
+            @excluded_sources_ids = params[:excluded_sources_ids] || []
+            @excluded_companies_ids = params[:excluded_companies_ids] || []
+            @excluded_destinations_ids = params[:excluded_destinations_ids] || []
             initialize_node_type(params[:node_type_id])
 
             @top_n = params[:top_n]
@@ -44,30 +53,63 @@ module Api
             Api::V3::NodeType.node_index_for_id(@context, @node_type.id)
           end
 
-          def nodes
-            return @nodes if defined? @nodes
+          def selected_nodes
+            return @selected_nodes if defined? @selected_nodes
 
-            @nodes = Api::V3::Node.where(
+            @selected_nodes = Api::V3::Node.where(
               id: @sources_ids + @companies_ids + @destinations_ids
             ).includes(:node_type)
           end
 
-          def nodes_ids_by_position
-            return @nodes_ids_by_position if defined? @nodes_ids_by_position
+          def selected_nodes_ids_by_position
+            if defined? @selected_nodes_ids_by_position
+              return @selected_nodes_ids_by_position
+            end
 
-            node_type_ids_to_positions = Hash[
+            @selected_nodes_ids_by_position =
+              nodes_ids_by_position(selected_nodes)
+          end
+
+          def excluded_nodes
+            return @excluded_nodes if defined? @excluded_nodes
+
+            @excluded_nodes = Api::V3::Node.where(
+              id: (
+                @excluded_sources_ids +
+                @excluded_companies_ids +
+                @excluded_destinations_ids
+              )
+            ).includes(:node_type)
+          end
+
+          def excluded_nodes_ids_by_position
+            if defined? @excluded_nodes_ids_by_position
+              return @excluded_nodes_ids_by_position
+            end
+
+            @excluded_nodes_ids_by_position =
+              nodes_ids_by_position(excluded_nodes)
+          end
+
+          private
+
+          def node_types_ids_to_positions
+            return @node_types_ids_to_positions if defined? @node_types_ids_positions
+
+            @node_types_ids_to_positions = Hash[
               @context.context_node_types.
                 select(:node_type_id, :column_position).map do |cnt|
                 [cnt.node_type_id, cnt.column_position]
               end
             ]
-            @nodes_ids_by_position = nodes.select(:id, :node_type_id).
-              group_by do |node|
-                node_type_ids_to_positions[node.node_type_id]
-              end
           end
 
-          private
+          def nodes_ids_by_position(nodes)
+            nodes.select(:id, :node_type_id).
+              group_by do |node|
+                node_types_ids_to_positions[node.node_type_id]
+              end
+          end
 
           def initialize_cont_attribute(cont_attribute_id)
             return unless cont_attribute_id.present?

--- a/app/services/api/v3/dashboards/parametrised_charts/flow_values_charts.rb
+++ b/app/services/api/v3/dashboards/parametrised_charts/flow_values_charts.rb
@@ -247,6 +247,9 @@ module Api
               sources_ids: @sources_ids.join(','),
               companies_ids: @companies_ids.join(','),
               destinations_ids: @destinations_ids.join(','),
+              excluded_sources_ids: @chart_params.excluded_sources_ids.join(','),
+              excluded_companies_ids: @chart_params.excluded_companies_ids.join(','),
+              excluded_destinations_ids: @chart_params.excluded_destinations_ids.join(','),
               start_year: @start_year,
               end_year: @end_year
             }

--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -9,7 +9,8 @@ module Api
         # cont_attribute_id - Quant for resizing
         # ncont_attribute_id - Ind / Qual for recoloring
         # (only one of these may be specified, Ind takes precedence)
-        # selected_nodes_ids - list of node ids for expanding.
+        # selected_nodes_ids - list of node ids for expanding
+        # excluded_nodes_ids
         # biome_id - id of biome to filter by
         # year_start
         # year_end

--- a/app/services/concerns/api/v3/dashboards/charts/flow_values_helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/flow_values_helpers.rb
@@ -52,11 +52,12 @@ module Api
           end
 
           def apply_flow_path_filters
-            @chart_parameters.nodes_ids_by_position.each do |position, nodes_ids|
-              @query = @query.where(
-                'flows.path[?] IN (?)', position + 1, nodes_ids
-              )
-            end
+            @chart_parameters.
+              selected_nodes_ids_by_position.each do |position, nodes_ids|
+                @query = @query.where(
+                  'flows.path[?] IN (?)', position + 1, nodes_ids
+                )
+              end
           end
 
           def node_type_axis_meta(node_type)
@@ -139,7 +140,7 @@ module Api
 
           def flow_path_filters
             flow_path_filters = {}
-            nodes = @chart_parameters.nodes
+            nodes = @chart_parameters.selected_nodes
             nodes_by_node_id = Hash[nodes.map { |node| [node.id, node] }]
             [:sources, :companies, :destinations].each do |filter_name|
               nodes_ids = @chart_parameters.send(:"#{filter_name}_ids")

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -1089,6 +1089,9 @@ paths:
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/start_year_req_query_param"
         - $ref: "#/components/parameters/end_year_opt_query_param"
       responses:
@@ -1745,6 +1748,27 @@ components:
         type: string
     dashboards_destinations_ids:
       name: destinations_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    excluded_dashboards_sources_ids:
+      name: excluded_sources_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    excluded_dashboards_companies_ids:
+      name: excluded_companies_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    excluded_dashboards_destinations_ids:
+      name: excluded_destinations_ids
       in: query
       description: String with comma-separated numeric ids
       required: false

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -3200,6 +3200,59 @@ components:
                     type: string
                     example: 'null'
                     nullable: true
+            excluded_sources:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  node_type_id:
+                    type: integer
+                  node_type:
+                    type: string
+                  profile:
+                    type: string
+                    example: 'place'
+                    nullable: true
+                    description: 'place or null'
+            excluded_companies:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  node_type_id:
+                    type: integer
+                  node_type:
+                    type: string
+                  profile:
+                    type: string
+                    example: 'actor'
+                    nullable: true
+                    description: 'actor or null'
+            excluded_destinations:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  name:
+                    type: string
+                  node_type_id:
+                    type: integer
+                  node_type:
+                    type: string
+                  profile:
+                    type: string
+                    example: 'null'
+                    nullable: true
         single_filter_key:
           type: string
           example: 'destinations'

--- a/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view_spec.rb
@@ -105,13 +105,30 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontNodeTypeView do
 
     context 'when filtered by 1 exporter' do
       let(:parameters_hash) {
-        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+        shared_parameters_hash.merge(companies_ids: [api_v3_exporter1_node.id])
       }
       it 'summarized flows matching exporter per ncont' do
         expect(data.size).to eq(1)
         expect(data[0][:x]).to eq(2015)
-        expect(data[0][exporter1_idx]).to be_nil
-        expect(data[0][other_exporter_idx]).to eq(25)
+        expect(data[0][exporter1_idx]).to eq(75)
+        expect(data[0][other_exporter_idx]).to be_nil
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 destination excluded' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [api_v3_exporter1_node.id],
+          excluded_destinations_ids: [
+            api_v3_other_country_of_destination_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching exporter per ncont' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][exporter1_idx]).to eq(55)
+        expect(data[0][other_exporter_idx]).to be_nil
       end
     end
 

--- a/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
@@ -45,12 +45,28 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontOverview do
 
     context 'when filtered by 1 exporter' do
       let(:parameters_hash) {
-        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+        shared_parameters_hash.merge(companies_ids: [api_v3_exporter1_node.id])
       }
       it 'summarized flows matching exporter per ncont' do
         expect(data.size).to eq(1)
         expect(data[0][:x]).to eq(2015)
-        expect(data[0][:y0]).to eq(25)
+        expect(data[0][:y0]).to eq(75)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 destination excluded' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [api_v3_exporter1_node.id],
+          excluded_destinations_ids: [
+            api_v3_other_country_of_destination_node.id
+          ]
+        )
+      }
+      it 'it summarized flows matching exporter' do
+        expect(data.size).to eq(1)
+        expect(data[0][:x]).to eq(2015)
+        expect(data[0][:y0]).to eq(55)
       end
     end
 

--- a/spec/services/api/v3/dashboards/charts/single_year_ncont_node_type_view_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_ncont_node_type_view_spec.rb
@@ -53,12 +53,26 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
 
     context 'when filtered by 1 exporter' do
       let(:parameters_hash) {
-        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+        shared_parameters_hash.merge(companies_ids: [api_v3_exporter1_node.id])
       }
       it 'it summarized flows matching exporter per biome' do
-        expect(data[0][:x0]).to eq(nil)
-        # y3 is the stack for value '3.0'
-        expect(data[0][:x3]).to eq(25)
+        expect(data[0][:x2]).to eq(20)
+        expect(data[0][:x3]).to be_nil
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 destination excluded' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [api_v3_exporter1_node.id],
+          excluded_destinations_ids: [
+            api_v3_other_country_of_destination_node.id
+          ]
+        )
+      }
+      it 'it summarized flows matching exporter per biome' do
+        expect(data[0][:x2]).to be_nil
+        expect(data[0][:x3]).to be_nil
       end
     end
 

--- a/spec/services/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
@@ -52,11 +52,26 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontOverview do
 
     context 'when filtered by 1 exporter' do
       let(:parameters_hash) {
-        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+        shared_parameters_hash.merge(companies_ids: [api_v3_exporter1_node.id])
       }
       it 'summarized flows matching exporter per ncont' do
-        expect(data.size).to eq(1)
-        expect(data[idx_of_x(data, 4.0)][:y0]).to eq(25)
+        expect(data.size).to eq(4)
+        expect(data[idx_of_x(data, 3.0)][:y0]).to eq(20)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 destination excluded' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [api_v3_exporter1_node.id],
+          excluded_destinations_ids: [
+            api_v3_other_country_of_destination_node.id
+          ]
+        )
+      }
+      it 'summarized flows matching exporter per ncont' do
+        expect(data.size).to eq(3)
+        expect(idx_of_x(data, 3.0)).to be_nil
       end
     end
 

--- a/spec/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view_spec.rb
@@ -94,10 +94,24 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontNodeTypeView do
 
     context 'when filtered by 1 exporter' do
       let(:parameters_hash) {
-        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+        shared_parameters_hash.merge(companies_ids: [api_v3_exporter1_node.id])
       }
       it 'it summarized flows matching exporter per biome' do
-        expect(data[0][:x0]).to eq(25)
+        expect(data[0][:x0]).to eq(75)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 destination excluded' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [api_v3_exporter1_node.id],
+          excluded_destinations_ids: [
+            api_v3_other_country_of_destination_node.id
+          ]
+        )
+      }
+      it 'it summarized flows matching exporter per biome' do
+        expect(data[0][:x0]).to eq(55)
       end
     end
 

--- a/spec/services/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
@@ -42,10 +42,24 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontOverview do
 
     context 'when filtered by 1 exporter' do
       let(:parameters_hash) {
-        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+        shared_parameters_hash.merge(companies_ids: [api_v3_exporter1_node.id])
       }
       it 'it summarized flows matching exporter' do
-        expect(data[0][:y0]).to eq(25)
+        expect(data[0][:y0]).to eq(75)
+      end
+    end
+
+    context 'when filtered by 1 exporter and 1 destination excluded' do
+      let(:parameters_hash) {
+        shared_parameters_hash.merge(
+          companies_ids: [api_v3_exporter1_node.id],
+          excluded_destinations_ids: [
+            api_v3_other_country_of_destination_node.id
+          ]
+        )
+      }
+      it 'it summarized flows matching exporter' do
+        expect(data[0][:y0]).to eq(55)
       end
     end
 

--- a/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
+++ b/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
@@ -25,7 +25,10 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
     {
       sources_ids: [],
       companies_ids: [],
-      destinations_ids: []
+      destinations_ids: [],
+      excluded_sources_ids: [],
+      excluded_companies_ids: [],
+      excluded_destinations_ids: []
     }
   }
   let(:single_year) { {start_year: 2017, end_year: 2017} }
@@ -227,6 +230,64 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
           break_by: :ncont_attribute,
           node_type_id: api_v3_exporter_node_type.id,
           companies_ids: [api_v3_exporter1_node.id],
+          single_filter_key: :companies,
+          grouping_key: :cont_attribute_id,
+          grouping_label: api_v3_exporter1_node.name
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_node_type_view,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+
+    it 'returns expected chart types' do
+      expect(chart_types).to match_array(expected_chart_types)
+    end
+  end
+
+  context 'when multiple years, non-cont indicator, 1 exporter, 1 excluded source' do
+    let(:overview_parameters) {
+      mandatory_parameters.merge(multi_year).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:parameters) {
+      overview_parameters.
+        merge(no_flow_path_filters).
+        merge(
+          companies_ids: [
+            api_v3_exporter1_node.id
+          ],
+          excluded_sources_ids: [api_v3_municipality_node.id]
+        )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute
+        },
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          node_type_id: api_v3_exporter_node_type.id,
+          companies_ids: [api_v3_exporter1_node.id],
+          excluded_sources_ids: [api_v3_municipality_node.id],
           single_filter_key: :companies,
           grouping_key: :cont_attribute_id,
           grouping_label: api_v3_exporter1_node.name

--- a/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
@@ -420,7 +420,10 @@
                 "ncont_attribute",
                 "sources",
                 "companies",
-                "destinations"
+                "destinations",
+                "excluded_sources",
+                "excluded_companies",
+                "excluded_destinations"
               ],
               "properties": {
                 "cont_attribute": {
@@ -441,6 +444,18 @@
                 },
                 "destinations": {
                   "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
+                },
+                "excluded_sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_sources",
+                  "type": "array"
+                },
+                "excluded_companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_companies",
+                  "type": "array"
+                },
+                "excluded_destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_destinations",
                   "type": "array"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_multi_year_no_ncont_node_type_view.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_no_ncont_node_type_view.json
@@ -288,7 +288,10 @@
                 "ncont_attribute",
                 "sources",
                 "companies",
-                "destinations"
+                "destinations",
+                "excluded_sources",
+                "excluded_companies",
+                "excluded_destinations"
               ],
               "properties": {
                 "cont_attribute": {
@@ -309,6 +312,18 @@
                 },
                 "destinations": {
                   "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
+                },
+                "excluded_sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_sources",
+                  "type": "array"
+                },
+                "excluded_companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_companies",
+                  "type": "array"
+                },
+                "excluded_destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_destinations",
                   "type": "array"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_no_ncont_overview.json
@@ -243,7 +243,10 @@
                 "ncont_attribute",
                 "sources",
                 "companies",
-                "destinations"
+                "destinations",
+                "excluded_sources",
+                "excluded_companies",
+                "excluded_destinations"
               ],
               "properties": {
                 "cont_attribute": {
@@ -264,6 +267,18 @@
                 },
                 "destinations": {
                   "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
+                },
+                "excluded_sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_sources",
+                  "type": "array"
+                },
+                "excluded_companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_companies",
+                  "type": "array"
+                },
+                "excluded_destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_destinations",
                   "type": "array"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_single_year_ncont_node_type_view.json
+++ b/spec/support/schemas/dashboards_charts_single_year_ncont_node_type_view.json
@@ -432,7 +432,10 @@
                 "ncont_attribute",
                 "sources",
                 "companies",
-                "destinations"
+                "destinations",
+                "excluded_sources",
+                "excluded_companies",
+                "excluded_destinations"
               ],
               "properties": {
                 "cont_attribute": {
@@ -453,6 +456,18 @@
                 },
                 "destinations": {
                   "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
+                },
+                "excluded_sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_sources",
+                  "type": "array"
+                },
+                "excluded_companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_companies",
+                  "type": "array"
+                },
+                "excluded_destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_destinations",
                   "type": "array"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_ncont_overview.json
@@ -243,7 +243,10 @@
                 "ncont_attribute",
                 "sources",
                 "companies",
-                "destinations"
+                "destinations",
+                "excluded_sources",
+                "excluded_companies",
+                "excluded_destinations"
               ],
               "properties": {
                 "cont_attribute": {
@@ -264,6 +267,18 @@
                 },
                 "destinations": {
                   "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
+                },
+                "excluded_sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_sources",
+                  "type": "array"
+                },
+                "excluded_companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_companies",
+                  "type": "array"
+                },
+                "excluded_destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_destinations",
                   "type": "array"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_single_year_no_ncont_node_type_view.json
+++ b/spec/support/schemas/dashboards_charts_single_year_no_ncont_node_type_view.json
@@ -244,7 +244,10 @@
                 "ncont_attribute",
                 "sources",
                 "companies",
-                "destinations"
+                "destinations",
+                "excluded_sources",
+                "excluded_companies",
+                "excluded_destinations"
               ],
               "properties": {
                 "cont_attribute": {
@@ -265,6 +268,18 @@
                 },
                 "destinations": {
                   "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
+                },
+                "excluded_sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_sources",
+                  "type": "array"
+                },
+                "excluded_companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_companies",
+                  "type": "array"
+                },
+                "excluded_destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_destinations",
                   "type": "array"
                 }
               }

--- a/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_single_year_no_ncont_overview.json
@@ -167,7 +167,10 @@
                 "ncont_attribute",
                 "sources",
                 "companies",
-                "destinations"
+                "destinations",
+                "excluded_sources",
+                "excluded_companies",
+                "excluded_destinations"
               ],
               "properties": {
                 "cont_attribute": {
@@ -188,6 +191,18 @@
                 },
                 "destinations": {
                   "$id": "#/properties/meta/properties/info/properties/filter/properties/destinations",
+                  "type": "array"
+                },
+                "excluded_sources": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_sources",
+                  "type": "array"
+                },
+                "excluded_companies": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_companies",
+                  "type": "array"
+                },
+                "excluded_destinations": {
+                  "$id": "#/properties/meta/properties/info/properties/filter/properties/excluded_destinations",
                   "type": "array"
                 }
               }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/167808485

https://www.pivotaltracker.com/story/show/167897916

Makes it possible to pass excluded_sources_ids, excluded_companies_ids and excluded_destinations_ids to the parametrised_charts endpoint and all the flow values chart endpoints.

For example:
http://0.0.0.0:3000/api/v3/dashboards/charts/single_year_no_ncont_overview?commodity_id=46&companies_ids=&cont_attribute_id=29&country_id=27&destinations_ids=&end_year=2017&excluded_companies_ids=&**excluded_destinations_ids=53**&excluded_sources_ids=&id=0&sources_ids=&start_year=2017&type=dynamic_sentence&top_n=9