### PR TITLE
Feature/nodes stats endpoint

### DIFF
--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -223,12 +223,16 @@ export const getTopCountries = (contexts, options = {}) => (dispatch, getState) 
   axios
     .get(topNodesUrl)
     .then(res => {
+      const contextId = res.data.context.id;
+      const updatedTopCountries = res.data.data.map(data => ({
+        data,
+        country: data.name,
+        topNodesKey: getTopNodesKey(contextId, 'country')
+      }));
+
       dispatch({
         type: APP__SET_TOP_DESTINATION_COUNTRIES,
-        payload: {
-          topNodesKeys,
-          topCountries: res.data.data
-        }
+        payload: { topCountries: updatedTopCountries }
       });
       dispatch({
         type: APP__SET_TOP_DESTINATION_COUNTRIES_LOADING,

--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -185,6 +185,7 @@ export const getTopCountries = contexts => (dispatch, getState) => {
   const selectedContexts = contexts || [defaultSelectedContext];
 
   const volumeIndicator = selectedContexts[0].resizeBy.find(i => i.name === 'Volume').attributeId;
+  const countryColumnId = selectedContexts[0].worldMap.countryColumnId;
 
   dispatch({
     type: APP__SET_TOP_DESTINATION_COUNTRIES_LOADING,
@@ -192,7 +193,8 @@ export const getTopCountries = contexts => (dispatch, getState) => {
   });
   const params = {
     contexts_ids: selectedContexts.map(c => c.id).join(),
-    attribute_id: volumeIndicator
+    attribute_id: volumeIndicator,
+    column_id: countryColumnId
   };
 
   const topNodesUrl = getURLFromParams(GET_TOP_NODE_STATS_URL, params);

--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -204,7 +204,7 @@ export const getTopCountries = (contexts, options = {}) => (dispatch, getState) 
 
   if (nonFetchedContexts.length === 0) return;
   const countryColumnId = nonFetchedContexts[0].worldMap.countryColumnId;
-  const volumeIndicator = nonFetchedContexts[0].resizeBy.find(i => i.name === 'Volume').id;
+  const volumeIndicator = nonFetchedContexts[0].resizeBy.find(i => i.name === 'Volume').attributeId;
 
   dispatch({
     type: APP__SET_TOP_DESTINATION_COUNTRIES_LOADING,
@@ -213,7 +213,6 @@ export const getTopCountries = (contexts, options = {}) => (dispatch, getState) 
       loading: true
     }
   });
-
   const params = {
     contexts_ids: nonFetchedContexts.map(c => c.id).join(),
     column_id: countryColumnId,
@@ -223,13 +222,19 @@ export const getTopCountries = (contexts, options = {}) => (dispatch, getState) 
   const topNodesUrl = getURLFromParams(GET_TOP_NODE_STATS_URL, params);
   axios
     .get(topNodesUrl)
-    .then(res => (res.ok ? res.json() : Promise.reject(res.statusText)))
     .then(res => {
       dispatch({
         type: APP__SET_TOP_DESTINATION_COUNTRIES,
         payload: {
           topNodesKeys,
-          data: res
+          topCountries: res.data.data
+        }
+      });
+      dispatch({
+        type: APP__SET_TOP_DESTINATION_COUNTRIES_LOADING,
+        payload: {
+          topNodesKeys,
+          loading: false
         }
       });
     })

--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -184,6 +184,7 @@ export const getTopCountries = contexts => (dispatch, getState) => {
   if (!defaultSelectedContext) return;
   const selectedContexts = contexts || [defaultSelectedContext];
 
+  // TODO move into context.worldMap
   const volumeIndicator = selectedContexts[0].resizeBy.find(i => i.name === 'Volume').attributeId;
   const countryColumnId = selectedContexts[0].worldMap.countryColumnId;
 
@@ -205,10 +206,12 @@ export const getTopCountries = contexts => (dispatch, getState) => {
         type: APP__SET_TOP_DESTINATION_COUNTRIES,
         payload: { topContextCountries: res.data.data }
       });
+    })
+    .catch(error => console.error(error))
+    .finally(() =>
       dispatch({
         type: APP__SET_TOP_DESTINATION_COUNTRIES_LOADING,
         payload: { loading: false }
-      });
-    })
-    .catch(error => console.error(error));
+      })
+    );
 };

--- a/frontend/scripts/react-components/explore/explore.component.jsx
+++ b/frontend/scripts/react-components/explore/explore.component.jsx
@@ -6,9 +6,7 @@ import TopCards from 'react-components/explore/top-cards';
 import Text from 'react-components/shared/text';
 import WorldMap from 'react-components/shared/world-map/world-map.container';
 import uniq from 'lodash/uniq';
-import last from 'lodash/last';
 import { EXPLORE_STEPS } from 'constants';
-import getTopNodesKey from 'utils/getTopNodesKey';
 import cx from 'classnames';
 import Responsive from 'react-components/shared/responsive.hoc';
 import { format } from 'd3-format';
@@ -52,15 +50,6 @@ function Explore({
     setModalOpen(false);
     setLinkInfo(null);
   };
-
-  const highlightedContextKey =
-    highlightedContext &&
-    getTopNodesKey(
-      highlightedContext.id,
-      'country',
-      last(highlightedContext.years),
-      last(highlightedContext.years)
-    );
 
   // Clear highlighted items on step change
   useEffect(() => {
@@ -128,7 +117,7 @@ function Explore({
 
   const setItemFunction = step === EXPLORE_STEPS.selectCommodity ? setCommodity : setCountry;
 
-  const destinationCountries = highlightedContextKey && topNodes[highlightedContextKey];
+  const destinationCountries = highlightedContext?.id && topNodes[highlightedContext.id];
   const getHighlightedCountryIds = useMemo(() => {
     switch (step) {
       case EXPLORE_STEPS.selectCommodity:

--- a/frontend/scripts/react-components/home/home.selectors.js
+++ b/frontend/scripts/react-components/home/home.selectors.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 import { getSelectedContext, getSelectedYears } from 'reducers/app.selectors';
-import getTopNodesKey from 'utils/getTopNodesKey';
 
 const getTopNodes = state => state.app.topNodes;
 
@@ -8,8 +7,6 @@ export const getDestinationCountries = createSelector(
   [getSelectedContext, getTopNodes, getSelectedYears],
   (selectedContext, topNodes, selectedYears) => {
     if (!selectedContext || !topNodes || !selectedYears) return null;
-    const [startYear, endYear] = selectedYears;
-    const countryKey = getTopNodesKey(selectedContext.id, 'country', startYear, endYear);
-    return topNodes[countryKey];
+    return topNodes[selectedContext.id];
   }
 );

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -80,7 +80,9 @@ export function* getToolLinksData() {
     }
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) console.error('Cancelled');
+      if (NODE_ENV_DEV) {
+        console.error('Cancelled');
+      }
       if (source) {
         source.cancel();
       }
@@ -99,7 +101,9 @@ export function* getToolColumnsData(selectedContext) {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) console.error('Cancelled');
+      if (NODE_ENV_DEV) {
+        console.error('Cancelled');
+      }
       if (source) {
         source.cancel();
       }
@@ -119,7 +123,9 @@ export function* getToolNodesByLink(selectedContext, { fetchAllNodes } = {}) {
     const difference = new Set(nodesInLinkPaths.filter(x => !existingNodes.has(`${x}`)));
 
     if (difference.size === 0) {
-      if (NODE_ENV_DEV) console.log('All necessary nodes have been downloaded');
+      if (NODE_ENV_DEV) {
+        console.log('All necessary nodes have been downloaded');
+      }
       return;
     }
     // we only want to fetch the missing nodes
@@ -143,7 +149,9 @@ export function* getToolNodesByLink(selectedContext, { fetchAllNodes } = {}) {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) console.error('Cancelled');
+      if (NODE_ENV_DEV) {
+        console.error('Cancelled');
+      }
       if (source) {
         source.cancel();
       }
@@ -167,7 +175,9 @@ export function* getToolGeoColumnNodes(selectedContext) {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) console.error('Cancelled');
+      if (NODE_ENV_DEV) {
+        console.error('Cancelled');
+      }
       if (source) {
         source.cancel();
       }
@@ -186,7 +196,9 @@ export function* getMissingLockedNodes() {
   const nodesIds = Array.from(lockedNodes).filter(lockedNode => !nodes[lockedNode]);
 
   if (nodesIds.length === 0) {
-    if (NODE_ENV_DEV) console.log('No missing nodes.');
+    if (NODE_ENV_DEV) {
+      console.log('No missing nodes.');
+    }
     return;
   }
   if (NODE_ENV_DEV) {
@@ -206,7 +218,9 @@ export function* getMissingLockedNodes() {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) console.error('Cancelled');
+      if (NODE_ENV_DEV) {
+        console.error('Cancelled');
+      }
       if (source) {
         source.cancel();
       }

--- a/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.fetch.saga.js
@@ -80,9 +80,7 @@ export function* getToolLinksData() {
     }
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) {
-        console.error('Cancelled');
-      }
+      if (NODE_ENV_DEV) console.error('Cancelled');
       if (source) {
         source.cancel();
       }
@@ -101,9 +99,7 @@ export function* getToolColumnsData(selectedContext) {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) {
-        console.error('Cancelled');
-      }
+      if (NODE_ENV_DEV) console.error('Cancelled');
       if (source) {
         source.cancel();
       }
@@ -123,9 +119,7 @@ export function* getToolNodesByLink(selectedContext, { fetchAllNodes } = {}) {
     const difference = new Set(nodesInLinkPaths.filter(x => !existingNodes.has(`${x}`)));
 
     if (difference.size === 0) {
-      if (NODE_ENV_DEV) {
-        console.log('All necessary nodes have been downloaded');
-      }
+      if (NODE_ENV_DEV) console.log('All necessary nodes have been downloaded');
       return;
     }
     // we only want to fetch the missing nodes
@@ -149,9 +143,7 @@ export function* getToolNodesByLink(selectedContext, { fetchAllNodes } = {}) {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) {
-        console.error('Cancelled');
-      }
+      if (NODE_ENV_DEV) console.error('Cancelled');
       if (source) {
         source.cancel();
       }
@@ -175,9 +167,7 @@ export function* getToolGeoColumnNodes(selectedContext) {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) {
-        console.error('Cancelled');
-      }
+      if (NODE_ENV_DEV) console.error('Cancelled');
       if (source) {
         source.cancel();
       }
@@ -196,9 +186,7 @@ export function* getMissingLockedNodes() {
   const nodesIds = Array.from(lockedNodes).filter(lockedNode => !nodes[lockedNode]);
 
   if (nodesIds.length === 0) {
-    if (NODE_ENV_DEV) {
-      console.log('No missing nodes.');
-    }
+    if (NODE_ENV_DEV) console.log('No missing nodes.');
     return;
   }
   if (NODE_ENV_DEV) {
@@ -218,9 +206,7 @@ export function* getMissingLockedNodes() {
     console.error('Error', e);
   } finally {
     if (yield cancelled()) {
-      if (NODE_ENV_DEV) {
-        console.error('Cancelled');
-      }
+      if (NODE_ENV_DEV) console.error('Cancelled');
       if (source) {
         source.cancel();
       }

--- a/frontend/scripts/reducers/app.initial-state.js
+++ b/frontend/scripts/reducers/app.initial-state.js
@@ -22,6 +22,7 @@ export default {
   topNodes: {},
   loading: {
     contexts: false,
-    tooltips: false
+    tooltips: false,
+    topCountries: false
   }
 };

--- a/frontend/scripts/reducers/app.reducer.js
+++ b/frontend/scripts/reducers/app.reducer.js
@@ -114,53 +114,40 @@ const appReducer = {
     return { ...state, selectedYears: initialState.selectedYears };
   },
   [APP__SET_TOP_DESTINATION_COUNTRIES](state, action) {
-    const { topCountries } = action.payload;
-    const getNodes = (data, country) =>
-      data.targetNodes.map(row => ({
-        ...row,
-        coordinates: COUNTRIES_COORDINATES[row.geo_id],
-        geoId: row.geo_id,
-        name: country === row.name ? 'DOMESTIC CONSUMPTION' : row.name
+    const { topContextCountries } = action.payload;
+    const { contexts } = state;
+
+    const getNodes = (countries, contextCountryName) =>
+      countries.map(c => ({
+        id: c.id,
+        value: c.attribute.value,
+        height: c.attribute.height,
+        coordinates: COUNTRIES_COORDINATES[c.geo_id],
+        geoId: c.geo_id,
+        name: contextCountryName === c.name ? 'DOMESTIC CONSUMPTION' : c.name,
+        otherIndicators: c.other_attributes
       }));
 
     const newTopCountries = {};
-    topCountries.forEach(c => {
-      newTopCountries[c.topNodesKey] = getNodes(c.data, c.country);
-    });
-
-    const topCountriesLoadingKeys = {};
-    topCountries.forEach(c => {
-      topCountriesLoadingKeys[c.topNodesKey] = false;
+    topContextCountries.forEach(c => {
+      const countryContext = contexts.find(context => c.context_id === context.id);
+      newTopCountries[c.context_id] = getNodes(c.top_nodes, countryContext?.countryName);
     });
     return {
       ...state,
       topNodes: {
         ...state.topNodes,
         ...newTopCountries
-      },
-      loading: {
-        ...state.loading,
-        topCountries: {
-          ...state.loading.topCountries,
-          ...topCountriesLoadingKeys
-        }
       }
     };
   },
   [APP__SET_TOP_DESTINATION_COUNTRIES_LOADING](state, action) {
-    const { topNodesKeys, loading } = action.payload;
-    const loadingNodes = {};
-    topNodesKeys.forEach(n => {
-      loadingNodes[n] = loading;
-    });
+    const { loading } = action.payload;
     return {
       ...state,
       loading: {
         ...state.loading,
-        topCountries: {
-          ...state.loading.topCountries,
-          ...loadingNodes
-        }
+        topCountries: loading
       }
     };
   }

--- a/frontend/scripts/tests/puppeteer/__recordings__/dashboard_3837856731/recording.har
+++ b/frontend/scripts/tests/puppeteer/__recordings__/dashboard_3837856731/recording.har
@@ -477,13 +477,17 @@
         }
       },
       {
-        "_id": "ca90eca4c4acc9ebd686041666f55002",
+        "_id": "5e1b5452fb3fd690b4f7e12b6d6a59ca",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
             {
               "name": "referer",
               "value": "http://0.0.0.0:8081/explore"
@@ -493,41 +497,28 @@
               "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/77.0.3844.0 Safari/537.36"
             }
           ],
-          "headersSize": 285,
+          "headersSize": 296,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
-          "queryString": [
-            {
-              "name": "start_year",
-              "value": "2017"
-            },
-            {
-              "name": "end_year",
-              "value": "2017"
-            },
-            {
-              "name": "column_id",
-              "value": "8"
-            }
-          ],
-          "url": "http://0.0.0.0:3000/api/v3/contexts/7/top_nodes?start_year=2017&end_year=2017&column_id=8"
+          "queryString": [],
+          "url": "http://0.0.0.0:3000/api/v3/commodities/46/countries_facts"
         },
         "response": {
-          "bodySize": 1035,
+          "bodySize": 668,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1035,
-            "text": "{\"data\":{\"context_id\":7,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"targetNodes\":[{\"id\":171,\"name\":\"PARAGUAY\",\"geo_id\":\"PY\",\"height\":0.3328367629541295,\"value\":208722.516512925},{\"id\":52,\"name\":\"CHILE\",\"geo_id\":\"CL\",\"height\":0.2158876230301401,\"value\":135383.506205577},{\"id\":184,\"name\":\"RUSSIAN FEDERATION\",\"geo_id\":\"RU\",\"height\":0.1815338806465775,\"value\":113840.21423779},{\"id\":35,\"name\":\"BRAZIL\",\"geo_id\":\"BR\",\"height\":0.047149050833532,\"value\":29567.2522885547},{\"id\":199,\"name\":\"VIETNAM\",\"geo_id\":\"VN\",\"height\":0.04181034109383152,\"value\":26219.3380680456},{\"id\":111,\"name\":\"ISRAEL\",\"geo_id\":\"IL\",\"height\":0.02976935958812865,\"value\":18668.4174940997},{\"id\":103,\"name\":\"HONG KONG\",\"geo_id\":\"HK\",\"height\":0.01792191538863865,\"value\":11238.8645035702},{\"id\":108,\"name\":\"IRAN\",\"geo_id\":\"IR\",\"height\":0.01703243045649781,\"value\":10681.0669460259},{\"id\":54,\"name\":\"TAIWAN\",\"geo_id\":\"TW\",\"height\":0.01671964309358637,\"value\":10484.9174433662},{\"id\":225,\"name\":\"EGYPT\",\"geo_id\":\"EG\",\"height\":0.01406730313698202,\"value\":8821.630414984251}]}}"
+            "size": 668,
+            "text": "{\"data\":[{\"countryId\":27,\"facts\":[{\"year\":2017,\"attributeId\":29,\"total\":1943066.42470546}]},{\"countryId\":50,\"facts\":[{\"year\":2017,\"attributeId\":29,\"total\":30879.1526721765}]},{\"countryId\":176,\"facts\":[{\"year\":2017,\"attributeId\":29,\"total\":627101.750000165}]}],\"meta\":{\"attributes\":[{\"id\":29,\"displayName\":\"Trade volume\",\"unit\":\"t\",\"tooltipText\":\"Amount of the traded commodity (tons). The total value is a composite of traded sub-products, which are converted to their original raw equivalents and then aggregated. For example exports of soy cake and soy oil are converted to soybean equivalents in the areas of production, where farmers are just producing beans.\"}]}}"
           },
           "cookies": [],
           "headers": [
             {
               "name": "x-runtime",
-              "value": "0.227261"
+              "value": "0.679100"
             },
             {
               "name": "etag",
-              "value": "W/\"ab5d36009f3e9868e3814cd20e3c8952\""
+              "value": "W/\"2d3e85d91694748a4f8d1a9ce7e823c7\""
             },
             {
               "name": "vary",
@@ -563,7 +554,7 @@
             },
             {
               "name": "x-request-id",
-              "value": "c2670813-8949-4139-b6ad-382a8b4b32ae"
+              "value": "7ce0b6d2-a6ba-415b-afe1-326e36f39bc6"
             },
             {
               "name": "access-control-expose-headers",
@@ -576,8 +567,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2019-09-18T18:17:28.994Z",
-        "time": 342,
+        "startedDateTime": "2019-09-20T16:28:52.416Z",
+        "time": 786,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -585,17 +576,21 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 342
+          "wait": 786
         }
       },
       {
-        "_id": "78b4d23ee0e82ba1c3433eeba77b2b07",
+        "_id": "27a17058def78a64ef6b874e8df9fa57",
         "_order": 0,
         "cache": {},
         "request": {
           "bodySize": 0,
           "cookies": [],
           "headers": [
+            {
+              "name": "accept",
+              "value": "application/json, text/plain, */*"
+            },
             {
               "name": "referer",
               "value": "http://0.0.0.0:8081/explore"
@@ -605,41 +600,41 @@
               "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/77.0.3844.0 Safari/537.36"
             }
           ],
-          "headersSize": 285,
+          "headersSize": 329,
           "httpVersion": "HTTP/1.1",
           "method": "GET",
           "queryString": [
             {
-              "name": "start_year",
-              "value": "2017"
+              "name": "contexts_ids",
+              "value": "6,7,46"
             },
             {
-              "name": "end_year",
-              "value": "2017"
+              "name": "attribute_id",
+              "value": "29"
             },
             {
               "name": "column_id",
               "value": "8"
             }
           ],
-          "url": "http://0.0.0.0:3000/api/v3/contexts/6/top_nodes?start_year=2017&end_year=2017&column_id=8"
+          "url": "http://0.0.0.0:3000/api/v3/nodes_stats?contexts_ids=6%2C7%2C46&attribute_id=29&column_id=8"
         },
         "response": {
-          "bodySize": 1056,
+          "bodySize": 5416,
           "content": {
             "mimeType": "application/json; charset=utf-8",
-            "size": 1056,
-            "text": "{\"data\":{\"context_id\":6,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"targetNodes\":[{\"id\":103,\"name\":\"HONG KONG\",\"geo_id\":\"HK\",\"height\":0.2088695349344581,\"value\":405847.380474996},{\"id\":53,\"name\":\"CHINA\",\"geo_id\":\"CN\",\"height\":0.1492437871755984,\"value\":289990.591956797},{\"id\":225,\"name\":\"EGYPT\",\"geo_id\":\"EG\",\"height\":0.1064249597976807,\"value\":206790.766133505},{\"id\":184,\"name\":\"RUSSIAN FEDERATION\",\"geo_id\":\"RU\",\"height\":0.09872006629578763,\"value\":191819.646264045},{\"id\":108,\"name\":\"IRAN\",\"geo_id\":\"IR\",\"height\":0.09203175177017187,\"value\":178823.806871451},{\"id\":52,\"name\":\"CHILE\",\"geo_id\":\"CL\",\"height\":0.04582657871100947,\"value\":89044.08645248591},{\"id\":228,\"name\":\"UNITED STATES\",\"geo_id\":\"US\",\"height\":0.03856075174989868,\"value\":74926.10203663159},{\"id\":192,\"name\":\"SAUDI ARABIA\",\"geo_id\":\"SA\",\"height\":0.02931960753239875,\"value\":56969.9449817462},{\"id\":226,\"name\":\"UNITED KINGDOM\",\"geo_id\":\"GB\",\"height\":0.02931647251876034,\"value\":56963.8534420044},{\"id\":112,\"name\":\"ITALY\",\"geo_id\":\"IT\",\"height\":0.02161726349239208,\"value\":42003.7788860788}]}}"
+            "size": 5416,
+            "text": "{\"data\":[{\"context_id\":6,\"top_nodes\":[{\"id\":103,\"name\":\"HONG KONG\",\"geo_id\":\"HK\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":405847.380474995,\"height\":0.208869534934461},\"other_attributes\":[]},{\"id\":53,\"name\":\"CHINA\",\"geo_id\":\"CN\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":289990.591956797,\"height\":0.1492437871756},\"other_attributes\":[]},{\"id\":225,\"name\":\"EGYPT\",\"geo_id\":\"EG\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":206790.766133505,\"height\":0.106424959797682},\"other_attributes\":[]},{\"id\":184,\"name\":\"RUSSIAN FEDERATION\",\"geo_id\":\"RU\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":191819.646264045,\"height\":0.09872006629578919},\"other_attributes\":[]},{\"id\":108,\"name\":\"IRAN\",\"geo_id\":\"IR\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":178823.806871451,\"height\":0.0920317517701732},\"other_attributes\":[]},{\"id\":52,\"name\":\"CHILE\",\"geo_id\":\"CL\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":89044.0864524861,\"height\":0.0458265787110102},\"other_attributes\":[]},{\"id\":228,\"name\":\"UNITED STATES\",\"geo_id\":\"US\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":74926.102036631,\"height\":0.0385607517498989},\"other_attributes\":[]},{\"id\":192,\"name\":\"SAUDI ARABIA\",\"geo_id\":\"SA\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":56969.9449817461,\"height\":0.0293196075323991},\"other_attributes\":[]},{\"id\":226,\"name\":\"UNITED KINGDOM\",\"geo_id\":\"GB\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":56963.8534420041,\"height\":0.0293164725187606},\"other_attributes\":[]},{\"id\":112,\"name\":\"ITALY\",\"geo_id\":\"IT\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":42003.7788860789,\"height\":0.0216172634923924},\"other_attributes\":[]}]},{\"context_id\":7,\"top_nodes\":[{\"id\":171,\"name\":\"PARAGUAY\",\"geo_id\":\"PY\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":208722.516512925,\"height\":0.33283676295413},\"other_attributes\":[]},{\"id\":52,\"name\":\"CHILE\",\"geo_id\":\"CL\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":135383.506205577,\"height\":0.215887623030141},\"other_attributes\":[]},{\"id\":184,\"name\":\"RUSSIAN FEDERATION\",\"geo_id\":\"RU\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":113840.21423779,\"height\":0.181533880646577},\"other_attributes\":[]},{\"id\":35,\"name\":\"BRAZIL\",\"geo_id\":\"BR\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":29567.2522885547,\"height\":0.0471490508335321},\"other_attributes\":[]},{\"id\":199,\"name\":\"VIETNAM\",\"geo_id\":\"VN\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":26219.3380680456,\"height\":0.0418103410938316},\"other_attributes\":[]},{\"id\":111,\"name\":\"ISRAEL\",\"geo_id\":\"IL\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":18668.4174940997,\"height\":0.0297693595881287},\"other_attributes\":[]},{\"id\":103,\"name\":\"HONG KONG\",\"geo_id\":\"HK\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":11238.8645035702,\"height\":0.0179219153886387},\"other_attributes\":[]},{\"id\":108,\"name\":\"IRAN\",\"geo_id\":\"IR\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":10681.0669460259,\"height\":0.0170324304564979},\"other_attributes\":[]},{\"id\":54,\"name\":\"TAIWAN\",\"geo_id\":\"TW\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":10484.9174433662,\"height\":0.0167196430935865},\"other_attributes\":[]},{\"id\":225,\"name\":\"EGYPT\",\"geo_id\":\"EG\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":8821.630414984251,\"height\":0.0140673031369821},\"other_attributes\":[]}]},{\"context_id\":46,\"top_nodes\":[{\"id\":124,\"name\":\"LEBANON\",\"geo_id\":\"LB\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":8018.522623243,\"height\":0.259674308695266},\"other_attributes\":[]},{\"id\":117,\"name\":\"JORDAN\",\"geo_id\":\"JO\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":7647.13442107098,\"height\":0.247647158659291},\"other_attributes\":[]},{\"id\":184,\"name\":\"RUSSIAN FEDERATION\",\"geo_id\":\"RU\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":5262.24915443149,\"height\":0.170414298938099},\"other_attributes\":[]},{\"id\":109,\"name\":\"IRAQ\",\"geo_id\":\"IQ\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":2617.28436868779,\"height\":0.0847589438892238},\"other_attributes\":[]},{\"id\":103,\"name\":\"HONG KONG\",\"geo_id\":\"HK\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":2218.7209082395,\"height\":0.071851741911256},\"other_attributes\":[]},{\"id\":199,\"name\":\"VIETNAM\",\"geo_id\":\"VN\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":2143.78851414338,\"height\":0.0694251081596234},\"other_attributes\":[]},{\"id\":225,\"name\":\"EGYPT\",\"geo_id\":\"EG\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":784.855336612096,\"height\":0.0254169971872086},\"other_attributes\":[]},{\"id\":154,\"name\":\"CURACAO\",\"geo_id\":\"CW\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":754.10821802803,\"height\":0.0244212730198233},\"other_attributes\":[]},{\"id\":128,\"name\":\"LIBYA\",\"geo_id\":\"LY\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":609.263023528688,\"height\":0.0197305615862206},\"other_attributes\":[]},{\"id\":173,\"name\":\"PERU\",\"geo_id\":\"PE\",\"attribute\":{\"id\":29,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"value\":364.8260364978,\"height\":0.0118146388397025},\"other_attributes\":[]}]}]}"
           },
           "cookies": [],
           "headers": [
             {
               "name": "x-runtime",
-              "value": "1.292344"
+              "value": "0.477259"
             },
             {
               "name": "etag",
-              "value": "W/\"65b12786f04cc4984321e2d31652c34a\""
+              "value": "W/\"0a7cf012d4276471b15cffff1395268b\""
             },
             {
               "name": "vary",
@@ -675,7 +670,7 @@
             },
             {
               "name": "x-request-id",
-              "value": "382df86b-0735-413a-9788-28a9f1787d5e"
+              "value": "35e42a1f-2088-4680-abe3-8b9f4007cdee"
             },
             {
               "name": "access-control-expose-headers",
@@ -688,8 +683,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2019-09-18T18:17:28.994Z",
-        "time": 1357,
+        "startedDateTime": "2019-09-20T16:28:52.885Z",
+        "time": 520,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -697,119 +692,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 1357
-        }
-      },
-      {
-        "_id": "73976a0469d25e5d4d9d6aa91607b094",
-        "_order": 0,
-        "cache": {},
-        "request": {
-          "bodySize": 0,
-          "cookies": [],
-          "headers": [
-            {
-              "name": "referer",
-              "value": "http://0.0.0.0:8081/explore"
-            },
-            {
-              "name": "user-agent",
-              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/77.0.3844.0 Safari/537.36"
-            }
-          ],
-          "headersSize": 286,
-          "httpVersion": "HTTP/1.1",
-          "method": "GET",
-          "queryString": [
-            {
-              "name": "start_year",
-              "value": "2017"
-            },
-            {
-              "name": "end_year",
-              "value": "2017"
-            },
-            {
-              "name": "column_id",
-              "value": "8"
-            }
-          ],
-          "url": "http://0.0.0.0:3000/api/v3/contexts/46/top_nodes?start_year=2017&end_year=2017&column_id=8"
-        },
-        "response": {
-          "bodySize": 1032,
-          "content": {
-            "mimeType": "application/json; charset=utf-8",
-            "size": 1032,
-            "text": "{\"data\":{\"context_id\":46,\"indicator\":\"Trade volume\",\"unit\":\"t\",\"targetNodes\":[{\"id\":124,\"name\":\"LEBANON\",\"geo_id\":\"LB\",\"height\":0.2596743086952658,\"value\":8018.522623243},{\"id\":117,\"name\":\"JORDAN\",\"geo_id\":\"JO\",\"height\":0.2476471586592915,\"value\":7647.13442107098},{\"id\":184,\"name\":\"RUSSIAN FEDERATION\",\"geo_id\":\"RU\",\"height\":0.1704142989380992,\"value\":5262.24915443149},{\"id\":109,\"name\":\"IRAQ\",\"geo_id\":\"IQ\",\"height\":0.0847589438892237,\"value\":2617.28436868778},{\"id\":103,\"name\":\"HONG KONG\",\"geo_id\":\"HK\",\"height\":0.07185174191125611,\"value\":2218.7209082395},{\"id\":199,\"name\":\"VIETNAM\",\"geo_id\":\"VN\",\"height\":0.06942510815962348,\"value\":2143.78851414338},{\"id\":225,\"name\":\"EGYPT\",\"geo_id\":\"EG\",\"height\":0.02541699718720863,\"value\":784.855336612096},{\"id\":154,\"name\":\"CURACAO\",\"geo_id\":\"CW\",\"height\":0.02442127301982335,\"value\":754.10821802803},{\"id\":128,\"name\":\"LIBYA\",\"geo_id\":\"LY\",\"height\":0.01973056158622064,\"value\":609.263023528688},{\"id\":173,\"name\":\"PERU\",\"geo_id\":\"PE\",\"height\":0.01181463883970251,\"value\":364.8260364978}]}}"
-          },
-          "cookies": [],
-          "headers": [
-            {
-              "name": "x-runtime",
-              "value": "0.061891"
-            },
-            {
-              "name": "etag",
-              "value": "W/\"0907255031bc91c5b2f73b9ebb3db211\""
-            },
-            {
-              "name": "vary",
-              "value": "Origin"
-            },
-            {
-              "name": "access-control-allow-methods",
-              "value": "GET, POST, OPTIONS"
-            },
-            {
-              "name": "content-type",
-              "value": "application/json; charset=utf-8"
-            },
-            {
-              "name": "access-control-allow-origin",
-              "value": "http://0.0.0.0:8081"
-            },
-            {
-              "name": "access-control-max-age",
-              "value": "1728000"
-            },
-            {
-              "name": "cache-control",
-              "value": "max-age=0, private, must-revalidate"
-            },
-            {
-              "name": "access-control-allow-credentials",
-              "value": "true"
-            },
-            {
-              "name": "transfer-encoding",
-              "value": "chunked"
-            },
-            {
-              "name": "x-request-id",
-              "value": "6371b8a1-1545-4801-b364-21397afd80c4"
-            },
-            {
-              "name": "access-control-expose-headers",
-              "value": ""
-            }
-          ],
-          "headersSize": 466,
-          "httpVersion": "HTTP/1.1",
-          "redirectURL": "",
-          "status": 200,
-          "statusText": "OK"
-        },
-        "startedDateTime": "2019-09-18T18:17:28.996Z",
-        "time": 132,
-        "timings": {
-          "blocked": -1,
-          "connect": -1,
-          "dns": -1,
-          "receive": 0,
-          "send": 0,
-          "ssl": -1,
-          "wait": 132
+          "wait": 520
         }
       }
     ],

--- a/frontend/scripts/utils/getTopNodesKey.js
+++ b/frontend/scripts/utils/getTopNodesKey.js
@@ -1,2 +1,4 @@
 export default (ctx, col, start, end) =>
-  ctx && col && start && end ? `CTX${ctx}_COL${col}_START${start}_END${end}` : null;
+  ctx && col && start && end
+    ? `CTX${ctx}_COL${col}${start ? `_START${start}` : ''}${end ? `_END${end}` : ''}`
+    : null;

--- a/frontend/scripts/utils/getURLFromParams.js
+++ b/frontend/scripts/utils/getURLFromParams.js
@@ -22,6 +22,7 @@ export const GET_TESTIMONIALS_URL = 'GET_TESTIMONIALS_URL';
 export const GET_MARKDOWN_CONTENT_URL = 'GET_MARKDOWN_CONTENT_URL';
 export const GET_TEAM_URL = 'GET_TEAM_URL';
 export const GET_TOP_NODES_URL = 'GET_TOP_NODES_URL';
+export const GET_TOP_NODE_STATS_URL = 'GET_TOP_NODE_STATS_URL';
 export const GET_NODE_SUMMARY_URL = 'GET_NODE_SUMMARY_URL';
 export const GET_PROFILE_METADATA = 'GET_PROFILE_METADATA';
 export const GET_PLACE_INDICATORS = 'GET_PLACE_INDICATORS';
@@ -68,6 +69,7 @@ const API_ENDPOINTS = {
     mock: '/mocks/v3_get_team.json'
   },
   [GET_TOP_NODES_URL]: { api: 3, endpoint: '/contexts/$context_id$/top_nodes' },
+  [GET_TOP_NODE_STATS_URL]: { api: 3, endpoint: '/nodes_stats' },
   [GET_NODE_SUMMARY_URL]: {
     api: 3,
     endpoint: '/contexts/$context_id$/$profile_type$s/$node_id$/basic_attributes'


### PR DESCRIPTION
- Use the new nodes_stats endpoint to retrieve the flows for the world maps
- The keys for the top nodes have been removed as the browser will cache the responses
- The top nodes keys are still used on the legacy-explore. That has a different endpoint, action, and reducer. And should be removed when is not used anymore