### PR TITLE
Removed parent name & node type from sources response

### DIFF
--- a/app/models/api/v3/chart.rb
+++ b/app/models/api/v3/chart.rb
@@ -2,12 +2,12 @@
 #
 # Table name: charts
 #
-#  id                                                                                                :integer          not null, primary key
-#  profile_id                                                                                        :integer          not null
-#  parent_id(Self-reference to parent used to define complex charts, e.g. table with values in tabs) :integer
-#  identifier(Identifier used to map this chart to a part of code which contains calculation logic)  :text             not null
-#  title(Title of chart for display)                                                                 :text             not null
-#  position(Display order in scope of profile)                                                       :integer          not null
+#  id                                                                                                                      :integer          not null, primary key
+#  profile_id                                                                                                              :integer          not null
+#  parent_id(Self-reference to parent used to define complex charts, e.g. table with values in tabs)                       :integer
+#  identifier(Identifier used to map this chart to a part of code which contains calculation logic)                        :text             not null
+#  title(Title of chart for display; you can use {{commodity_name}}, {{company_name}}, {{jurisdiction_name}} and {{year}}) :text             not null
+#  position(Display order in scope of profile)                                                                             :integer          not null
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/dashboards/commodity.rb
+++ b/app/models/api/v3/readonly/dashboards/commodity.rb
@@ -2,12 +2,12 @@
 #
 # Table name: dashboards_commodities_mv
 #
-#  id            :integer          primary key
-#  name          :text
-#  name_tsvector :tsvector
-#  country_id    :integer
-#  node_id       :integer
-#  profile       :text
+#  id(id of commodity (not unique))                                               :integer          primary key
+#  country_id(id of country, from which this commodity is sourced)                :integer
+#  node_id(id of node, through which this commodity is sourced from this country) :integer
+#  name                                                                           :text
+#  name_tsvector                                                                  :tsvector
+#  profile                                                                        :text
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/dashboards/company.rb
+++ b/app/models/api/v3/readonly/dashboards/company.rb
@@ -2,15 +2,15 @@
 #
 # Table name: dashboards_companies_mv
 #
-#  id            :integer          primary key
-#  name          :text
-#  name_tsvector :tsvector
-#  node_type_id  :integer
-#  node_type     :text
-#  profile       :text
-#  country_id    :integer
-#  commodity_id  :integer
-#  node_id       :integer
+#  id(id of company node (not unique))                              :integer          primary key
+#  name                                                             :text
+#  name_tsvector                                                    :tsvector
+#  node_type_id                                                     :integer
+#  node_type                                                        :text
+#  profile                                                          :text
+#  country_id(id of country sourcing commodity traded by this node) :integer
+#  commodity_id(id of commodity traded by this node)                :integer
+#  node_id(id of another node from the same supply chain)           :integer
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/dashboards/country.rb
+++ b/app/models/api/v3/readonly/dashboards/country.rb
@@ -2,13 +2,13 @@
 #
 # Table name: dashboards_countries_mv
 #
-#  id            :integer          primary key
-#  commodity_id  :integer
-#  node_id       :integer
-#  iso2          :text
-#  name          :text
-#  name_tsvector :tsvector
-#  profile       :text
+#  id(id of sourcing country (not unique))                                        :integer          primary key
+#  commodity_id(id of commodity sourced from this country)                        :integer
+#  node_id(id of node, through which this commodity is sourced from this country) :integer
+#  iso2                                                                           :text
+#  name                                                                           :text
+#  name_tsvector                                                                  :tsvector
+#  profile                                                                        :text
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/dashboards/destination.rb
+++ b/app/models/api/v3/readonly/dashboards/destination.rb
@@ -2,15 +2,15 @@
 #
 # Table name: dashboards_destinations_mv
 #
-#  id            :integer          primary key
-#  name          :text
-#  name_tsvector :tsvector
-#  node_type_id  :integer
-#  node_type     :text
-#  profile       :text
-#  country_id    :integer
-#  commodity_id  :integer
-#  node_id       :integer
+#  id(id of destination node (not unique))                         :integer          primary key
+#  name                                                            :text
+#  name_tsvector                                                   :tsvector
+#  node_type_id                                                    :integer
+#  node_type                                                       :text
+#  profile                                                         :text
+#  country_id(id of country sourcing commodity going to this node) :integer
+#  commodity_id(id of commodity going to this node)                :integer
+#  node_id(id of another node from the same supply chain)          :integer
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/dashboards/source.rb
+++ b/app/models/api/v3/readonly/dashboards/source.rb
@@ -2,23 +2,20 @@
 #
 # Table name: dashboards_sources_mv
 #
-#  id               :integer          primary key
-#  name             :text
-#  name_tsvector    :tsvector
-#  node_type_id     :integer
-#  node_type        :text
-#  profile          :text
-#  parent_node_type :text
-#  parent_name      :text
-#  country_id       :integer
-#  commodity_id     :integer
-#  node_id          :integer
+#  id            :integer          primary key
+#  name          :text
+#  name_tsvector :tsvector
+#  node_type_id  :integer
+#  node_type     :text
+#  profile       :text
+#  country_id    :integer
+#  commodity_id  :integer
+#  node_id       :integer
 #
 # Indexes
 #
 #  dashboards_sources_mv_commodity_id_idx   (commodity_id)
 #  dashboards_sources_mv_country_id_idx     (country_id)
-#  dashboards_sources_mv_group_columns_idx  (id,name,node_type,parent_name,parent_node_type)
 #  dashboards_sources_mv_name_idx           (name)
 #  dashboards_sources_mv_name_tsvector_idx  (name_tsvector) USING gin
 #  dashboards_sources_mv_node_id_idx        (node_id)

--- a/app/models/api/v3/readonly/dashboards_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards_attribute.rb
@@ -2,10 +2,10 @@
 #
 # Table name: dashboards_attributes_mv
 #
-#  id                            :bigint(8)        primary key
-#  dashboards_attribute_group_id :bigint(8)
-#  position                      :integer
-#  attribute_id                  :bigint(8)
+#  id                                                       :bigint(8)        primary key
+#  dashboards_attribute_group_id                            :bigint(8)
+#  position                                                 :integer
+#  attribute_id(References the unique id in attributes_mv.) :bigint(8)
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -2,14 +2,14 @@
 #
 # Table name: download_attributes_mv
 #
-#  id            :integer          primary key
-#  context_id    :integer
-#  position      :integer
-#  display_name  :text
-#  years         :integer          is an Array
-#  attribute_id  :bigint(8)
-#  original_type :text
-#  original_id   :integer
+#  id                                                       :integer          primary key
+#  context_id                                               :integer
+#  position                                                 :integer
+#  display_name                                             :text
+#  years                                                    :integer          is an Array
+#  attribute_id(References the unique id in attributes_mv.) :bigint(8)
+#  original_type                                            :text
+#  original_id                                              :integer
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/flow_node.rb
+++ b/app/models/api/v3/readonly/flow_node.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: flow_nodes_mv
+#
+#  context_id :integer
+#  flow_id    :integer
+#  year       :integer
+#  position   :bigint(8)
+#  node_id    :integer
+#
+# Indexes
+#
+#  flow_nodes_mv_flow_id_node_id_idx  (flow_id,node_id) UNIQUE
+#
+
 # This materialised view does not depend on any yellow tables.
 # It should only be refreshed once per data import.
 module Api

--- a/app/serializers/api/v3/dashboards/source_serializer.rb
+++ b/app/serializers/api/v3/dashboards/source_serializer.rb
@@ -2,7 +2,7 @@ module Api
   module V3
     module Dashboards
       class SourceSerializer < ActiveModel::Serializer
-        attributes :id, :name, :parent_name, :parent_node_type
+        attributes :id, :name
         attribute :node_type do
           object['node_type']
         end

--- a/app/services/api/v3/dashboards/filter_sources.rb
+++ b/app/services/api/v3/dashboards/filter_sources.rb
@@ -21,17 +21,13 @@ module Api
               :id,
               :name,
               :node_type,
-              :node_type_id,
-              :parent_name,
-              :parent_node_type
+              :node_type_id
             ).
             group(
               :id,
               :name,
               :node_type,
-              :node_type_id,
-              :parent_name,
-              :parent_node_type
+              :node_type_id
             ).
             order(:name)
         end

--- a/db/migrate/20190919063754_remove_parent_node_from_dashboards_sources_mv.rb
+++ b/db/migrate/20190919063754_remove_parent_node_from_dashboards_sources_mv.rb
@@ -1,0 +1,8 @@
+class RemoveParentNodeFromDashboardsSourcesMv < ActiveRecord::Migration[5.2]
+  def change
+    update_view :dashboards_sources_mv,
+      materialized: true,
+      version: 7,
+      revert_to_version: 6
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3551,19 +3551,13 @@ CREATE MATERIALIZED VIEW public.dashboards_sources_mv AS
                 CASE
                     WHEN ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text)) THEN cnt.profile
                     ELSE NULL::text
-                END AS profile,
-            quals.name AS parent_node_type,
-            node_quals.value AS parent_name
-           FROM (((((((((flow_nodes
-             JOIN public.contexts ON ((contexts.id = flow_nodes.context_id)))
+                END AS profile
+           FROM (((((flow_nodes
              JOIN public.nodes ON ((nodes.id = flow_nodes.node_id)))
              JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
              JOIN public.node_types ON ((node_types.id = nodes.node_type_id)))
-             JOIN active_cnt cnt ON (((cnt.context_id = flow_nodes.context_id) AND (contexts.id = cnt.context_id) AND ((cnt.column_position + 1) = flow_nodes."position"))))
-             LEFT JOIN public.context_node_types prev_cnt ON (((prev_cnt.context_id = flow_nodes.context_id) AND (prev_cnt.context_id = cnt.context_id) AND (contexts.id = prev_cnt.context_id) AND ((prev_cnt.column_position + 1) = cnt.column_position))))
-             LEFT JOIN public.node_types prev_nt ON ((prev_nt.id = prev_cnt.node_type_id)))
-             LEFT JOIN public.quals ON ((quals.name = prev_nt.name)))
-             LEFT JOIN public.node_quals ON (((flow_nodes.node_id = node_quals.node_id) AND (quals.id = node_quals.qual_id))))
+             JOIN active_cnt cnt ON (((cnt.context_id = flow_nodes.context_id) AND ((cnt.column_position + 1) = flow_nodes."position"))))
+             JOIN public.contexts ON (((contexts.id = flow_nodes.context_id) AND (contexts.id = cnt.context_id))))
           WHERE ((cnt.role)::text = 'source'::text)
         )
  SELECT ffn.node_id AS id,
@@ -3574,13 +3568,11 @@ CREATE MATERIALIZED VIEW public.dashboards_sources_mv AS
     ffn.profile,
     ffn.country_id,
     ffn.commodity_id,
-    ffn.parent_node_type,
-    ffn.parent_name,
     fn.node_id
    FROM (filtered_flow_nodes ffn
      JOIN flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
   WHERE (ffn.node_id <> fn.node_id)
-  GROUP BY ffn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type_id, ffn.node_type, ffn.profile, ffn.country_id, ffn.commodity_id, ffn.parent_node_type, ffn.parent_name, fn.node_id
+  GROUP BY ffn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type_id, ffn.node_type, ffn.profile, ffn.country_id, ffn.commodity_id, fn.node_id
   WITH NO DATA;
 
 
@@ -7959,13 +7951,6 @@ CREATE INDEX dashboards_sources_mv_country_id_idx ON public.dashboards_sources_m
 
 
 --
--- Name: dashboards_sources_mv_group_columns_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX dashboards_sources_mv_group_columns_idx ON public.dashboards_sources_mv USING btree (id, name, node_type, parent_name, parent_node_type);
-
-
---
 -- Name: dashboards_sources_mv_name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -9292,6 +9277,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190807095141'),
 ('20190814161133'),
 ('20190820105523'),
-('20190823135415');
+('20190823135415'),
+('20190919063754');
 
 

--- a/db/views/dashboards_sources_mv_v07.sql
+++ b/db/views/dashboards_sources_mv_v07.sql
@@ -1,0 +1,72 @@
+WITH active_cnt AS (
+  SELECT context_id, column_position, cnt_props.role, profiles.name AS profile
+  FROM context_node_types cnt
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  WHERE cnt_props.role IS NOT NULL
+), flow_nodes AS (
+  SELECT
+    flow_nodes.context_id,
+    flow_id,
+    node_id,
+    position
+  FROM (
+    SELECT
+      context_id,
+      flow_id,
+      node_id,
+      position
+    FROM flow_nodes_mv
+  ) flow_nodes
+  JOIN active_cnt ON flow_nodes.context_id = active_cnt.context_id
+    AND flow_nodes.position = active_cnt.column_position + 1
+), filtered_flow_nodes AS (
+  SELECT
+  flow_nodes.flow_id,
+  flow_nodes.node_id,
+  nodes.node_type_id,
+  contexts.country_id,
+  contexts.commodity_id,
+  TRIM(nodes.name) AS name,
+  TO_TSVECTOR('simple', COALESCE(TRIM(nodes.name)::TEXT, '')) AS name_tsvector,
+  node_types.name AS node_type,
+  CASE
+    -- this is the same condition as in nodes_mv
+    WHEN nodes.is_unknown = FALSE AND node_properties.is_domestic_consumption = FALSE AND nodes.name NOT ILIKE 'OTHER'
+    THEN cnt.profile
+    ELSE NULL
+  END AS profile
+  FROM flow_nodes
+  JOIN nodes ON nodes.id = flow_nodes.node_id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN node_types ON node_types.id = nodes.node_type_id
+  JOIN active_cnt cnt ON cnt.context_id = flow_nodes.context_id
+    AND cnt.column_position + 1 = flow_nodes.position
+  JOIN contexts ON contexts.id = flow_nodes.context_id AND contexts.id = cnt.context_id
+  WHERE cnt.role = 'source'
+)
+SELECT
+  ffn.node_id AS id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type_id,
+  ffn.node_type,
+  ffn.profile,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id
+FROM filtered_flow_nodes ffn
+JOIN flow_nodes fn
+ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type_id,
+  ffn.node_type,
+  ffn.profile,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id
+);


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168571749

This is to fix the bug with duplicated states in dashboards filters. The root cause of the bug is that Brazil states are returned twice, once with a parent (biome) as inferred from Brazil-soy supply chain, and once without a parent, as inferred from the Brazil-beef supply chain, which has no biomes. Clearly, this is not a good way to infer about parent nodes. I think these properties were not used anyway in the frontend (@sorodrigo ?), so I think it's better to remove and figure out a better way to do it without knowing which commodity we're looking at.