### PR TITLE
Feature/quick sankey cards

### DIFF
--- a/app/admin/api/v3/sankey_card_link.rb
+++ b/app/admin/api/v3/sankey_card_link.rb
@@ -1,0 +1,46 @@
+ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
+  menu parent: 'Sankey & Map'
+
+  permit_params :link_param, :title, :subtitle
+
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :link_param, input_html: {value: f.object.link}, as: :string, required: true
+      input :title, as: :string, required: true
+      input :subtitle, as: :string
+    end
+    f.actions
+  end
+
+  index do
+    column('Title', sortable: true, &:title)
+    column :subtitle
+    column('Link', sortable: true) do |sankey_card_link|
+      link_to(sankey_card_link.link, sankey_card_link.link)
+    end
+    actions
+  end
+
+  filter :link_contains, as: :string, label: 'Link'
+
+  show do
+    attributes_table do
+      row :link do |sankey_card_link|
+        link_to(sankey_card_link.link, sankey_card_link.link)
+      end
+      row :title
+      row :subtitle
+      row :created_at
+      row :updated_at
+    end
+  end
+end

--- a/app/models/api/v3/commodity.rb
+++ b/app/models/api/v3/commodity.rb
@@ -22,6 +22,8 @@ module Api
       has_many :quant_commodity_properties
       has_many :qual_commodity_properties
 
+      has_many :sankey_card_links
+
       validates :name, presence: true, uniqueness: true
 
       def self.import_key

--- a/app/models/api/v3/country.rb
+++ b/app/models/api/v3/country.rb
@@ -24,6 +24,8 @@ module Api
       has_many :quant_country_properties
       has_many :qual_country_properties
 
+      has_many :sankey_card_links
+
       delegate :latitude, to: :country_property
       delegate :longitude, to: :country_property
       delegate :zoom, to: :country_property

--- a/app/models/api/v3/node.rb
+++ b/app/models/api/v3/node.rb
@@ -39,6 +39,9 @@ module Api
 
       has_many :nodes_stats
 
+      has_many :sankey_card_link_nodes
+      has_many :sankey_card_links, through: :sankey_card_link_nodes
+
       def stringify
         name + ' - ' + node_type.name + ' - ' + node_type&.context_node_types&.first&.context&.country&.name + ' ' + node_type&.context_node_types&.first&.context&.commodity&.name
       end

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -25,6 +25,13 @@ module Api
       class Attribute < Api::V3::Readonly::BaseModel
         self.table_name = 'attributes'
 
+        has_many :cont_attribute_sankey_card_links,
+          class_name: 'Api::V3::SankeyCardLink',
+          inverse_of: :cont_attribute
+        has_many :ncont_attribute_sankey_card_links,
+          class_name: 'Api::V3::SankeyCardLink',
+          inverse_of: :ncont_attribute
+
         delegate :values_meta, to: :original_attribute
 
         class << self

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -1,8 +1,37 @@
+# == Schema Information
+#
+# Table name: sankey_card_links
+#
+#  id         :bigint(8)        not null, primary key
+#  link       :json             not null
+#  title      :text             not null
+#  subtitle   :text
+#
+
 module Api
   module V3
     class SankeyCardLink < YellowTable
-      validates :link, presence: true
+      attr_accessor :link_param
+
+      validates :host, presence: true
+      validates :query_params, presence: true
       validates :title, presence: true
+
+      before_save :extract_link_params
+
+      def link
+        "#{self.host}?#{self.query_params.to_query}"
+      end
+
+      private
+
+      def extract_link_params
+        uri = URI.parse link_param
+        self.host = uri.host
+
+        ary = URI.decode_www_form(uri.query).to_h
+        self.query_params = ary
+      end
     end
   end
 end

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -51,6 +51,10 @@ module Api
         "http://#{self.host}?#{self.query_params&.to_query}"
       end
 
+      def self.ransackable_scopes(*)
+        %i(link_contains)
+      end
+
       private
 
       def extract_link_params

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -1,0 +1,8 @@
+module Api
+  module V3
+    class SankeyCardLink < YellowTable
+      validates :link, presence: true
+      validates :title, presence: true
+    end
+  end
+end

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -2,11 +2,29 @@
 #
 # Table name: sankey_card_links
 #
-#  id           :bigint(8)        not null, primary key
-#  host         :text             not null
-#  query_params :json             not null
-#  title        :text             not null
-#  subtitle     :text
+#  id                 :bigint(8)        not null, primary key
+#  host               :text             not null
+#  query_params       :json             not null
+#  title              :text             not null
+#  subtitle           :text
+#  commodity_id       :bigint(8)
+#  country_id         :bigint(8)
+#  cont_attribute_id  :bigint(8)
+#  ncont_attribute_id :bigint(8)
+#
+# Indexes
+#
+#  index_sankey_card_links_on_commodity_id        (commodity_id)
+#  index_sankey_card_links_on_cont_attribute_id   (cont_attribute_id)
+#  index_sankey_card_links_on_country_id          (country_id)
+#  index_sankey_card_links_on_ncont_attribute_id  (ncont_attribute_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (commodity_id => commodities.id)
+#  fk_rails_...  (cont_attribute_id => attributes.id)
+#  fk_rails_...  (country_id => countries.id)
+#  fk_rails_...  (ncont_attribute_id => attributes.id)
 #
 
 module Api
@@ -14,7 +32,7 @@ module Api
     class SankeyCardLink < YellowTable
       attr_accessor :link_param
 
-      VALID_QUERY_PARAMS =%w[
+      VALID_QUERY_PARAMS = %w[
         commodity_id
         country_id
         nodes_ids
@@ -24,18 +42,42 @@ module Api
         end_year
       ]
 
+      REQUIRED_QUERY_PARAMS = %w[
+        commodity_id
+        country_id
+        cont_attribute_id
+        ncont_attribute_id
+      ]
+
       scope :link_contains, ->(link) {
         where("host LIKE '%#{link}%' OR
                query_params->>'#{link}' IS NOT NULL OR
-               query_params->>'commodity_id' LIKE '%#{link}%' OR
-               query_params->>'country_id' LIKE '%#{link}%' OR
+               commodity_id = '%#{link}%' OR
+               country_id = '%#{link}%' OR
+               cont_attribute_id = '%#{link}%' OR
+               ncont_attribute_id = '%#{link}%' OR
                query_params->>'nodes_ids' LIKE '%#{link}%' OR
-               query_params->>'cont_attribute_id' LIKE '%#{link}%' OR
-               query_params->>'ncont_attribute_id' LIKE '%#{link}%' OR
                query_params->>'start_year' LIKE '%#{link}%' OR
                query_params->>'end_year' LIKE '%#{link}%'"
         )
       }
+
+      belongs_to :commodity
+      belongs_to :country
+      belongs_to :cont_attribute,
+        class_name: 'Api::V3::Readonly::Attribute',
+        foreign_key: 'cont_attribute_id',
+        inverse_of: :cont_attribute_sankey_card_links,
+        dependent: :destroy
+      belongs_to :ncont_attribute,
+        class_name: 'Api::V3::Readonly::Attribute',
+        foreign_key: 'ncont_attribute_id',
+        inverse_of: :ncont_attribute_sankey_card_links,
+        dependent: :destroy
+      has_many :sankey_card_link_nodes
+      has_many :nodes,
+        class_name: 'Api::V3::SankeyCardLinkNode',
+        through: :sankey_card_link_nodes
 
       validates :host, presence: true
       validates :query_params, presence: true
@@ -44,6 +86,8 @@ module Api
       validate :check_valid_query_params
 
       before_validation :extract_link_params
+      before_validation :extract_required_params
+      after_commit :add_nodes_relations
 
       def link
         return '' unless self.host && self.query_params
@@ -55,22 +99,64 @@ module Api
         %i(link_contains)
       end
 
+      def self.blue_foreign_keys
+        [
+          {name: :commodity_id, table_class: Api::V3::Commodity},
+          {name: :country_id, table_class: Api::V3::Country},
+          {name: :cont_attribute_id, table_class: Api::V3::Readonly::Attribute},
+          {name: :ncont_attribute_id, table_class: Api::V3::Readonly::Attribute}
+        ]
+      end
+
       private
 
       def extract_link_params
         return unless link_param
-
         uri = URI.parse link_param
         self.host = uri.host
 
+        return unless uri.query
         ary = URI.decode_www_form(uri.query).to_h
         self.query_params = ary
       end
 
-      def check_valid_query_params
-        return unless ((query_params || {}).keys - VALID_QUERY_PARAMS).any?
+      def extract_required_params
+        return unless self.query_params
 
-        errors.add(:query_params, 'includes invalid parameters')
+        REQUIRED_QUERY_PARAMS.each do |required_parameter|
+          self.send("#{required_parameter}=", self.query_params[required_parameter])
+        end
+      end
+
+      def add_nodes_relations
+        nodes_ids = self.query_params['nodes_ids'].split(',')
+        nodes_ids.each do |node_id|
+          Api::V3::SankeyCardLinkNode.find_or_create_by!(
+            node_id: node_id,
+            sankey_card_link_id: self.id
+          )
+        end
+
+        # Remove old sankey card link nodes relations
+        Api::V3::SankeyCardLinkNode.
+          where(sankey_card_link_id: self.id).
+          where.not(node_id: nodes_ids).
+          destroy_all
+      end
+
+      def check_valid_query_params
+        # Check if we are indicating only permitted params
+        if ((query_params || {}).keys - VALID_QUERY_PARAMS).any?
+          errors.add(:link_param, 'includes invalid parameters')
+        end
+
+        # Check if we are including all obligatory params
+        if (REQUIRED_QUERY_PARAMS - (query_params || {}).keys).any?
+          errors.add(
+            :link_param,
+            'must specify commodity, country, cont_attribute and ncont_attribute'
+          )
+        end
       end
     end
   end

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -2,10 +2,11 @@
 #
 # Table name: sankey_card_links
 #
-#  id         :bigint(8)        not null, primary key
-#  link       :json             not null
-#  title      :text             not null
-#  subtitle   :text
+#  id           :bigint(8)        not null, primary key
+#  host         :text             not null
+#  query_params :json             not null
+#  title        :text             not null
+#  subtitle     :text
 #
 
 module Api
@@ -13,24 +14,59 @@ module Api
     class SankeyCardLink < YellowTable
       attr_accessor :link_param
 
+      VALID_QUERY_PARAMS =%w[
+        commodity_id
+        country_id
+        nodes_ids
+        cont_attribute_id
+        ncont_attribute_id
+        start_year
+        end_year
+      ]
+
+      scope :link_contains, ->(link) {
+        where("host LIKE '%#{link}%' OR
+               query_params->>'#{link}' IS NOT NULL OR
+               query_params->>'commodity_id' LIKE '%#{link}%' OR
+               query_params->>'country_id' LIKE '%#{link}%' OR
+               query_params->>'nodes_ids' LIKE '%#{link}%' OR
+               query_params->>'cont_attribute_id' LIKE '%#{link}%' OR
+               query_params->>'ncont_attribute_id' LIKE '%#{link}%' OR
+               query_params->>'start_year' LIKE '%#{link}%' OR
+               query_params->>'end_year' LIKE '%#{link}%'"
+        )
+      }
+
       validates :host, presence: true
       validates :query_params, presence: true
       validates :title, presence: true
 
-      before_save :extract_link_params
+      validate :check_valid_query_params
+
+      before_validation :extract_link_params
 
       def link
-        "#{self.host}?#{self.query_params.to_query}"
+        return '' unless self.host && self.query_params
+
+        "http://#{self.host}?#{self.query_params&.to_query}"
       end
 
       private
 
       def extract_link_params
+        return unless link_param
+
         uri = URI.parse link_param
         self.host = uri.host
 
         ary = URI.decode_www_form(uri.query).to_h
         self.query_params = ary
+      end
+
+      def check_valid_query_params
+        return unless ((query_params || {}).keys - VALID_QUERY_PARAMS).any?
+
+        errors.add(:query_params, 'includes invalid parameters')
       end
     end
   end

--- a/app/models/api/v3/sankey_card_link_node.rb
+++ b/app/models/api/v3/sankey_card_link_node.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: sankey_card_link_nodes
+#
+#  id                  :bigint(8)        not null, primary key
+#  sankey_card_link_id :bigint(8)
+#  node_id             :bigint(8)
+#
+# Indexes
+#
+#  index_sankey_card_link_nodes_on_node_id              (node_id)
+#  index_sankey_card_link_nodes_on_sankey_card_link_id  (sankey_card_link_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (node_id => nodes.id)
+#  fk_rails_...  (sankey_card_link_id => sankey_card_links.id)
+#
+
+module Api
+  module V3
+    class SankeyCardLinkNode < YellowTable
+      belongs_to :sankey_card_link,
+        class_name: 'Api::V3::SankeyCardLink',
+        inverse_of: :sankey_card_link_nodes
+      belongs_to :node,
+        class_name: 'Api::V3::Node',
+        inverse_of: :sankey_card_link_nodes
+
+      validates :sankey_card_link_id, uniqueness: {scope: :node_id}
+    end
+  end
+end

--- a/app/services/api/v3/import/tables.rb
+++ b/app/services/api/v3/import/tables.rb
@@ -8,14 +8,16 @@ module Api
             table_class: Api::V3::Country,
             yellow_tables: [
               Api::V3::CountryProperty,
-              Api::V3::DashboardTemplateCountry
+              Api::V3::DashboardTemplateCountry,
+              Api::V3::SankeyCardLink
             ]
           },
           {
             table_class: Api::V3::Commodity,
             yellow_tables: [
               Api::V3::DashboardTemplateCommodity,
-              Api::V3::TopProfileImage
+              Api::V3::TopProfileImage,
+              Api::V3::SankeyCardLink
             ]
           },
           {
@@ -52,8 +54,8 @@ module Api
               Api::V3::TopProfile,
               Api::V3::DashboardTemplateSource,
               Api::V3::DashboardTemplateCompany,
-              Api::V3::DashboardTemplateDestination
-
+              Api::V3::DashboardTemplateDestination,
+              Api::V3::SankeyCardLinkNode
             ]
           },
           {

--- a/db/migrate/20190920090440_create_sankey_card_links.rb
+++ b/db/migrate/20190920090440_create_sankey_card_links.rb
@@ -1,7 +1,8 @@
 class CreateSankeyCardLinks < ActiveRecord::Migration[5.2]
   def change
     create_table :sankey_card_links do |t|
-      t.json :link, null: false
+      t.text :host, null: false
+      t.json :query_params, null: false
       t.text :title, null: false
       t.text :subtitle
 

--- a/db/migrate/20190920090440_create_sankey_card_links.rb
+++ b/db/migrate/20190920090440_create_sankey_card_links.rb
@@ -1,0 +1,11 @@
+class CreateSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sankey_card_links do |t|
+      t.json :link, null: false
+      t.text :title, null: false
+      t.text :subtitle
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190923143224_add_relations_to_sankey_card_links.rb
+++ b/db/migrate/20190923143224_add_relations_to_sankey_card_links.rb
@@ -1,0 +1,13 @@
+class AddRelationsToSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :sankey_card_links, :commodity, foreign_key: true
+    add_reference :sankey_card_links, :country, foreign_key: true
+    add_reference :sankey_card_links, :cont_attribute, foreign_key: {to_table: :attributes}
+    add_reference :sankey_card_links, :ncont_attribute, foreign_key: {to_table: :attributes}
+
+    create_table :sankey_card_link_nodes do |t|
+      t.references :sankey_card_link, foreign_key: true
+      t.references :node, foreign_key: true
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3573,6 +3573,41 @@ ALTER SEQUENCE public.dashboards_quants_id_seq OWNED BY public.dashboards_quants
 
 
 --
+-- Name: node_quals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.node_quals (
+    id integer NOT NULL,
+    node_id integer NOT NULL,
+    qual_id integer NOT NULL,
+    year integer,
+    value text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
+
+
+--
+-- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
+
+
+--
+-- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
+
+
+--
 -- Name: dashboards_sources_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -4936,41 +4971,6 @@ ALTER SEQUENCE public.node_properties_id_seq OWNED BY public.node_properties.id;
 
 
 --
--- Name: node_quals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.node_quals (
-    id integer NOT NULL,
-    node_id integer NOT NULL,
-    qual_id integer NOT NULL,
-    year integer,
-    value text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
-
-
---
--- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
-
-
---
--- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
-
-
---
 -- Name: node_quals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -5906,39 +5906,6 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
--- Name: sankey_card_links; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sankey_card_links (
-    id bigint NOT NULL,
-    link json NOT NULL,
-    title text NOT NULL,
-    subtitle text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: sankey_card_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sankey_card_links_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sankey_card_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sankey_card_links_id_seq OWNED BY public.sankey_card_links.id;
-
-
---
 -- Name: sankey_nodes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -6580,13 +6547,6 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
-
-
---
--- Name: sankey_card_links id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sankey_card_links ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_links_id_seq'::regclass);
 
 
 --
@@ -7678,14 +7638,6 @@ ALTER TABLE ONLY public.resize_by_quants
 
 ALTER TABLE ONLY public.resize_by_quants
     ADD CONSTRAINT resize_by_quants_resize_by_attribute_id_quant_id_key UNIQUE (resize_by_attribute_id, quant_id);
-
-
---
--- Name: sankey_card_links sankey_card_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sankey_card_links
-    ADD CONSTRAINT sankey_card_links_pkey PRIMARY KEY (id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3573,41 +3573,6 @@ ALTER SEQUENCE public.dashboards_quants_id_seq OWNED BY public.dashboards_quants
 
 
 --
--- Name: node_quals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.node_quals (
-    id integer NOT NULL,
-    node_id integer NOT NULL,
-    qual_id integer NOT NULL,
-    year integer,
-    value text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
-
-
---
--- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
-
-
---
--- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
-
-
---
 -- Name: dashboards_sources_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -4971,6 +4936,41 @@ ALTER SEQUENCE public.node_properties_id_seq OWNED BY public.node_properties.id;
 
 
 --
+-- Name: node_quals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.node_quals (
+    id integer NOT NULL,
+    node_id integer NOT NULL,
+    qual_id integer NOT NULL,
+    year integer,
+    value text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
+
+
+--
+-- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
+
+
+--
+-- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
+
+
+--
 -- Name: node_quals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -5906,6 +5906,40 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
+-- Name: sankey_card_links; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sankey_card_links (
+    id bigint NOT NULL,
+    host text NOT NULL,
+    query_params json NOT NULL,
+    title text NOT NULL,
+    subtitle text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sankey_card_links_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sankey_card_links_id_seq OWNED BY public.sankey_card_links.id;
+
+
+--
 -- Name: sankey_nodes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -6547,6 +6581,13 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: sankey_card_links id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_links_id_seq'::regclass);
 
 
 --
@@ -7638,6 +7679,14 @@ ALTER TABLE ONLY public.resize_by_quants
 
 ALTER TABLE ONLY public.resize_by_quants
     ADD CONSTRAINT resize_by_quants_resize_by_attribute_id_quant_id_key UNIQUE (resize_by_attribute_id, quant_id);
+
+
+--
+-- Name: sankey_card_links sankey_card_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT sankey_card_links_pkey PRIMARY KEY (id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5906,6 +5906,39 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
+-- Name: sankey_card_links; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sankey_card_links (
+    id bigint NOT NULL,
+    link json NOT NULL,
+    title text NOT NULL,
+    subtitle text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sankey_card_links_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sankey_card_links_id_seq OWNED BY public.sankey_card_links.id;
+
+
+--
 -- Name: sankey_nodes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -6547,6 +6580,13 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: sankey_card_links id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_links_id_seq'::regclass);
 
 
 --
@@ -7638,6 +7678,14 @@ ALTER TABLE ONLY public.resize_by_quants
 
 ALTER TABLE ONLY public.resize_by_quants
     ADD CONSTRAINT resize_by_quants_resize_by_attribute_id_quant_id_key UNIQUE (resize_by_attribute_id, quant_id);
+
+
+--
+-- Name: sankey_card_links sankey_card_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT sankey_card_links_pkey PRIMARY KEY (id);
 
 
 --
@@ -9372,7 +9420,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190823135415'),
 ('20190919063754'),
 ('20190919211340'),
+('20190920090440'),
 ('20190923074833'),
 ('20190924075531');
-
 

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
     sequence(:host) { |n| "host#{n}.com" }
-    sequence(:query_params) { |n| {property: n} }
+    sequence(:query_params) { |n| {nodes_ids: [n]} }
   end
 end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
-    sequence(:link) { |n| {property: n} }
+    sequence(:host) { |n| "host#{n}.com" }
+    sequence(:query_params) { |n| {property: n} }
   end
 end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
+    sequence(:title) { |n| "Title#{n}" }
+    sequence(:link) { |n| {property: n} }
+  end
+end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
     sequence(:host) { |n| "host#{n}.com" }
-    sequence(:query_params) { |n| {nodes_ids: [n]} }
+    query_params { {
+      commodity_id: Api::V3::Commodity.first.id,
+      country_id: Api::V3::Country.first.id,
+      cont_attribute_id: Api::V3::Readonly::Attribute.first.id,
+      ncont_attribute_id: Api::V3::Readonly::Attribute.first.id
+    } }
   end
 end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::SankeyCardLink, type: :model do
+  describe :validate do
+    let(:sankey_card_link_without_link) {
+      FactoryBot.build(:api_v3_sankey_card_link, link: nil)
+    }
+    let(:sankey_card_link_without_title) {
+      FactoryBot.build(:api_v3_sankey_card_link, title: nil)
+    }
+
+    it 'fails when link blank' do
+      expect(sankey_card_link_without_link).to have(1).errors_on(:link)
+    end
+
+    it 'fails when title blank' do
+      expect(sankey_card_link_without_title).to have(1).errors_on(:title)
+    end
+  end
+end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::SankeyCardLink, type: :model do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil resize by attributes'
+
+  before do
+    Api::V3::Readonly::Node.refresh(sync: true)
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+  end
+
   let(:sankey_card_link) {
     FactoryBot.build(:api_v3_sankey_card_link)
   }
@@ -10,13 +18,16 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
       FactoryBot.build(:api_v3_sankey_card_link, host: nil)
     }
     let(:sankey_card_link_without_query_params) {
-      FactoryBot.build(:api_v3_sankey_card_link, query_params: nil)
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: nil, link_param: 'http://test.com')
     }
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
     let(:sankey_card_link_with_invalid_query_params) {
-      FactoryBot.build(:api_v3_sankey_card_link, query_params: {one: 1})
+      FactoryBot.build(:api_v3_sankey_card_link, link_param: 'http://test.com?one=1')
+    }
+    let(:sankey_card_link_without_required_params) {
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: {commodity_id: 1})
     }
 
     it 'fails when host blank' do
@@ -28,7 +39,11 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     end
 
     it 'fails when query_params include invalid parameters' do
-      expect(sankey_card_link_with_invalid_query_params).to have(1).errors_on(:query_params)
+      expect(sankey_card_link_with_invalid_query_params).to have(2).errors_on(:link_param)
+    end
+
+    it 'fails when query_params doesnt include all required parameters' do
+      expect(sankey_card_link_without_required_params).to have(1).errors_on(:link_param)
     end
 
     it 'fails when title blank' do
@@ -47,12 +62,47 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
   end
 
   describe :callbacks do
-    describe 'before_save' do
+    describe 'before_validation' do
       describe '#extract_link_params' do
         it 'extract parameters from link' do
-          sankey_card_link.update_attributes(link_param: 'http://test.com?one=1')
+          sankey_card_link.update_attributes(link_param: 'http://test.com?start_year=1')
           expect(sankey_card_link.host).to eql 'test.com'
-          expect(sankey_card_link.query_params).to eql({'one' => '1'})
+          expect(sankey_card_link.query_params).to eql({'start_year' => '1'})
+        end
+      end
+
+      describe '#extract_required_params' do
+        it 'extract relations from the required params' do
+          sankey_card_link.update_attributes(link_param: 'http://test.com?commodity_id=1')
+          expect(sankey_card_link.host).to eql 'test.com'
+          expect(sankey_card_link.commodity_id).to eql 1
+        end
+      end
+    end
+
+    describe 'after_commit' do
+      describe '#add_nodes_relations' do
+        it 'extract new nodes relations' do
+          expect do
+            node = Api::V3::Node.first
+            sankey_card_link.update_attributes(
+              link_param: "#{sankey_card_link.link}&nodes_ids=#{node.id}"
+            )
+          end.to change { Api::V3::SankeyCardLinkNode.count }.by(1)
+        end
+
+        it 'removes old nodes relations' do
+          base_link = sankey_card_link.link
+          nodes = Api::V3::Node.all
+          sankey_card_link.update_attributes(
+            link_param: "#{base_link}&nodes_ids=#{nodes.first.id},#{nodes.second.id}"
+          )
+
+          expect do
+            sankey_card_link.update_attributes(
+              link_param: "#{base_link}&nodes_ids=#{nodes.first.id}"
+            )
+          end.to change { Api::V3::SankeyCardLinkNode.count }.by(-1)
         end
       end
     end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -1,20 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::SankeyCardLink, type: :model do
+  let(:sankey_card_link) {
+    FactoryBot.build(:api_v3_sankey_card_link)
+  }
+
   describe :validate do
-    let(:sankey_card_link_without_link) {
-      FactoryBot.build(:api_v3_sankey_card_link, link: nil)
+    let(:sankey_card_link_without_host) {
+      FactoryBot.build(:api_v3_sankey_card_link, host: nil)
+    }
+    let(:sankey_card_link_without_query_params) {
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: nil)
     }
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
 
-    it 'fails when link blank' do
-      expect(sankey_card_link_without_link).to have(1).errors_on(:link)
+    it 'fails when host blank' do
+      expect(sankey_card_link_without_host).to have(1).errors_on(:host)
+    end
+
+    it 'fails when query_params blank' do
+      expect(sankey_card_link_without_query_params).to have(1).errors_on(:query_params)
     end
 
     it 'fails when title blank' do
       expect(sankey_card_link_without_title).to have(1).errors_on(:title)
+    end
+  end
+
+  describe :methods do
+    describe '#link' do
+      it 'return complete link' do
+        expect(sankey_card_link.link).to eql(
+          "#{sankey_card_link.host}?#{sankey_card_link.query_params.to_query}"
+        )
+      end
+    end
+  end
+
+  describe :callbacks do
+    describe 'before_save' do
+      describe '#extract_link_params' do
+        it 'extract parameters from link' do
+          sankey_card_link.update_attributes(title: 'test', link_param: 'http://test.com?one=1')
+          expect(sankey_card_link.host).to eql 'test.com'
+          expect(sankey_card_link.query_params).to eql({'one' => '1'})
+        end
+      end
     end
   end
 end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
+    let(:sankey_card_link_with_invalid_query_params) {
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: {one: 1})
+    }
 
     it 'fails when host blank' do
       expect(sankey_card_link_without_host).to have(1).errors_on(:host)
@@ -22,6 +25,10 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
 
     it 'fails when query_params blank' do
       expect(sankey_card_link_without_query_params).to have(1).errors_on(:query_params)
+    end
+
+    it 'fails when query_params include invalid parameters' do
+      expect(sankey_card_link_with_invalid_query_params).to have(1).errors_on(:query_params)
     end
 
     it 'fails when title blank' do
@@ -33,7 +40,7 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     describe '#link' do
       it 'return complete link' do
         expect(sankey_card_link.link).to eql(
-          "#{sankey_card_link.host}?#{sankey_card_link.query_params.to_query}"
+          "http://#{sankey_card_link.host}?#{sankey_card_link.query_params.to_query}"
         )
       end
     end
@@ -43,7 +50,7 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     describe 'before_save' do
       describe '#extract_link_params' do
         it 'extract parameters from link' do
-          sankey_card_link.update_attributes(title: 'test', link_param: 'http://test.com?one=1')
+          sankey_card_link.update_attributes(link_param: 'http://test.com?one=1')
           expect(sankey_card_link.host).to eql 'test.com'
           expect(sankey_card_link.query_params).to eql({'one' => '1'})
         end


### PR DESCRIPTION
Create a new entity `SankeyCardLink` for managing the curated list of "Quick Sankey cards". To make easier the process of updating the links when an import process is done, the relation between `SankeyCardLink` and `Node` entities has been done using an intermediate table `SankeyCardLinkNode`. 

On the admin panel, a new section has been added to managing the links, which is available on `Sankey & Map` -> `Sankey Card Links`.