### PR TITLE
We need the vanilla tooltip as we use an ejs

### DIFF
--- a/frontend/scripts/react-components/tool/tool.component.jsx
+++ b/frontend/scripts/react-components/tool/tool.component.jsx
@@ -10,6 +10,7 @@ import MapContextContainer from 'react-components/tool/map-context/map-context.c
 import Sankey from 'react-components/tool/sankey';
 import MapLegend from 'react-components/tool/map-legend/map-legend.container';
 import MapDimensionsContainer from 'react-components/tool/map-dimensions/map-dimensions.react';
+import Tooltip from 'react-components/tool/help-tooltip/help-tooltip.container';
 import Basemaps from 'react-components/tool/basemaps';
 import LegacyBasemaps from 'react-components/tool/legacy-basemaps/legacy-basemaps.container';
 import EventManager from 'utils/eventManager';
@@ -95,6 +96,7 @@ const renderVainillaComponents = () => (
     <MapDimensionsContainer />
     <FlowContentContainer />
     <MapLegend />
+    <Tooltip />
     {!ENABLE_REDESIGN_PAGES && <LegacyBasemaps />}
     <MapContextContainer />
     <NodesTitlesContainer />


### PR DESCRIPTION
The tooltip was missing on the layers info. As we use an ejs template in the map-dimensions component we cant use the react tooltip so we need to load the vanilla tooltip to the tool.

![image](https://user-images.githubusercontent.com/9701591/65133566-1dba0c80-da03-11e9-8321-a123373576a6.png)
