### PR TITLE
Fix screen overflowing in firefox and short screens

### DIFF
--- a/frontend/scripts/react-components/explore/explore.scss
+++ b/frontend/scripts/react-components/explore/explore.scss
@@ -69,6 +69,11 @@ $explore-heading: 66px;
       @media (min-height: 700px) {
         min-height: 400px;
       }
+
+      @media (max-height: 480px) {
+        display: none;
+      }
+
     }
 
     .bubble {

--- a/frontend/scripts/react-components/explore/top-cards/top-cards.scss
+++ b/frontend/scripts/react-components/explore/top-cards/top-cards.scss
@@ -15,6 +15,7 @@
     background-color: $mid-light-gray;
     width: 100%;
     height: 120px;
+    overflow: hidden;
   }
 
   .back-button {


### PR DESCRIPTION
Firefox screen:

![image](https://user-images.githubusercontent.com/9701591/64973133-c143d980-d8aa-11e9-89ac-beb2a2cd2332.png)

Short chrome screen:

![image](https://user-images.githubusercontent.com/9701591/64973061-a40f0b00-d8aa-11e9-9534-89ee2695e3cb.png)
