### PR TITLE
Feat: sankey node tooltip + profiles node menu link

### DIFF
--- a/frontend/scripts/actions/app.actions.js
+++ b/frontend/scripts/actions/app.actions.js
@@ -185,7 +185,8 @@ export const getTopCountries = contexts => (dispatch, getState) => {
   const selectedContexts = contexts || [defaultSelectedContext];
 
   // TODO move into context.worldMap
-  const volumeIndicator = selectedContexts[0].resizeBy.find(i => i.name === 'Volume').attributeId;
+  const volumeIndicator = selectedContexts[0].resizeBy.find(i => i.name === 'Volume')
+  const volumneIndicatorId = volumeIndicator?.attributeId;
   const countryColumnId = selectedContexts[0].worldMap.countryColumnId;
 
   dispatch({
@@ -194,7 +195,7 @@ export const getTopCountries = contexts => (dispatch, getState) => {
   });
   const params = {
     contexts_ids: selectedContexts.map(c => c.id).join(),
-    attribute_id: volumeIndicator,
+    attribute_id: volumneIndicatorId,
     column_id: countryColumnId
   };
 

--- a/frontend/scripts/react-components/tool-links/tool-links.actions.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.actions.js
@@ -165,3 +165,13 @@ export function selectSearchNode(results) {
     payload: { results }
   };
 }
+
+export function goToProfileFromSankey({ profileType, ...query }) {
+  return {
+    type: 'profileNode',
+    payload: {
+      query,
+      profileType
+    }
+  };
+}

--- a/frontend/scripts/react-components/tool/map/map.container.js
+++ b/frontend/scripts/react-components/tool/map/map.container.js
@@ -1,15 +1,19 @@
 /* eslint-disable no-shadow */
 // see sankey.container for details on how to use those containers
-import { toggleMap, toggleMapLayerMenu } from 'actions/app.actions';
+import { toggleMap } from 'actions/app.actions';
 import {
   selectNodeFromGeoId,
   highlightNodeFromGeoId,
   saveMapView
 } from 'react-components/tool/tool.actions';
-import { getSelectedColumnsIds } from 'react-components/tool/tool.selectors';
+import {
+  getHighlightedNodesData,
+  getSelectedColumnsIds
+} from 'react-components/tool/tool.selectors';
 import {
   getVisibleNodes,
-  getSelectedBiomeFilter
+  getSelectedBiomeFilter,
+  getSelectedResizeBy
 } from 'react-components/tool-links/tool-links.selectors';
 import {
   getMapView,
@@ -19,7 +23,8 @@ import {
   getChoroplethOptions,
   getSelectedMapContextualLayersData,
   getShouldFitBoundsSelectedPolygons,
-  getMapDimensionsWarnings
+  getMapDimensionsWarnings,
+  getSelectedMapDimensionsData
 } from 'react-components/tool-layers/tool-layers.selectors';
 import { getSelectedContext } from 'reducers/app.selectors';
 import { mapToVanilla } from 'react-components/shared/vanilla-react-bridge.component';
@@ -47,7 +52,12 @@ const mapStateToProps = state => {
     visibleNodes: getVisibleNodes(state),
     selectedBiomeFilter: getSelectedBiomeFilter(state),
     basemapId: getBasemap(state),
-    selectedMapDimensionsWarnings: getMapDimensionsWarnings(state)
+    selectedMapDimensionsWarnings: getMapDimensionsWarnings(state),
+    selectedResizeBy: getSelectedResizeBy(state),
+    selectedMapDimensions: getSelectedMapDimensionsData(state),
+    highlightedNodesData: getHighlightedNodesData(state),
+    coordinates: state.toolLayers.highlightedNodeCoordinates,
+    nodeAttributes: state.toolLinks.data.nodeAttributes
   };
 };
 
@@ -122,6 +132,18 @@ const methodProps = [
     name: 'showMapWarnings',
     compared: ['selectedMapDimensionsWarnings'],
     returned: ['selectedMapDimensionsWarnings']
+  },
+  {
+    name: 'highlightNode',
+    compared: ['highlightedNodesData'],
+    returned: [
+      'nodeHeights',
+      'selectedResizeBy',
+      'selectedMapDimensions',
+      'highlightedNodesData',
+      'coordinates',
+      'nodeAttributes'
+    ]
   }
 ];
 
@@ -129,7 +151,6 @@ const mapDispatchToProps = {
   onPolygonClicked: geoId => selectNodeFromGeoId(geoId),
   onPolygonHighlighted: (geoId, coordinates) => highlightNodeFromGeoId(geoId, coordinates),
   onToggleMap: () => toggleMap(),
-  onToggleMapLayerMenu: () => toggleMapLayerMenu(),
   onMoveEnd: (latlng, zoom) => saveMapView(latlng, zoom)
 };
 

--- a/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.component.js
+++ b/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.component.js
@@ -1,6 +1,5 @@
 import formatValue from 'utils/formatValue';
 import NodeTitleTemplate from 'templates/tool/nodeTitle.ejs';
-import Tooltip from 'components/shared/info-tooltip.component';
 import getNodeMeta from 'reducers/helpers/getNodeMeta';
 
 import 'scripts/react-components/tool/tool-search/node-title-group/node-title-group.scss';
@@ -11,7 +10,6 @@ export default class {
     this.el = document.querySelector('.js-nodes-titles');
     this.container = this.el.querySelector('.js-nodes-titles-container');
     this.clear = this.el.querySelector('.js-nodes-titles-clear');
-    this.tooltip = new Tooltip('.js-node-tooltip');
     this.nodeTitleLinks = [];
     this.nodeTitleCloseButtons = [];
 
@@ -70,32 +68,6 @@ export default class {
       selectedYears,
       selectedContextId
     });
-  }
-
-  highlightNode({
-    attributes,
-    nodeHeights,
-    selectedMapDimensions,
-    highlightedNodesData,
-    coordinates,
-    selectedResizeBy
-  }) {
-    this.tooltip.hide();
-    if (highlightedNodesData === undefined || !highlightedNodesData.length) {
-      return;
-    }
-    // if we have coordinates, request came from hover on map, so we have a tooltip and don't need to show pill
-    // else show pill for sankey node
-    if (coordinates !== undefined) {
-      this._showTooltip({
-        nodeHeights,
-        nodesData: highlightedNodesData,
-        coordinates,
-        attributes,
-        selectedResizeBy,
-        selectedMapDimensions
-      });
-    }
   }
 
   _update({
@@ -208,48 +180,5 @@ export default class {
   _onNodeTitleCloseClick(e) {
     e.stopPropagation();
     this.callbacks.onCloseNodeClicked(parseInt(e.currentTarget.dataset.nodeId, 10));
-  }
-
-  _showTooltip({
-    nodeHeights,
-    nodesData,
-    coordinates,
-    selectedMapDimensions,
-    attributes,
-    selectedResizeBy
-  }) {
-    const node = nodesData[0];
-    const nodeHeight = nodeHeights && nodeHeights[node.id];
-
-    if (!coordinates) {
-      return;
-    }
-
-    let values = [];
-    if (attributes && selectedMapDimensions && selectedMapDimensions.length > 0) {
-      values = selectedMapDimensions
-        .map(dimension => {
-          const meta = getNodeMeta(dimension, node, attributes, selectedResizeBy, nodeHeights);
-          if (!meta) {
-            return null;
-          }
-          return {
-            title: dimension.name,
-            unit: dimension.unit,
-            value: formatValue(meta.value, dimension.name)
-          };
-        })
-        .filter(Boolean);
-    }
-
-    // if node is visible in sankey, quant is available
-    if (nodeHeight) {
-      values.push({
-        title: selectedResizeBy.label,
-        unit: selectedResizeBy.unit,
-        value: formatValue(nodeHeight.quant, selectedResizeBy.label)
-      });
-    }
-    this.tooltip.show(coordinates.pageX, coordinates.pageY, node.name, values);
   }
 }

--- a/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.component.js
+++ b/frontend/scripts/react-components/tool/nodes-titles/nodes-titles.component.js
@@ -1,5 +1,6 @@
 import formatValue from 'utils/formatValue';
 import NodeTitleTemplate from 'templates/tool/nodeTitle.ejs';
+import Tooltip from 'components/shared/info-tooltip.component';
 import getNodeMeta from 'reducers/helpers/getNodeMeta';
 
 import 'scripts/react-components/tool/tool-search/node-title-group/node-title-group.scss';
@@ -10,6 +11,7 @@ export default class {
     this.el = document.querySelector('.js-nodes-titles');
     this.container = this.el.querySelector('.js-nodes-titles-container');
     this.clear = this.el.querySelector('.js-nodes-titles-clear');
+    this.tooltip = new Tooltip('.js-node-tooltip');
     this.nodeTitleLinks = [];
     this.nodeTitleCloseButtons = [];
 
@@ -68,6 +70,32 @@ export default class {
       selectedYears,
       selectedContextId
     });
+  }
+
+  highlightNode({
+    attributes,
+    nodeHeights,
+    selectedMapDimensions,
+    highlightedNodesData,
+    coordinates,
+    selectedResizeBy
+  }) {
+    this.tooltip.hide();
+    if (highlightedNodesData === undefined || !highlightedNodesData.length) {
+      return;
+    }
+    // if we have coordinates, request came from hover on map, so we have a tooltip and don't need to show pill
+    // else show pill for sankey node
+    if (coordinates !== undefined) {
+      this._showTooltip({
+        nodeHeights,
+        nodesData: highlightedNodesData,
+        coordinates,
+        attributes,
+        selectedResizeBy,
+        selectedMapDimensions
+      });
+    }
   }
 
   _update({
@@ -180,5 +208,48 @@ export default class {
   _onNodeTitleCloseClick(e) {
     e.stopPropagation();
     this.callbacks.onCloseNodeClicked(parseInt(e.currentTarget.dataset.nodeId, 10));
+  }
+
+  _showTooltip({
+    nodeHeights,
+    nodesData,
+    coordinates,
+    selectedMapDimensions,
+    attributes,
+    selectedResizeBy
+  }) {
+    const node = nodesData[0];
+    const nodeHeight = nodeHeights && nodeHeights[node.id];
+
+    if (!coordinates) {
+      return;
+    }
+
+    let values = [];
+    if (attributes && selectedMapDimensions && selectedMapDimensions.length > 0) {
+      values = selectedMapDimensions
+        .map(dimension => {
+          const meta = getNodeMeta(dimension, node, attributes, selectedResizeBy, nodeHeights);
+          if (!meta) {
+            return null;
+          }
+          return {
+            title: dimension.name,
+            unit: dimension.unit,
+            value: formatValue(meta.value, dimension.name)
+          };
+        })
+        .filter(Boolean);
+    }
+
+    // if node is visible in sankey, quant is available
+    if (nodeHeight) {
+      values.push({
+        title: selectedResizeBy.label,
+        unit: selectedResizeBy.unit,
+        value: formatValue(nodeHeight.quant, selectedResizeBy.label)
+      });
+    }
+    this.tooltip.show(coordinates.pageX, coordinates.pageY, node.name, values);
   }
 }

--- a/frontend/scripts/react-components/tool/sankey/node-menu.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/node-menu.component.jsx
@@ -18,7 +18,7 @@ function NodeMenu(props) {
       <ul className="options">
         {options.map((option, i) => (
           <li key={option.id} className={cx('menu-item', option.className)}>
-            <button onClick={option.onClick}>
+            <button className="menu-item-button" onClick={option.onClick}>
               <Text color="grey" variant="mono" weight="light">
                 {option.label?.toUpperCase()}
               </Text>

--- a/frontend/scripts/react-components/tool/sankey/node-menu.scss
+++ b/frontend/scripts/react-components/tool/sankey/node-menu.scss
@@ -40,7 +40,7 @@
   .options {
     display: none;
     position: absolute;
-    width: 200px;
+    min-width: 200px;
     box-shadow: $box-shadow-big;
     font-family: $font-family-1;
     top: 2px;
@@ -63,12 +63,13 @@
       height: 32px;
       background-color: $white;
 
-      > button {
+      .menu-item-button {
         width: 100%;
         cursor: pointer;
         padding: 10px 8px;
         display: flex;
         justify-content: space-between;
+        white-space: nowrap;
       }
 
       > .icon {

--- a/frontend/scripts/react-components/tool/sankey/sankey-column.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey-column.component.jsx
@@ -5,10 +5,11 @@ import cx from 'classnames';
 function SankeyColumn(props) {
   const {
     column,
+    onNodeOver,
+    onNodeOut,
     highlightedNodeId,
     selectedNodesIds,
     onNodeClicked,
-    onNodeHighlighted,
     sankeyColumnsWidth
   } = props;
   return (
@@ -26,9 +27,9 @@ function SankeyColumn(props) {
               '-selected': selectedNodesIds.includes(node.id)
             })}
             transform={`translate(0,${node.y})`}
-            onClick={() => onNodeClicked(node.id, node.isAggregated)}
-            onMouseOver={() => !node.isAggregated && onNodeHighlighted(node.id)}
-            onMouseOut={() => !node.isAggregated && onNodeHighlighted(null)}
+            onClick={() => list.length > 1 && onNodeClicked(node.id, node.isAggregated)}
+            onMouseOver={e => onNodeOver(e, node)}
+            onMouseOut={e => onNodeOut(e, node)}
           >
             <rect
               className="sankey-node-rect"
@@ -65,7 +66,8 @@ SankeyColumn.propTypes = {
   highlightedNodeId: PropTypes.number,
   selectedNodesIds: PropTypes.array.isRequired,
   onNodeClicked: PropTypes.func.isRequired,
-  onNodeHighlighted: PropTypes.func.isRequired,
+  onNodeOver: PropTypes.func.isRequired,
+  onNodeOut: PropTypes.func.isRequired,
   sankeyColumnsWidth: PropTypes.number.isRequired
 };
 

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -16,13 +16,29 @@ import * as Defs from './sankey-defs.component';
 import 'react-components/tool/sankey/sankey.scss';
 
 function useMenuOptions(props) {
-  const { hasExpandedNodesIds, isReExpand, onExpandClick, onCollapseClick, onClearClick } = props;
+  const {
+    goToProfile,
+    hasExpandedNodesIds,
+    isReExpand,
+    onExpandClick,
+    onCollapseClick,
+    onClearClick,
+    lastSelectedNodeLink
+  } = props;
   return useMemo(() => {
     const items = [
       { id: 'expand', label: isReExpand ? 'Re-Expand' : 'Expand', onClick: onExpandClick },
       { id: 'collapse', label: 'Collapse', onClick: onCollapseClick },
       { id: 'clear', label: 'Clear Selection', onClick: onClearClick }
     ];
+
+    if (lastSelectedNodeLink) {
+      items.splice(2, 0, {
+        id: 'profile-link',
+        label: 'Go To Profile',
+        onClick: () => goToProfile(lastSelectedNodeLink)
+      });
+    }
 
     if (!isReExpand && hasExpandedNodesIds) {
       return items.filter(item => item.id !== 'expand');
@@ -32,11 +48,19 @@ function useMenuOptions(props) {
     }
 
     return items;
-  }, [hasExpandedNodesIds, isReExpand, onClearClick, onCollapseClick, onExpandClick]);
+  }, [
+    lastSelectedNodeLink,
+    hasExpandedNodesIds,
+    isReExpand,
+    onClearClick,
+    onCollapseClick,
+    onExpandClick,
+    goToProfile
+  ]);
 }
 
-function useMenuPosition(props, columns) {
-  const { selectedNodesIds, isReExpand } = props;
+function useMenuPosition(props) {
+  const { selectedNodesIds, isReExpand, columns } = props;
   const [menuPos, setMenuPos] = useState({ x: 0, y: 0 });
   const ref = useRef(null);
 
@@ -147,7 +171,7 @@ function Sankey(props) {
   const menuOptions = useMenuOptions(props);
   const [tooltipRef, setTooltip] = useVanillaTooltip(props);
   const [rect, svgRef] = useDomNodeRect(columns);
-  const [menuPos, scrollContainerRef] = useMenuPosition(props, columns);
+  const [menuPos, scrollContainerRef] = useMenuPosition(props);
   const placeholderHeight = useNodeRefHeight(scrollContainerRef);
 
   const getLinkColor = link => {

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -6,7 +6,6 @@ import Tooltip from 'components/shared/info-tooltip.component';
 import formatValue from 'utils/formatValue';
 import capitalize from 'lodash/capitalize';
 import startCase from 'lodash/startCase';
-import addApostrophe from 'utils/addApostrophe';
 import getNodeMeta from 'reducers/helpers/getNodeMeta';
 import Heading from 'react-components/shared/heading';
 import SankeyColumn from './sankey-column.component';
@@ -57,7 +56,7 @@ function useMenuOptions(props, hoveredSelectedNode) {
     if (link.profileType) {
       items.splice(2, 0, {
         id: 'profile-link',
-        label: `Go To ${nodeType}${addApostrophe(nodeType)} Profile`,
+        label: `Go To The ${nodeType} Profile`,
         onClick: () => goToProfile(link)
       });
     }
@@ -285,6 +284,8 @@ function Sankey(props) {
     }
 
     const nodeHeight = nodeHeights[node.id];
+    const tooltipPadding = 10;
+    const minTooltipWidth = 180;
     const tooltip = {
       title: node.name,
       values: [
@@ -296,8 +297,12 @@ function Sankey(props) {
       ],
       width: rect.width,
       height: rect.height,
-      x: e.clientX - rect.x,
-      y: e.clientY - rect.y
+      x:
+        // this math is here to prevent overflow from the viewport, or the tooltip appearing on top of the mouse
+        node.x + sankeyColumnsWidth + tooltipPadding > rect.width - minTooltipWidth
+          ? node.x
+          : node.x + sankeyColumnsWidth,
+      y: node.y - tooltipPadding
     };
     if (nodeAttributes && selectedMapDimensions && selectedMapDimensions.length > 0) {
       const nodeIndicators = selectedMapDimensions
@@ -351,7 +356,13 @@ function Sankey(props) {
             </Heading>
           </div>
         )}
-        <NodeMenu menuPos={menuPos} isVisible={selectedNodesIds.length > 0} options={menuOptions} />
+        {!loading && (
+          <NodeMenu
+            menuPos={menuPos}
+            isVisible={selectedNodesIds.length > 0}
+            options={menuOptions}
+          />
+        )}
         <div ref={tooltipRef} className="c-info-tooltip" />
         <svg
           ref={svgRef}

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -33,12 +33,12 @@ function useMenuOptions(props, hoveredSelectedNode) {
       { id: 'clear', label: 'Clear Selection', onClick: onClearClick }
     ];
 
-    let nodeName = null;
+    let nodeType = null;
     let link = {};
 
     if (lastSelectedNodeLink) {
-      const { name, ...params } = lastSelectedNodeLink;
-      nodeName = name;
+      const { type, ...params } = lastSelectedNodeLink;
+      nodeType = type;
       link = {
         ...params
       };
@@ -49,7 +49,7 @@ function useMenuOptions(props, hoveredSelectedNode) {
       hoveredSelectedNode.isUnknown !== true &&
       hoveredSelectedNode.isDomesticConsumption !== true
     ) {
-      nodeName = hoveredSelectedNode.name;
+      nodeType = hoveredSelectedNode.type;
       link.profileType = hoveredSelectedNode.profileType;
       link.nodeId = hoveredSelectedNode.id;
     }
@@ -57,7 +57,7 @@ function useMenuOptions(props, hoveredSelectedNode) {
     if (link.profileType) {
       items.splice(2, 0, {
         id: 'profile-link',
-        label: `Go To ${nodeName}${addApostrophe(nodeName)} Profile`,
+        label: `Go To ${nodeType}${addApostrophe(nodeType)} Profile`,
         onClick: () => goToProfile(link)
       });
     }

--- a/frontend/scripts/react-components/tool/sankey/sankey.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.js
@@ -8,7 +8,8 @@ import {
   getIsReExpand,
   getSankeyColumns,
   getSankeyLinks,
-  getGapBetweenColumns
+  getGapBetweenColumns,
+  getLastSelectedNodeLink
 } from 'react-components/tool/sankey/sankey.selectors';
 import { connect } from 'react-redux';
 import Sankey from 'react-components/tool/sankey/sankey.component';
@@ -17,7 +18,8 @@ import {
   collapseSankey,
   expandSankey,
   highlightNode,
-  selectNodes
+  selectNodes,
+  goToProfileFromSankey
 } from 'react-components/tool-links/tool-links.actions';
 import { getSelectedMapDimensionsData } from 'react-components/tool-layers/tool-layers.selectors';
 
@@ -37,11 +39,13 @@ const mapStateToProps = state => ({
   hasExpandedNodesIds: getHasExpandedNodesIds(state),
   gapBetweenColumns: getGapBetweenColumns(state),
   flowsLoading: state.toolLinks.flowsLoading,
+  lastSelectedNodeLink: getLastSelectedNodeLink(state),
   highlightedNodeId: state.toolLinks.highlightedNodeId,
   selectedMapDimensions: getSelectedMapDimensionsData(state)
 });
 
 const mapDispatchToProps = {
+  goToProfile: goToProfileFromSankey,
   onNodeClicked: selectNodes,
   onNodeHighlighted: highlightNode,
   onExpandClick: expandSankey,

--- a/frontend/scripts/react-components/tool/sankey/sankey.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.js
@@ -19,6 +19,7 @@ import {
   highlightNode,
   selectNodes
 } from 'react-components/tool-links/tool-links.actions';
+import { getSelectedMapDimensionsData } from 'react-components/tool-layers/tool-layers.selectors';
 
 const mapStateToProps = state => ({
   links: getSankeyLinks(state),
@@ -26,6 +27,8 @@ const mapStateToProps = state => ({
   isReExpand: getIsReExpand(state),
   sankeySize: state.app.sankeySize,
   maxHeight: getSankeyMaxHeight(state),
+  nodeHeights: state.toolLinks.data.nodeHeights,
+  nodeAttributes: state.toolLinks.data.nodeAttributes,
   sankeyColumnsWidth: state.toolLinks.sankeyColumnsWidth,
   selectedResizeBy: getSelectedResizeBy(state),
   detailedView: state.toolLinks.detailedView,
@@ -34,7 +37,8 @@ const mapStateToProps = state => ({
   hasExpandedNodesIds: getHasExpandedNodesIds(state),
   gapBetweenColumns: getGapBetweenColumns(state),
   flowsLoading: state.toolLinks.flowsLoading,
-  highlightedNodeId: state.toolLinks.highlightedNodeId
+  highlightedNodeId: state.toolLinks.highlightedNodeId,
+  selectedMapDimensions: getSelectedMapDimensionsData(state)
 });
 
 const mapDispatchToProps = {

--- a/frontend/scripts/react-components/tool/sankey/sankey.scss
+++ b/frontend/scripts/react-components/tool/sankey/sankey.scss
@@ -30,17 +30,10 @@
     }
 
     &.-is-alone-in-column {
-      pointer-events: none;
-
-      & > .sankey-node-rect {
-        fill: $background-white;
-      }
+      cursor: default;
     }
 
     &.-selected {
-      // disabled for now because of a Firefox rendering bug
-      //filter: url(#drop-shadow); //ignore sasslint warning here
-
       .sankey-node-rect {
         fill: $white;
         stroke: $charcoal-grey;

--- a/frontend/scripts/react-components/tool/sankey/sankey.selectors.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.selectors.js
@@ -17,6 +17,7 @@ import sortVisibleNodes from 'reducers/helpers/sortVisibleNodes';
 import mergeLinks from 'reducers/helpers/mergeLinks';
 import filterLinks from 'reducers/helpers/filterLinks';
 import splitLinksByColumn from 'reducers/helpers/splitLinksByColumn';
+import { getSelectedContext, getSelectedYears } from 'reducers/app.selectors';
 
 const getToolNodeHeights = state => state.toolLinks.data.nodeHeights;
 const getToolColumns = state => state.toolLinks.data.columns;
@@ -262,5 +263,39 @@ export const getSankeyLinks = createSelector(
     });
 
     return sankeyLinks;
+  }
+);
+
+export const getLastSelectedNodeLink = createSelector(
+  [getToolSelectedNodesIds, getToolNodes, getToolColumns, getSelectedContext, getSelectedYears],
+  (selectedNodesIds, nodes, columns, selectedContext, selectedYears) => {
+    if (!nodes || !columns || !selectedContext || selectedNodesIds.length === 0) {
+      return null;
+    }
+
+    const last = selectedNodesIds.length - 1;
+    const lastId = selectedNodesIds[last];
+    const node = nodes[lastId];
+    const column = columns[(node?.columnId)];
+
+    if (!node || !column) {
+      return null;
+    }
+
+    const link =
+      node.isUnknown !== true &&
+      node.isDomesticConsumption !== true &&
+      column?.profileType !== undefined &&
+      column?.profileType !== null;
+
+    if (link) {
+      return {
+        nodeId: node.id,
+        year: selectedYears[0],
+        contextId: selectedContext.id,
+        profileType: column.profileType
+      };
+    }
+    return null;
   }
 );

--- a/frontend/scripts/react-components/tool/sankey/sankey.selectors.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.selectors.js
@@ -283,7 +283,7 @@ export const getLastSelectedNodeLink = createSelector(
     }
 
     return {
-      name: node.name,
+      type: node.type,
       nodeId: node.id,
       year: selectedYears[0],
       contextId: selectedContext.id,

--- a/frontend/scripts/react-components/tool/sankey/sankey.selectors.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.selectors.js
@@ -282,20 +282,12 @@ export const getLastSelectedNodeLink = createSelector(
       return null;
     }
 
-    const link =
-      node.isUnknown !== true &&
-      node.isDomesticConsumption !== true &&
-      column?.profileType !== undefined &&
-      column?.profileType !== null;
-
-    if (link) {
-      return {
-        nodeId: node.id,
-        year: selectedYears[0],
-        contextId: selectedContext.id,
-        profileType: column.profileType
-      };
-    }
-    return null;
+    return {
+      name: node.name,
+      nodeId: node.id,
+      year: selectedYears[0],
+      contextId: selectedContext.id,
+      profileType: column.profileType
+    };
   }
 );

--- a/frontend/scripts/react-components/tool/tool.component.jsx
+++ b/frontend/scripts/react-components/tool/tool.component.jsx
@@ -88,7 +88,7 @@ const renderVainillaComponents = () => (
     <Tooltip />
     {!ENABLE_REDESIGN_PAGES && <LegacyBasemaps />}
     <MapContextContainer />
-    <NodesTitlesContainer />
+    {!ENABLE_REDESIGN_PAGES && <NodesTitlesContainer />}
     <ModalContainer />
   </>
 );


### PR DESCRIPTION
This PR removed the node-titles vanilla component and replaces its functionality with a tooltip that appears on node hover plus a link to profiles that appears in the node menu.
![Screen Shot 2019-09-22 at 18 37 59](https://user-images.githubusercontent.com/12124839/65391328-4118ea80-dd68-11e9-98e8-2bcd9714a003.png)
![Screen Shot 2019-09-22 at 18 30 32](https://user-images.githubusercontent.com/12124839/65391329-41b18100-dd68-11e9-8c60-11a852958286.png)

