### PR TITLE
Feature/stabilise attribute ids

### DIFF
--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -1,51 +1,73 @@
 # == Schema Information
 #
-# Table name: attributes_mv
+# Table name: attributes
 #
-#  id(The unique id is a sequential number which is generated at REFRESH and therefore not fixed.) :bigint(8)        primary key
-#  original_type(Type of the original entity (Ind / Qual / Quant))                                 :text
-#  original_id(Id from the original table (inds / quals / quants))                                 :integer
-#  name                                                                                            :text
-#  display_name                                                                                    :text
-#  unit                                                                                            :text
-#  unit_type                                                                                       :text
-#  tooltip_text                                                                                    :text
-#  is_visible_on_actor_profile                                                                     :boolean
-#  is_visible_on_place_profile                                                                     :boolean
-#  is_temporal_on_actor_profile                                                                    :boolean
-#  is_temporal_on_place_profile                                                                    :boolean
-#  aggregate_method                                                                                :text
+#  id(Id is fixed between data updates, unless name changes)       :bigint(8)        not null, primary key
+#  original_id(Id from the original table (inds / quals / quants)) :integer          not null
+#  original_type(Type of the original entity (Ind / Qual / Quant)) :text             not null
+#  name                                                            :text             not null
+#  display_name                                                    :text
+#  unit                                                            :text
+#  unit_type                                                       :text
+#  tooltip_text                                                    :text
 #
 # Indexes
 #
-#  attributes_mv_id_idx    (id) UNIQUE
-#  attributes_mv_name_idx  (name) UNIQUE
+#  attributes_original_type_name_idx  (original_type,name) UNIQUE
 #
 
+# This class is not backed by a materialized view, but a table.
+# The table is refreshed using Postgres "upsert" to preserve ids.
+# The upsert is defined in a SQL function.
 module Api
   module V3
     module Readonly
       class Attribute < Api::V3::Readonly::BaseModel
-        self.table_name = 'attributes_mv'
-        self.primary_key = 'id'
+        self.table_name = 'attributes'
 
         delegate :values_meta, to: :original_attribute
 
-        def self.select_options
-          order(:display_name).map do |a|
-            ["#{a.display_name} (#{a.name})", a.id]
+        class << self
+          def select_options
+            order(:display_name).map do |a|
+              ["#{a.display_name} (#{a.name})", a.id]
+            end
           end
-        end
 
-        def self.refresh_dependents(options = {})
-          [
-            Api::V3::Readonly::DownloadAttribute,
-            Api::V3::Readonly::MapAttribute,
-            Api::V3::Readonly::RecolorByAttribute,
-            Api::V3::Readonly::ResizeByAttribute,
-            Api::V3::Readonly::DashboardsAttribute
-          ].each do |mview_klass|
-            mview_klass.refresh(options.merge(skip_dependencies: true))
+          # @param options
+          # @option options [Boolean] :skip_dependencies skip refreshing
+          # @option options [Boolean] :skip_dependents skip refreshing
+          def refresh_now(options = {})
+            refresh_dependencies(options) unless options[:skip_dependencies]
+            upsert_attributes
+            refresh_dependents(options) unless options[:skip_dependents]
+          end
+
+          # @param options
+          # @option options [Boolean] :skip_dependencies skip refreshing
+          # @option options [Boolean] :skip_dependents skip refreshing
+          def refresh_later(options = {})
+            UpsertAttributesWorker.perform_async(options)
+          end
+
+          protected
+
+          def upsert_attributes
+            connection.execute('SELECT upsert_attributes()')
+          end
+
+          def refresh_dependents(options = {})
+            [
+              Api::V3::Readonly::DownloadAttribute,
+              Api::V3::Readonly::MapAttribute,
+              Api::V3::Readonly::RecolorByAttribute,
+              Api::V3::Readonly::ResizeByAttribute,
+              Api::V3::Readonly::DashboardsAttribute
+            ].each do |mview_klass|
+              mview_klass.refresh(
+                options.merge(skip_dependencies: true, sync: false)
+              )
+            end
           end
         end
 

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -16,7 +16,7 @@ module Api
             # rubocop:disable Style/DoubleNegation
             sync_processing = !!options[:sync]
             # rubocop:enable Style/DoubleNegation
-            if long_running? && !sync_processing
+            if long_running? || !sync_processing
               refresh_later(options)
             else
               refresh_now(options)

--- a/app/models/api/v3/readonly/chart_attribute.rb
+++ b/app/models/api/v3/readonly/chart_attribute.rb
@@ -2,22 +2,22 @@
 #
 # Table name: chart_attributes_mv
 #
-#  id                                                                             :integer          primary key
-#  chart_id                                                                       :integer
-#  position                                                                       :integer
-#  years                                                                          :integer          is an Array
-#  display_name(If absent in chart_attributes this is pulled from attributes_mv.) :text
-#  legend_name                                                                    :text
-#  display_type                                                                   :text
-#  display_style                                                                  :text
-#  state_average                                                                  :boolean
-#  identifier                                                                     :text
-#  name                                                                           :text
-#  unit                                                                           :text
-#  tooltip_text                                                                   :text
-#  attribute_id                                                                   :bigint(8)
-#  original_id                                                                    :integer
-#  original_type                                                                  :text
+#  id                                                                          :integer          primary key
+#  chart_id                                                                    :integer
+#  position                                                                    :integer
+#  years                                                                       :integer          is an Array
+#  display_name(If absent in chart_attributes this is pulled from attributes.) :text
+#  legend_name                                                                 :text
+#  display_type                                                                :text
+#  display_style                                                               :text
+#  state_average                                                               :boolean
+#  identifier                                                                  :text
+#  name                                                                        :text
+#  unit                                                                        :text
+#  tooltip_text                                                                :text
+#  attribute_id                                                                :bigint(8)
+#  original_id                                                                 :integer
+#  original_type                                                               :text
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/dashboards/source.rb
+++ b/app/models/api/v3/readonly/dashboards/source.rb
@@ -2,15 +2,15 @@
 #
 # Table name: dashboards_sources_mv
 #
-#  id            :integer          primary key
-#  name          :text
-#  name_tsvector :tsvector
-#  node_type_id  :integer
-#  node_type     :text
-#  profile       :text
-#  country_id    :integer
-#  commodity_id  :integer
-#  node_id       :integer
+#  id(id of source node (not unique))                                 :integer          primary key
+#  name                                                               :text
+#  name_tsvector                                                      :tsvector
+#  node_type_id                                                       :integer
+#  node_type                                                          :text
+#  profile                                                            :text
+#  country_id(id of country sourcing commodity coming from this node) :integer
+#  commodity_id(id of commodity coming from this node)                :integer
+#  node_id(id of another node from the same supply chain)             :integer
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/dashboards_attribute.rb
+++ b/app/models/api/v3/readonly/dashboards_attribute.rb
@@ -2,10 +2,10 @@
 #
 # Table name: dashboards_attributes_mv
 #
-#  id                                                       :bigint(8)        primary key
-#  dashboards_attribute_group_id                            :bigint(8)
-#  position                                                 :integer
-#  attribute_id(References the unique id in attributes_mv.) :bigint(8)
+#  id                                                    :bigint(8)        primary key
+#  dashboards_attribute_group_id                         :bigint(8)
+#  position                                              :integer
+#  attribute_id(References the unique id in attributes.) :bigint(8)
 #
 # Indexes
 #
@@ -24,8 +24,12 @@ module Api
         delegate :original_type, to: :readonly_attribute
         delegate :original_id, to: :readonly_attribute
 
-        def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
+        class << self
+          protected
+
+          def refresh_dependencies(options = {})
+            Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/download_attribute.rb
+++ b/app/models/api/v3/readonly/download_attribute.rb
@@ -2,14 +2,14 @@
 #
 # Table name: download_attributes_mv
 #
-#  id                                                       :integer          primary key
-#  context_id                                               :integer
-#  position                                                 :integer
-#  display_name                                             :text
-#  years                                                    :integer          is an Array
-#  attribute_id(References the unique id in attributes_mv.) :bigint(8)
-#  original_type                                            :text
-#  original_id                                              :integer
+#  id                                                    :integer          primary key
+#  context_id                                            :integer
+#  position                                              :integer
+#  display_name                                          :text
+#  years                                                 :integer          is an Array
+#  attribute_id(References the unique id in attributes.) :bigint(8)
+#  original_type                                         :text
+#  original_id                                           :integer
 #
 # Indexes
 #
@@ -33,8 +33,12 @@ module Api
         delegate :original_type, to: :readonly_attribute
         delegate :original_id, to: :readonly_attribute
 
-        def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
+        class << self
+          protected
+
+          def refresh_dependencies(options = {})
+            Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/flow_quant_total.rb
+++ b/app/models/api/v3/readonly/flow_quant_total.rb
@@ -23,8 +23,8 @@ module Api
         self.table_name = 'flow_quant_totals_mv'
 
         scope :with_attribute_id, -> {
-          select('flow_quant_totals_mv.*, attributes_mv.id AS attribute_id').
-            joins("JOIN attributes_mv ON original_type = 'Quant' AND original_id = quant_id")
+          select('flow_quant_totals_mv.*, attributes.id AS attribute_id').
+            joins("JOIN attributes ON original_type = 'Quant' AND original_id = quant_id")
         }
 
         def attribute_id

--- a/app/models/api/v3/readonly/map_attribute.rb
+++ b/app/models/api/v3/readonly/map_attribute.rb
@@ -2,23 +2,22 @@
 #
 # Table name: map_attributes_mv
 #
-#  id                                                       :integer          primary key
-#  map_attribute_group_id                                   :integer
-#  position                                                 :integer
-#  dual_layer_buckets                                       :float            is an Array
-#  single_layer_buckets                                     :float            is an Array
-#  color_scale                                              :text
-#  years                                                    :integer          is an Array
-#  is_disabled                                              :boolean
-#  is_default                                               :boolean
-#  attribute_id(References the unique id in attributes_mv.) :bigint(8)
-#  name(Display name of the ind/quant)                      :text
-#  attribute_type(Type of the attribute (ind/quant))        :text
-#  unit(Name of the attribute's unit)                       :text
-#  description(Attribute's description)                     :text
-#  aggregate_method(The method used to aggregate the data)  :text
-#  original_attribute_id(The attribute's original id)       :integer
-#  context_id(References the context)                       :integer
+#  id                                                    :integer          primary key
+#  map_attribute_group_id                                :integer
+#  position                                              :integer
+#  dual_layer_buckets                                    :float            is an Array
+#  single_layer_buckets                                  :float            is an Array
+#  color_scale                                           :text
+#  years                                                 :integer          is an Array
+#  is_disabled                                           :boolean
+#  is_default                                            :boolean
+#  attribute_id(References the unique id in attributes.) :bigint(8)
+#  name(Display name of the ind/quant)                   :text
+#  attribute_type(Type of the attribute (ind/quant))     :text
+#  unit(Name of the attribute's unit)                    :text
+#  description(Attribute's description)                  :text
+#  original_attribute_id(The attribute's original id)    :integer
+#  context_id(References the context)                    :integer
 #
 # Indexes
 #
@@ -33,8 +32,12 @@ module Api
 
         belongs_to :map_attribute_group
 
-        def self.refresh_dependencies(options = {})
-          Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
+        class << self
+          protected
+
+          def refresh_dependencies(options = {})
+            Api::V3::Readonly::Attribute.refresh(options.merge(skip_dependents: true))
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/recolor_by_attribute.rb
+++ b/app/models/api/v3/readonly/recolor_by_attribute.rb
@@ -2,22 +2,22 @@
 #
 # Table name: recolor_by_attributes_mv
 #
-#  id                                                       :integer          primary key
-#  context_id                                               :integer
-#  group_number                                             :integer
-#  position                                                 :integer
-#  legend_type                                              :text
-#  legend_color_theme                                       :text
-#  interval_count                                           :integer
-#  min_value                                                :text
-#  max_value                                                :text
-#  divisor                                                  :float
-#  tooltip_text                                             :text
-#  years                                                    :integer          is an Array
-#  is_disabled                                              :boolean
-#  is_default                                               :boolean
-#  attribute_id(References the unique id in attributes_mv.) :bigint(8)
-#  legend                                                   :text             is an Array
+#  id                                                    :integer          primary key
+#  context_id                                            :integer
+#  group_number                                          :integer
+#  position                                              :integer
+#  legend_type                                           :text
+#  legend_color_theme                                    :text
+#  interval_count                                        :integer
+#  min_value                                             :text
+#  max_value                                             :text
+#  divisor                                               :float
+#  tooltip_text                                          :text
+#  years                                                 :integer          is an Array
+#  is_disabled                                           :boolean
+#  is_default                                            :boolean
+#  attribute_id(References the unique id in attributes.) :bigint(8)
+#  legend                                                :text             is an Array
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/resize_by_attribute.rb
+++ b/app/models/api/v3/readonly/resize_by_attribute.rb
@@ -2,15 +2,15 @@
 #
 # Table name: resize_by_attributes_mv
 #
-#  id                                                       :integer          primary key
-#  context_id                                               :integer
-#  group_number                                             :integer
-#  position                                                 :integer
-#  tooltip_text                                             :text
-#  years                                                    :integer          is an Array
-#  is_disabled                                              :boolean
-#  is_default                                               :boolean
-#  attribute_id(References the unique id in attributes_mv.) :bigint(8)
+#  id                                                    :integer          primary key
+#  context_id                                            :integer
+#  group_number                                          :integer
+#  position                                              :integer
+#  tooltip_text                                          :text
+#  years                                                 :integer          is an Array
+#  is_disabled                                           :boolean
+#  is_default                                            :boolean
+#  attribute_id(References the unique id in attributes.) :bigint(8)
 #
 # Indexes
 #

--- a/app/models/api/v3/top_profile.rb
+++ b/app/models/api/v3/top_profile.rb
@@ -20,7 +20,7 @@
 #
 #  fk_rails_...  (context_id => contexts.id) ON DELETE => cascade ON UPDATE => cascade
 #  fk_rails_...  (node_id => nodes.id) ON DELETE => cascade ON UPDATE => cascade
-#  fk_rails_...  (top_profile_image_id => top_profile_images.id)
+#  fk_rails_...  (top_profile_image_id => top_profile_images.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api
@@ -34,6 +34,12 @@ module Api
       validates :context, presence: true
 
       before_create :derive_top_profile_details
+
+      def self.yellow_foreign_keys
+        [
+          {name: :top_profile_image_id, table_class: Api::V3::TopProfileImage}
+        ]
+      end
 
       def self.blue_foreign_keys
         [

--- a/app/models/api/v3/top_profile_image.rb
+++ b/app/models/api/v3/top_profile_image.rb
@@ -15,7 +15,7 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (commodity_id => commodities.id)
+#  fk_rails_...  (commodity_id => commodities.id) ON DELETE => cascade ON UPDATE => cascade
 #
 
 module Api
@@ -31,8 +31,7 @@ module Api
 
       def self.blue_foreign_keys
         [
-          {name: :context_id, table_class: Api::V3::Context},
-          {name: :node_id, table_class: Api::V3::Node}
+          {name: :commodity_id, table_class: Api::V3::Commodity}
         ]
       end
 

--- a/app/services/api/v3/database_validation/chain_builders/recolor_by_attribute_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/recolor_by_attribute_chain_builder.rb
@@ -12,11 +12,9 @@ module Api
       module ChainBuilders
         class RecolorByAttributeChainBuilder < AbstractChainBuilder
           checks :declared_years_match_flow_attributes,
-                 association: :recolor_by_ind,
-                 link: :edit
+                 association: :recolor_by_ind
           checks :declared_years_match_flow_attributes,
-                 association: :recolor_by_qual,
-                 link: :edit
+                 association: :recolor_by_qual
           checks :attribute_present,
                  attribute: :tooltip_text,
                  link: :edit,
@@ -24,7 +22,7 @@ module Api
           checks :has_exactly_one_of,
                  associations: [:recolor_by_ind, :recolor_by_qual],
                  link: :index
-          checks :active_record_check, on: :recolor_by_attribute, link: :edit
+          checks :active_record_check, on: :recolor_by_attribute
 
           def self.build_chain(context)
             chain = []

--- a/app/services/api/v3/database_validation/chain_builders/resize_by_attribute_chain_builder.rb
+++ b/app/services/api/v3/database_validation/chain_builders/resize_by_attribute_chain_builder.rb
@@ -10,8 +10,7 @@ module Api
       module ChainBuilders
         class ResizeByAttributeChainBuilder < AbstractChainBuilder
           checks :declared_years_match_flow_attributes,
-                 association: :resize_by_quant,
-                 link: :edit
+                 association: :resize_by_quant
           checks :attribute_present,
                  attribute: :tooltip_text,
                  link: :edit,
@@ -19,7 +18,7 @@ module Api
           checks :has_exactly_one,
                  association: :resize_by_quant,
                  link: :index
-          checks :active_record_check, on: :resize_by_attribute, link: :edit
+          checks :active_record_check, on: :resize_by_attribute
 
           def self.build_chain(context)
             chain = []

--- a/app/services/api/v3/import/tables.rb
+++ b/app/services/api/v3/import/tables.rb
@@ -14,7 +14,8 @@ module Api
           {
             table_class: Api::V3::Commodity,
             yellow_tables: [
-              Api::V3::DashboardTemplateCommodity
+              Api::V3::DashboardTemplateCommodity,
+              Api::V3::TopProfileImage
             ]
           },
           {

--- a/app/services/api/v3/map_layers/map_attribute_filter.rb
+++ b/app/services/api/v3/map_layers/map_attribute_filter.rb
@@ -36,7 +36,6 @@ attribute_type) AS single_layer_buckets",
               'attribute_type AS type',
               'unit',
               'description',
-              'aggregate_method',
               'original_attribute_id AS layer_attribute_id',
               'map_attribute_group_id AS group_id'
             ]).

--- a/app/workers/upsert_attributes_worker.rb
+++ b/app/workers/upsert_attributes_worker.rb
@@ -1,0 +1,15 @@
+class UpsertAttributesWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: :database,
+                  retry: 0,
+                  backtrace: true,
+                  unique: :until_and_while_executing,
+                  log_duplicate_payload: true
+
+  # @param options
+  # @option options [Boolean] :skip_dependencies skip refreshing
+  # @option options [Boolean] :skip_dependents skip refreshing
+  def perform(options)
+    Api::V3::Readonly::Attribute.refresh_now(options.symbolize_keys)
+  end
+end

--- a/db/migrate/20190919211340_change_attributes_to_table.rb
+++ b/db/migrate/20190919211340_change_attributes_to_table.rb
@@ -1,0 +1,131 @@
+class ChangeAttributesToTable < ActiveRecord::Migration[5.2]
+  def change
+    create_view :attributes_v,
+      version: 1,
+      materialized: false
+
+    create_table :attributes do |t|
+      t.integer :original_id, null: false
+      t.text :original_type, null: false
+      t.text :name, null: false
+      t.text :display_name
+      t.text :unit
+      t.text :unit_type
+      t.text :tooltip_text
+    end
+
+    execute "ALTER TABLE attributes ADD CONSTRAINT attributes_original_type_check CHECK (original_type IN ('Ind', 'Qual', 'Quant'))"
+
+    add_index :attributes,
+      [:original_type, :name],
+      unique: true,
+      name: 'attributes_original_type_name_idx'
+
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION upsert_attributes()
+      RETURNS VOID
+      LANGUAGE 'sql'
+      VOLATILE
+      AS $BODY$
+
+      INSERT INTO attributes (
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        tooltip_text
+      )
+      SELECT
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        tooltip_text
+      FROM attributes_v
+
+      EXCEPT
+
+      SELECT
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        tooltip_text
+      FROM attributes
+      ON CONFLICT (name, original_type) DO UPDATE SET
+        original_id = excluded.original_id,
+        display_name = excluded.display_name,
+        unit = excluded.unit,
+        unit_type = excluded.unit_type,
+        tooltip_text = excluded.tooltip_text;
+
+      DELETE FROM attributes
+      USING (
+        SELECT
+          original_id,
+          original_type,
+          name,
+          display_name,
+          unit,
+          unit_type,
+          tooltip_text
+        FROM attributes
+
+        EXCEPT
+
+        SELECT
+          original_id,
+          original_type,
+          name,
+          display_name,
+          unit,
+          unit_type,
+          tooltip_text
+        FROM attributes_v
+      ) s
+      WHERE attributes.name = s.name AND attributes.original_type = s.original_type;
+      $BODY$;
+
+      COMMENT ON FUNCTION upsert_attributes() IS
+      'Upserts attributes based on new values as returned by attributes_v (identity by original_type + name)';
+    SQL
+
+    update_view :chart_attributes_mv,
+      version: 4,
+      revert_to_version: 3,
+      materialized: true
+
+    update_view :dashboards_attributes_mv,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+
+    update_view :download_attributes_mv,
+      version: 4,
+      revert_to_version: 3,
+      materialized: true
+
+    update_view :map_attributes_mv,
+      version: 5,
+      revert_to_version: 4,
+      materialized: true
+
+    update_view :recolor_by_attributes_mv,
+      version: 4,
+      revert_to_version: 3,
+      materialized: true
+
+    update_view :resize_by_attributes_mv,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+
+    drop_view :attributes_mv, materialized: true
+  end
+end

--- a/db/migrate/20190923074833_fix_foreign_keys.rb
+++ b/db/migrate/20190923074833_fix_foreign_keys.rb
@@ -1,0 +1,8 @@
+class FixForeignKeys < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :top_profile_images, :commodities
+    add_foreign_key :top_profile_images, :commodities, {on_delete: :cascade, on_update: :cascade}
+    remove_foreign_key :top_profiles, :top_profile_images
+    add_foreign_key :top_profiles, :top_profile_images, {on_delete: :cascade, on_update: :cascade}
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -497,36 +497,36 @@ tables:
         comment: Count of warnings detected
       - name: report
         comment: JSON structure with validation report
-materialized_views:
-  - name: attributes_mv
-    comment: Materialized view which merges inds, quals and quants.
+  - name: attributes
+    comment: Merges inds, quals and quants.
     columns:
       - name: id
-        comment: The unique id is a sequential number which is generated at REFRESH and therefore not fixed.
+        comment: Id is fixed between data updates, unless name changes
       - name: original_type
         comment: Type of the original entity (Ind / Qual / Quant)
       - name: original_id
         comment: Id from the original table (inds / quals / quants)
+materialized_views:
   - name: chart_attributes_mv
     comment: Materialized view which merges chart_inds, chart_quals and chart_quants with chart_attributes.
     columns:
       - name: display_name
-        comment: If absent in chart_attributes this is pulled from attributes_mv.
+        comment: If absent in chart_attributes this is pulled from attributes.
   - name: dashboards_attributes_mv
     comment: Materialized view which merges dashboards_inds, dashboards_quals and dashboards_quants with dashboards_attributes.
     columns:
       - name: attribute_id
-        comment: References the unique id in attributes_mv.
+        comment: References the unique id in attributes.
   - name: download_attributes_mv
     comment: Materialized view which merges download_quals and download_quants with download_attributes.
     columns:
       - name: attribute_id
-        comment: References the unique id in attributes_mv.
+        comment: References the unique id in attributes.
   - name: map_attributes_mv
     comment: Materialized view which merges map_inds and map_quants with map_attributes.
     columns:
       - name: attribute_id
-        comment: References the unique id in attributes_mv.
+        comment: References the unique id in attributes.
       - name: name
         comment: Display name of the ind/quant
       - name: attribute_type
@@ -535,8 +535,6 @@ materialized_views:
         comment: Name of the attribute''s unit
       - name: description
         comment: Attribute''s description
-      - name: aggregate_method
-        comment: The method used to aggregate the data
       - name: original_attribute_id
         comment: The attribute''s original id
       - name: context_id
@@ -545,12 +543,12 @@ materialized_views:
     comment: Materialized view which merges recolor_by_inds and recolor_by_quals with recolor_by_attributes.
     columns:
       - name: attribute_id
-        comment: References the unique id in attributes_mv.
+        comment: References the unique id in attributes.
   - name: resize_by_attributes_mv
     comment: Materialized view which merges resize_by_quants with resize_by_attributes.
     columns:
       - name: attribute_id
-        comment: References the unique id in attributes_mv.
+        comment: References the unique id in attributes.
   - name: context_attribute_properties_mv
     comment: Materialized view combining context specific properties for inds, quals and quants.
     columns:

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -8744,7 +8744,7 @@ ALTER TABLE ONLY public.recolor_by_inds
 --
 
 ALTER TABLE ONLY public.top_profile_images
-    ADD CONSTRAINT fk_rails_29f1862b03 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id);
+    ADD CONSTRAINT fk_rails_29f1862b03 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -9264,7 +9264,7 @@ ALTER TABLE ONLY public.chart_node_types
 --
 
 ALTER TABLE ONLY public.top_profiles
-    ADD CONSTRAINT fk_rails_f4a644ec90 FOREIGN KEY (top_profile_image_id) REFERENCES public.top_profile_images(id);
+    ADD CONSTRAINT fk_rails_f4a644ec90 FOREIGN KEY (top_profile_image_id) REFERENCES public.top_profile_images(id) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -9371,6 +9371,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190820105523'),
 ('20190823135415'),
 ('20190919063754'),
-('20190919211340');
+('20190919211340'),
+('20190923074833');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,7 +5,6 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
@@ -148,6 +147,86 @@ $$;
 --
 
 COMMENT ON FUNCTION public.bucket_index(buckets double precision[], value double precision) IS 'Given an n-element array of choropleth buckets and a positive value, returns index of bucket where value falls (1 to n + 1); else returns 0.';
+
+
+--
+-- Name: upsert_attributes(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.upsert_attributes() RETURNS void
+    LANGUAGE sql
+    AS $$
+
+INSERT INTO attributes (
+  original_id,
+  original_type,
+  name,
+  display_name,
+  unit,
+  unit_type,
+  tooltip_text
+)
+SELECT
+  original_id,
+  original_type,
+  name,
+  display_name,
+  unit,
+  unit_type,
+  tooltip_text
+FROM attributes_v
+
+EXCEPT
+
+SELECT
+  original_id,
+  original_type,
+  name,
+  display_name,
+  unit,
+  unit_type,
+  tooltip_text
+FROM attributes
+ON CONFLICT (name, original_type) DO UPDATE SET
+  original_id = excluded.original_id,
+  display_name = excluded.display_name,
+  unit = excluded.unit,
+  unit_type = excluded.unit_type,
+  tooltip_text = excluded.tooltip_text;
+
+DELETE FROM attributes
+USING (
+  SELECT
+    original_id,
+    original_type,
+    name,
+    display_name,
+    unit,
+    unit_type,
+    tooltip_text
+  FROM attributes
+
+  EXCEPT
+
+  SELECT
+    original_id,
+    original_type,
+    name,
+    display_name,
+    unit,
+    unit_type,
+    tooltip_text
+  FROM attributes_v
+) s
+WHERE attributes.name = s.name AND attributes.original_type = s.original_type;
+$$;
+
+
+--
+-- Name: FUNCTION upsert_attributes(); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.upsert_attributes() IS 'Upserts attributes based on new values as returned by attributes_v (identity by original_type + name)';
 
 
 SET default_tablespace = '';
@@ -473,6 +552,70 @@ CREATE TABLE public.ar_internal_metadata (
 
 
 --
+-- Name: attributes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.attributes (
+    id bigint NOT NULL,
+    original_id integer NOT NULL,
+    original_type text NOT NULL,
+    name text NOT NULL,
+    display_name text,
+    unit text,
+    unit_type text,
+    tooltip_text text,
+    CONSTRAINT attributes_original_type_check CHECK ((original_type = ANY (ARRAY['Ind'::text, 'Qual'::text, 'Quant'::text])))
+);
+
+
+--
+-- Name: TABLE attributes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.attributes IS 'Merges inds, quals and quants.';
+
+
+--
+-- Name: COLUMN attributes.id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.attributes.id IS 'Id is fixed between data updates, unless name changes';
+
+
+--
+-- Name: COLUMN attributes.original_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.attributes.original_id IS 'Id from the original table (inds / quals / quants)';
+
+
+--
+-- Name: COLUMN attributes.original_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.attributes.original_type IS 'Type of the original entity (Ind / Qual / Quant)';
+
+
+--
+-- Name: attributes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.attributes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: attributes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.attributes_id_seq OWNED BY public.attributes.id;
+
+
+--
 -- Name: ind_properties; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -734,96 +877,46 @@ COMMENT ON COLUMN public.quants.unit IS 'Unit in which values for this attribute
 
 
 --
--- Name: attributes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+-- Name: attributes_v; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE MATERIALIZED VIEW public.attributes_mv AS
- SELECT row_number() OVER () AS id,
+CREATE VIEW public.attributes_v AS
+ SELECT s.original_id,
     s.original_type,
-    s.original_id,
     s.name,
     s.display_name,
     s.unit,
     s.unit_type,
-    s.tooltip_text,
-    s.is_visible_on_actor_profile,
-    s.is_visible_on_place_profile,
-    s.is_temporal_on_actor_profile,
-    s.is_temporal_on_place_profile,
-    s.aggregate_method
-   FROM ( SELECT 'Quant'::text AS original_type,
-            quants.id AS original_id,
+    s.tooltip_text
+   FROM ( SELECT quants.id AS original_id,
+            'Quant'::text AS original_type,
             quants.name,
             qp.display_name,
             quants.unit,
             qp.unit_type,
-            qp.tooltip_text,
-            qp.is_visible_on_actor_profile,
-            qp.is_visible_on_place_profile,
-            qp.is_temporal_on_actor_profile,
-            qp.is_temporal_on_place_profile,
-            'SUM'::text AS aggregate_method
+            qp.tooltip_text
            FROM (public.quants
              LEFT JOIN public.quant_properties qp ON ((qp.quant_id = quants.id)))
         UNION ALL
-         SELECT 'Ind'::text AS text,
-            inds.id,
+         SELECT inds.id,
+            'Ind'::text,
             inds.name,
             ip.display_name,
             inds.unit,
             ip.unit_type,
-            ip.tooltip_text,
-            ip.is_visible_on_actor_profile,
-            ip.is_visible_on_place_profile,
-            ip.is_temporal_on_actor_profile,
-            ip.is_temporal_on_place_profile,
-            'AVG'::text AS text
+            ip.tooltip_text
            FROM (public.inds
              LEFT JOIN public.ind_properties ip ON ((ip.ind_id = inds.id)))
         UNION ALL
-         SELECT 'Qual'::text AS text,
-            quals.id,
+         SELECT quals.id,
+            'Qual'::text,
             quals.name,
             qp.display_name,
-            NULL::text AS text,
-            NULL::text AS text,
-            qp.tooltip_text,
-            qp.is_visible_on_actor_profile,
-            qp.is_visible_on_place_profile,
-            qp.is_temporal_on_actor_profile,
-            qp.is_temporal_on_place_profile,
-            NULL::text AS text
+            NULL::text,
+            NULL::text,
+            qp.tooltip_text
            FROM (public.quals
-             LEFT JOIN public.qual_properties qp ON ((qp.qual_id = quals.id)))) s
-  WITH NO DATA;
-
-
---
--- Name: MATERIALIZED VIEW attributes_mv; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON MATERIALIZED VIEW public.attributes_mv IS 'Materialized view which merges inds, quals and quants.';
-
-
---
--- Name: COLUMN attributes_mv.id; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.attributes_mv.id IS 'The unique id is a sequential number which is generated at REFRESH and therefore not fixed.';
-
-
---
--- Name: COLUMN attributes_mv.original_type; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.attributes_mv.original_type IS 'Type of the original entity (Ind / Qual / Quant)';
-
-
---
--- Name: COLUMN attributes_mv.original_id; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.attributes_mv.original_id IS 'Id from the original table (inds / quals / quants)';
+             LEFT JOIN public.qual_properties qp ON ((qp.qual_id = quals.id)))) s;
 
 
 --
@@ -1082,7 +1175,7 @@ CREATE MATERIALIZED VIEW public.chart_attributes_mv AS
     cha.updated_at
    FROM ((public.chart_quals chq
      JOIN public.chart_attributes cha ON ((cha.id = chq.chart_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = chq.qual_id) AND (a.original_type = 'Qual'::text))))
+     JOIN public.attributes a ON (((a.original_id = chq.qual_id) AND (a.original_type = 'Qual'::text))))
 UNION ALL
  SELECT cha.id,
     cha.chart_id,
@@ -1104,7 +1197,7 @@ UNION ALL
     cha.updated_at
    FROM ((public.chart_quants chq
      JOIN public.chart_attributes cha ON ((cha.id = chq.chart_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = chq.quant_id) AND (a.original_type = 'Quant'::text))))
+     JOIN public.attributes a ON (((a.original_id = chq.quant_id) AND (a.original_type = 'Quant'::text))))
 UNION ALL
  SELECT cha.id,
     cha.chart_id,
@@ -1126,7 +1219,7 @@ UNION ALL
     cha.updated_at
    FROM ((public.chart_inds chi
      JOIN public.chart_attributes cha ON ((cha.id = chi.chart_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = chi.ind_id) AND (a.original_type = 'Ind'::text))))
+     JOIN public.attributes a ON (((a.original_id = chi.ind_id) AND (a.original_type = 'Ind'::text))))
   WITH NO DATA;
 
 
@@ -1141,7 +1234,7 @@ COMMENT ON MATERIALIZED VIEW public.chart_attributes_mv IS 'Materialized view wh
 -- Name: COLUMN chart_attributes_mv.display_name; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.chart_attributes_mv.display_name IS 'If absent in chart_attributes this is pulled from attributes_mv.';
+COMMENT ON COLUMN public.chart_attributes_mv.display_name IS 'If absent in chart_attributes this is pulled from attributes.';
 
 
 --
@@ -2959,7 +3052,7 @@ CREATE MATERIALIZED VIEW public.dashboards_attributes_mv AS
     a.id AS attribute_id
    FROM ((public.dashboards_inds di
      JOIN public.dashboards_attributes da ON ((da.id = di.dashboards_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = di.ind_id) AND (a.original_type = 'Ind'::text))))
+     JOIN public.attributes a ON (((a.original_id = di.ind_id) AND (a.original_type = 'Ind'::text))))
 UNION ALL
  SELECT da.id,
     da.dashboards_attribute_group_id,
@@ -2967,7 +3060,7 @@ UNION ALL
     a.id AS attribute_id
    FROM ((public.dashboards_quals dq
      JOIN public.dashboards_attributes da ON ((da.id = dq.dashboards_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = dq.qual_id) AND (a.original_type = 'Qual'::text))))
+     JOIN public.attributes a ON (((a.original_id = dq.qual_id) AND (a.original_type = 'Qual'::text))))
 UNION ALL
  SELECT da.id,
     da.dashboards_attribute_group_id,
@@ -2975,7 +3068,7 @@ UNION ALL
     a.id AS attribute_id
    FROM ((public.dashboards_quants dq
      JOIN public.dashboards_attributes da ON ((da.id = dq.dashboards_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = dq.quant_id) AND (a.original_type = 'Quant'::text))))
+     JOIN public.attributes a ON (((a.original_id = dq.quant_id) AND (a.original_type = 'Quant'::text))))
   WITH NO DATA;
 
 
@@ -2990,7 +3083,7 @@ COMMENT ON MATERIALIZED VIEW public.dashboards_attributes_mv IS 'Materialized vi
 -- Name: COLUMN dashboards_attributes_mv.attribute_id; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.dashboards_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
+COMMENT ON COLUMN public.dashboards_attributes_mv.attribute_id IS 'References the unique id in attributes.';
 
 
 --
@@ -3480,41 +3573,6 @@ ALTER SEQUENCE public.dashboards_quants_id_seq OWNED BY public.dashboards_quants
 
 
 --
--- Name: node_quals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.node_quals (
-    id integer NOT NULL,
-    node_id integer NOT NULL,
-    qual_id integer NOT NULL,
-    year integer,
-    value text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
-
-
---
--- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
-
-
---
--- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
-
-
---
 -- Name: dashboards_sources_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -3885,7 +3943,7 @@ CREATE MATERIALIZED VIEW public.download_attributes_mv AS
     a.original_id
    FROM ((public.download_quants daq
      JOIN public.download_attributes da ON ((da.id = daq.download_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = daq.quant_id) AND (a.original_type = 'Quant'::text))))
+     JOIN public.attributes a ON (((a.original_id = daq.quant_id) AND (a.original_type = 'Quant'::text))))
 UNION ALL
  SELECT da.id,
     da.context_id,
@@ -3899,7 +3957,7 @@ UNION ALL
     a.original_id
    FROM ((public.download_quals daq
      JOIN public.download_attributes da ON ((da.id = daq.download_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = daq.qual_id) AND (a.original_type = 'Qual'::text))))
+     JOIN public.attributes a ON (((a.original_id = daq.qual_id) AND (a.original_type = 'Qual'::text))))
   WITH NO DATA;
 
 
@@ -3914,7 +3972,7 @@ COMMENT ON MATERIALIZED VIEW public.download_attributes_mv IS 'Materialized view
 -- Name: COLUMN download_attributes_mv.attribute_id; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.download_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
+COMMENT ON COLUMN public.download_attributes_mv.attribute_id IS 'References the unique id in attributes.';
 
 
 --
@@ -4713,13 +4771,12 @@ CREATE MATERIALIZED VIEW public.map_attributes_mv AS
     'quant'::text AS attribute_type,
     a.unit,
     a.tooltip_text AS description,
-    a.aggregate_method,
     a.original_id AS original_attribute_id,
     mag.context_id
    FROM (((public.map_quants maq
      JOIN public.map_attributes ma ON ((ma.id = maq.map_attribute_id)))
      JOIN public.map_attribute_groups mag ON ((mag.id = ma.map_attribute_group_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = maq.quant_id) AND (a.original_type = 'Quant'::text))))
+     JOIN public.attributes a ON (((a.original_id = maq.quant_id) AND (a.original_type = 'Quant'::text))))
 UNION ALL
  SELECT ma.id,
     ma.map_attribute_group_id,
@@ -4737,13 +4794,12 @@ UNION ALL
     'ind'::text AS attribute_type,
     a.unit,
     a.tooltip_text AS description,
-    a.aggregate_method,
     a.original_id AS original_attribute_id,
     mag.context_id
    FROM (((public.map_inds mai
      JOIN public.map_attributes ma ON ((ma.id = mai.map_attribute_id)))
      JOIN public.map_attribute_groups mag ON ((mag.id = ma.map_attribute_group_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = mai.ind_id) AND (a.original_type = 'Ind'::text))))
+     JOIN public.attributes a ON (((a.original_id = mai.ind_id) AND (a.original_type = 'Ind'::text))))
   WITH NO DATA;
 
 
@@ -4758,7 +4814,7 @@ COMMENT ON MATERIALIZED VIEW public.map_attributes_mv IS 'Materialized view whic
 -- Name: COLUMN map_attributes_mv.attribute_id; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.map_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
+COMMENT ON COLUMN public.map_attributes_mv.attribute_id IS 'References the unique id in attributes.';
 
 
 --
@@ -4787,13 +4843,6 @@ COMMENT ON COLUMN public.map_attributes_mv.unit IS 'Name of the attribute''s uni
 --
 
 COMMENT ON COLUMN public.map_attributes_mv.description IS 'Attribute''s description';
-
-
---
--- Name: COLUMN map_attributes_mv.aggregate_method; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.map_attributes_mv.aggregate_method IS 'The method used to aggregate the data';
 
 
 --
@@ -4884,6 +4933,41 @@ CREATE SEQUENCE public.node_properties_id_seq
 --
 
 ALTER SEQUENCE public.node_properties_id_seq OWNED BY public.node_properties.id;
+
+
+--
+-- Name: node_quals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.node_quals (
+    id integer NOT NULL,
+    node_id integer NOT NULL,
+    qual_id integer NOT NULL,
+    year integer,
+    value text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
+
+
+--
+-- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
+
+
+--
+-- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
 
 
 --
@@ -5784,7 +5868,7 @@ CREATE MATERIALIZED VIEW public.resize_by_attributes_mv AS
     a.id AS attribute_id
    FROM ((public.resize_by_quants raq
      JOIN public.resize_by_attributes ra ON ((ra.id = raq.resize_by_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = raq.quant_id) AND (a.original_type = 'Quant'::text))))
+     JOIN public.attributes a ON (((a.original_id = raq.quant_id) AND (a.original_type = 'Quant'::text))))
   WITH NO DATA;
 
 
@@ -5799,7 +5883,7 @@ COMMENT ON MATERIALIZED VIEW public.resize_by_attributes_mv IS 'Materialized vie
 -- Name: COLUMN resize_by_attributes_mv.attribute_id; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.resize_by_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
+COMMENT ON COLUMN public.resize_by_attributes_mv.attribute_id IS 'References the unique id in attributes.';
 
 
 --
@@ -5987,6 +6071,13 @@ ALTER TABLE ONLY content.testimonials ALTER COLUMN id SET DEFAULT nextval('conte
 --
 
 ALTER TABLE ONLY content.users ALTER COLUMN id SET DEFAULT nextval('content.users_id_seq'::regclass);
+
+
+--
+-- Name: attributes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.attributes ALTER COLUMN id SET DEFAULT nextval('public.attributes_id_seq'::regclass);
 
 
 --
@@ -6505,7 +6596,7 @@ CREATE MATERIALIZED VIEW public.recolor_by_attributes_mv AS
     ARRAY[]::text[] AS legend
    FROM ((public.recolor_by_inds rai
      JOIN public.recolor_by_attributes ra ON ((ra.id = rai.recolor_by_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = rai.ind_id) AND (a.original_type = 'Ind'::text))))
+     JOIN public.attributes a ON (((a.original_id = rai.ind_id) AND (a.original_type = 'Ind'::text))))
 UNION ALL
  SELECT ra.id,
     ra.context_id,
@@ -6527,7 +6618,7 @@ UNION ALL
     array_agg(DISTINCT flow_quals.value) AS legend
    FROM ((((public.recolor_by_quals raq
      JOIN public.recolor_by_attributes ra ON ((ra.id = raq.recolor_by_attribute_id)))
-     JOIN public.attributes_mv a ON (((a.original_id = raq.qual_id) AND (a.original_type = 'Qual'::text))))
+     JOIN public.attributes a ON (((a.original_id = raq.qual_id) AND (a.original_type = 'Qual'::text))))
      JOIN public.flow_quals ON ((flow_quals.qual_id = raq.qual_id)))
      JOIN public.flows ON (((flow_quals.flow_id = flows.id) AND (flows.context_id = ra.context_id))))
   WHERE (flow_quals.value !~~ 'UNKNOWN%'::text)
@@ -6546,7 +6637,7 @@ COMMENT ON MATERIALIZED VIEW public.recolor_by_attributes_mv IS 'Materialized vi
 -- Name: COLUMN recolor_by_attributes_mv.attribute_id; Type: COMMENT; Schema: public; Owner: -
 --
 
-COMMENT ON COLUMN public.recolor_by_attributes_mv.attribute_id IS 'References the unique id in attributes_mv.';
+COMMENT ON COLUMN public.recolor_by_attributes_mv.attribute_id IS 'References the unique id in attributes.';
 
 
 --
@@ -6619,6 +6710,14 @@ ALTER TABLE ONLY content.users
 
 ALTER TABLE ONLY public.ar_internal_metadata
     ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: attributes attributes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.attributes
+    ADD CONSTRAINT attributes_pkey PRIMARY KEY (id);
 
 
 --
@@ -7594,17 +7693,10 @@ CREATE UNIQUE INDEX index_users_on_reset_password_token ON content.users USING b
 
 
 --
--- Name: attributes_mv_id_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: attributes_original_type_name_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX attributes_mv_id_idx ON public.attributes_mv USING btree (id);
-
-
---
--- Name: attributes_mv_name_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX attributes_mv_name_idx ON public.attributes_mv USING btree (name);
+CREATE UNIQUE INDEX attributes_original_type_name_idx ON public.attributes USING btree (original_type, name);
 
 
 --
@@ -9278,6 +9370,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190814161133'),
 ('20190820105523'),
 ('20190823135415'),
-('20190919063754');
+('20190919063754'),
+('20190919211340');
 
 

--- a/db/views/attributes_v_v01.sql
+++ b/db/views/attributes_v_v01.sql
@@ -1,0 +1,38 @@
+SELECT * FROM (
+  SELECT
+    quants.id AS original_id,
+    'Quant' AS original_type,
+    quants.name,
+    qp.display_name,
+    quants.unit,
+    qp.unit_type,
+    qp.tooltip_text
+  FROM quants
+  LEFT JOIN quant_properties qp ON qp.quant_id = quants.id
+
+  UNION ALL
+
+  SELECT
+    inds.id,
+    'Ind',
+    inds.name,
+    ip.display_name,
+    inds.unit,
+    ip.unit_type,
+    ip.tooltip_text
+  FROM inds
+  LEFT JOIN ind_properties ip ON ip.ind_id = inds.id
+
+  UNION ALL
+
+  SELECT
+    quals.id,
+    'Qual',
+    quals.name,
+    qp.display_name,
+    NULL,
+    NULL,
+    qp.tooltip_text
+  FROM quals
+  LEFT JOIN qual_properties qp ON qp.qual_id = quals.id
+) s;

--- a/db/views/chart_attributes_mv_v04.sql
+++ b/db/views/chart_attributes_mv_v04.sql
@@ -1,0 +1,72 @@
+SELECT
+  cha.id,
+  cha.chart_id,
+  cha.position,
+  cha.years,
+  COALESCE(NULLIF(cha.display_name, ''), NULLIF(a.display_name, '')) AS display_name,
+  cha.legend_name,
+  cha.display_type,
+  cha.display_style,
+  cha.state_average,
+  cha.identifier,
+  a.name,
+  a.unit,
+  a.tooltip_text,
+  a.id AS attribute_id,
+  a.original_id,
+  a.original_type,
+  cha.created_at,
+  cha.updated_at
+FROM chart_quals chq
+JOIN chart_attributes cha ON cha.id = chq.chart_attribute_id
+JOIN attributes a ON a.original_id = chq.qual_id AND a.original_type = 'Qual'
+
+UNION ALL
+
+SELECT
+  cha.id,
+  cha.chart_id,
+  cha.position,
+  cha.years,
+  COALESCE(NULLIF(cha.display_name, ''), NULLIF(a.display_name, '')),
+  cha.legend_name,
+  cha.display_type,
+  cha.display_style,
+  cha.state_average,
+  cha.identifier,
+  a.name,
+  a.unit,
+  a.tooltip_text,
+  a.id,
+  a.original_id,
+  a.original_type,
+  cha.created_at,
+  cha.updated_at
+FROM chart_quants chq
+JOIN chart_attributes cha ON cha.id = chq.chart_attribute_id
+JOIN attributes a ON a.original_id = chq.quant_id AND a.original_type = 'Quant'
+
+UNION ALL
+
+SELECT
+  cha.id,
+  cha.chart_id,
+  cha.position,
+  cha.years,
+  COALESCE(NULLIF(cha.display_name, ''), NULLIF(a.display_name, '')),
+  cha.legend_name,
+  cha.display_type,
+  cha.display_style,
+  cha.state_average,
+  cha.identifier,
+  a.name,
+  a.unit,
+  a.tooltip_text,
+  a.id,
+  a.original_id,
+  a.original_type,
+  cha.created_at,
+  cha.updated_at
+FROM chart_inds chi
+JOIN chart_attributes cha ON cha.id = chi.chart_attribute_id
+JOIN attributes a ON a.original_id = chi.ind_id AND a.original_type = 'Ind'

--- a/db/views/dashboards_attributes_mv_v03.sql
+++ b/db/views/dashboards_attributes_mv_v03.sql
@@ -1,0 +1,18 @@
+SELECT da.id, da.dashboards_attribute_group_id, position, a.id AS attribute_id
+FROM dashboards_inds di
+JOIN dashboards_attributes da ON da.id = di.dashboards_attribute_id
+JOIN attributes a ON a.original_id = di.ind_id AND a.original_type = 'Ind'
+
+UNION ALL
+
+SELECT da.id, da.dashboards_attribute_group_id, position, a.id AS attribute_id
+FROM dashboards_quals dq
+JOIN dashboards_attributes da ON da.id = dq.dashboards_attribute_id
+JOIN attributes a ON a.original_id = dq.qual_id AND a.original_type = 'Qual'
+
+UNION ALL
+
+SELECT da.id, da.dashboards_attribute_group_id, position, a.id AS attribute_id
+FROM dashboards_quants dq
+JOIN dashboards_attributes da ON da.id = dq.dashboards_attribute_id
+JOIN attributes a ON a.original_id = dq.quant_id AND a.original_type = 'Quant'

--- a/db/views/download_attributes_mv_v04.sql
+++ b/db/views/download_attributes_mv_v04.sql
@@ -1,0 +1,11 @@
+SELECT da.*, a.id AS attribute_id, a.original_type, a.original_id
+FROM download_quants daq
+JOIN download_attributes da ON da.id = daq.download_attribute_id
+JOIN attributes a ON a.original_id = daq.quant_id AND a.original_type = 'Quant'
+
+UNION ALL
+
+SELECT da.*, a.id AS attribute_id, a.original_type, a.original_id
+FROM download_quals daq
+JOIN download_attributes da ON da.id = daq.download_attribute_id
+JOIN attributes a ON a.original_id = daq.qual_id AND a.original_type = 'Qual'

--- a/db/views/map_attributes_mv_v05.sql
+++ b/db/views/map_attributes_mv_v05.sql
@@ -1,0 +1,17 @@
+SELECT ma.*, a.id AS attribute_id, a.display_name as name, 'quant' as attribute_type, a.unit as unit,
+  tooltip_text as description, a.original_id as original_attribute_id,
+  mag.context_id
+FROM map_quants maq
+JOIN map_attributes ma ON ma.id = maq.map_attribute_id
+JOIN map_attribute_groups mag ON mag.id = ma.map_attribute_group_id
+JOIN attributes a ON a.original_id = maq.quant_id AND a.original_type = 'Quant'
+
+UNION ALL
+
+SELECT ma.*, a.id AS attribute_id, a.display_name as name, 'ind' as attribute_type, a.unit as unit,
+  tooltip_text as description, a.original_id as original_attribute_id,
+  mag.context_id
+FROM map_inds mai
+JOIN map_attributes ma ON ma.id = mai.map_attribute_id
+JOIN map_attribute_groups mag ON mag.id = ma.map_attribute_group_id
+JOIN attributes a ON a.original_id = mai.ind_id AND a.original_type = 'Ind'

--- a/db/views/recolor_by_attributes_mv_v04.sql
+++ b/db/views/recolor_by_attributes_mv_v04.sql
@@ -1,0 +1,15 @@
+SELECT ra.*, a.id AS attribute_id, ARRAY[]::TEXT[] AS legend
+FROM recolor_by_inds rai
+JOIN recolor_by_attributes ra ON ra.id = rai.recolor_by_attribute_id
+JOIN attributes a ON a.original_id = rai.ind_id AND a.original_type = 'Ind'
+
+UNION ALL
+
+SELECT ra.*, a.id AS attribute_id, ARRAY_AGG(DISTINCT flow_quals.value)
+FROM recolor_by_quals raq
+JOIN recolor_by_attributes ra ON ra.id = raq.recolor_by_attribute_id
+JOIN attributes a ON a.original_id = raq.qual_id AND a.original_type = 'Qual'
+JOIN flow_quals ON flow_quals.qual_id = raq.qual_id
+JOIN flows ON flow_quals.flow_id = flows.id AND flows.context_id = ra.context_id
+WHERE value NOT LIKE 'UNKNOWN%'
+GROUP BY ra.id, a.id

--- a/db/views/resize_by_attributes_mv_v03.sql
+++ b/db/views/resize_by_attributes_mv_v03.sql
@@ -1,0 +1,4 @@
+SELECT ra.*, a.id AS attribute_id
+FROM resize_by_quants raq
+JOIN resize_by_attributes ra ON ra.id = raq.resize_by_attribute_id
+JOIN attributes a ON a.original_id = raq.quant_id AND a.original_type = 'Quant'

--- a/frontend/docs/backend/database_objects_naming_conventions.md
+++ b/frontend/docs/backend/database_objects_naming_conventions.md
@@ -34,3 +34,7 @@ Same as for tables, but with \_mv suffix.
 ```
 
 These kinds of names are typically shorter that the default Rails-generated names. However, in case the name still goes over the limit, instead of enumerating the columns involved in the index we go for a descriptive name, e.g. xxx\_grouping\_idx.
+
+## Foreign keys
+
+No naming convention. However, please define with ON DELETE CASCADE behaviour (important for the data upload script).

--- a/spec/support/schemas/v3_map_layers.json
+++ b/spec/support/schemas/v3_map_layers.json
@@ -184,16 +184,6 @@
                 1990
               ]
             }
-          },
-          "aggregateMethod": {
-            "$id": "/properties/dimensions/items/properties/aggregateMethod",
-            "type": "string",
-            "title": "The Aggregatemethod Schema",
-            "description": "An explanation about the purpose of this instance.",
-            "default": "",
-            "examples": [
-              "SUM"
-            ]
           }
         },
         "required": [
@@ -208,8 +198,7 @@
           "layerAttributeId",
           "description",
           "colorScale",
-          "years",
-          "aggregateMethod"
+          "years"
         ]
       }
     },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168335405

The approach I took was to turn attributes_mv into a plain table and control the refreshing process using postgres "upsert". If, following a data release, the `name` of the original indicators remains the same, the id in attributes will be kept. New indicators will be assigned identifiers from a sequence.

I also took the opportunity to clean up:
- removed is visible / is temporal flags that used to be in attributes_mv, don't think they're used anywhere
- removed aggregate_method, which used to be returned in map layers endpoint, but don't think it was actually used anywhere as aggregation is carried out in the backend
- all of the xxx_attributes materialised views, which depend on the attributes table, can be refreshed in background

also sorted out this, as it was breaking the database validation script:
https://www.pivotaltracker.com/story/show/168661910

and this, as it was breaking the data upload:
https://www.pivotaltracker.com/story/show/168664213