### PR TITLE
Hopefully fixes the migrations that clear resize / recolor by attribu…

### DIFF
--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -58,11 +58,12 @@ module Api
 
           def refresh_dependents(options = {})
             [
+              Api::V3::Readonly::ChartAttribute,
+              Api::V3::Readonly::DashboardsAttribute,
               Api::V3::Readonly::DownloadAttribute,
               Api::V3::Readonly::MapAttribute,
               Api::V3::Readonly::RecolorByAttribute,
-              Api::V3::Readonly::ResizeByAttribute,
-              Api::V3::Readonly::DashboardsAttribute
+              Api::V3::Readonly::ResizeByAttribute
             ].each do |mview_klass|
               mview_klass.refresh(
                 options.merge(skip_dependencies: true, sync: false)

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -66,7 +66,7 @@ module Api
               Api::V3::Readonly::ResizeByAttribute
             ].each do |mview_klass|
               mview_klass.refresh(
-                options.merge(skip_dependencies: true, sync: false)
+                options.merge(skip_dependencies: true)
               )
             end
           end

--- a/app/models/api/v3/readonly/base_model.rb
+++ b/app/models/api/v3/readonly/base_model.rb
@@ -13,13 +13,13 @@ module Api
           # @option options [Boolean] :skip_dependents skip refreshing
           # @option options [Boolean] :sync synchronously
           def refresh(options = {})
-            # rubocop:disable Style/DoubleNegation
-            sync_processing = !!options[:sync]
-            # rubocop:enable Style/DoubleNegation
-            if long_running? || !sync_processing
-              refresh_later(options)
-            else
+            sync_processing = options[:sync]
+            # in unspecified, decide based on how long it takes to run
+            sync_processing ||= !long_running?
+            if sync_processing
               refresh_now(options)
+            else
+              refresh_later(options)
             end
           end
 

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -115,11 +115,11 @@ module Api
           # synchronously, skip dependencies (already refreshed)
           [
             Api::V3::Readonly::ChartAttribute,
+            Api::V3::Readonly::DashboardsAttribute,
             Api::V3::Readonly::DownloadAttribute,
             Api::V3::Readonly::MapAttribute,
             Api::V3::Readonly::RecolorByAttribute,
             Api::V3::Readonly::ResizeByAttribute,
-            Api::V3::Readonly::DashboardsAttribute,
             Api::V3::Readonly::Dashboards::Commodity,
             Api::V3::Readonly::Dashboards::Country,
             Api::V3::Readonly::Dashboards::Source,

--- a/db/migrate/20190919211340_change_attributes_to_table.rb
+++ b/db/migrate/20190919211340_change_attributes_to_table.rb
@@ -1,5 +1,5 @@
 class ChangeAttributesToTable < ActiveRecord::Migration[5.2]
-  def change
+  def up
     create_view :attributes_v,
       version: 1,
       materialized: false
@@ -129,5 +129,51 @@ class ChangeAttributesToTable < ActiveRecord::Migration[5.2]
     drop_view :attributes_mv, materialized: true
 
     Api::V3::Readonly::Attribute.refresh_now
+  end
+
+  def down
+    execute 'DROP MATERIALIZED VIEW IF EXISTS attributes_mv'
+
+    create_view :attributes_mv,
+      version: 3,
+      materialized: true
+
+    add_index :attributes_mv, :id, unique: true,
+      name: 'index_attributes_mv_id_idx'
+    add_index :attributes_mv, :name, unique: true,
+      name: 'attributes_mv_name_idx'
+
+    update_view :chart_attributes_mv,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+
+    update_view :dashboards_attributes_mv,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+
+    update_view :download_attributes_mv,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+
+    update_view :map_attributes_mv,
+      version: 4,
+      revert_to_version: 3,
+      materialized: true
+
+    update_view :recolor_by_attributes_mv,
+      version: 3,
+      revert_to_version: 2,
+      materialized: true
+
+    update_view :resize_by_attributes_mv,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+
+    drop_table :attributes
+    drop_view :attributes_v, materialized: false
   end
 end

--- a/db/migrate/20190919211340_change_attributes_to_table.rb
+++ b/db/migrate/20190919211340_change_attributes_to_table.rb
@@ -127,5 +127,7 @@ class ChangeAttributesToTable < ActiveRecord::Migration[5.2]
       materialized: true
 
     drop_view :attributes_mv, materialized: true
+
+    Api::V3::Readonly::Attribute.refresh_now
   end
 end

--- a/db/migrate/20190919211340_change_attributes_to_table.rb
+++ b/db/migrate/20190919211340_change_attributes_to_table.rb
@@ -128,7 +128,9 @@ class ChangeAttributesToTable < ActiveRecord::Migration[5.2]
 
     drop_view :attributes_mv, materialized: true
 
-    Api::V3::Readonly::Attribute.refresh_now
+    Api::V3::Readonly::Attribute.refresh(
+      sync: (Rails.env.development? || Rails.env.test?)
+    )
   end
 
   def down

--- a/db/migrate/20190924075531_make_role_and_prefix_mandatory.rb
+++ b/db/migrate/20190924075531_make_role_and_prefix_mandatory.rb
@@ -9,9 +9,9 @@ class MakeRoleAndPrefixMandatory < ActiveRecord::Migration[5.2]
           cnt_prop.save!
         end
         Api::V3::ContextNodeTypeProperty.set_callback(:commit, :after, :refresh_dependents)
-        Api::V3::Readonly::Dashboards::Source.refresh_later
-        Api::V3::Readonly::Dashboards::Company.refresh_later
-        Api::V3::Readonly::Dashboards::Destination.refresh_later
+        Api::V3::Readonly::Dashboards::Source.refresh_now
+        Api::V3::Readonly::Dashboards::Company.refresh_now
+        Api::V3::Readonly::Dashboards::Destination.refresh_now
       end
     end
 


### PR DESCRIPTION
…tes and hit redis errors

A few things going on here:

- added an extra refresh to attributes and their dependents to be extra sure
- fixed an issue when refreshing attributes dependencies, where chart attributes were not considered (causing exceptions in profiles)
- when people run migrations in development, they usually don't have sidekiq running, so in those envs refreshing should be running synchronously in migrations, which took a bit of changing how the `sync` option is handled in case of the "long running" refreshes
- added a reverse migration to make this easier to test