### PR TITLE
Fix analytics param

### DIFF
--- a/frontend/scripts/analytics/explore.events.js
+++ b/frontend/scripts/analytics/explore.events.js
@@ -60,9 +60,9 @@ export default [
     action: 'Select top card',
     getPayload(action) {
       const {
-        payload: { linkInfo }
+        payload: { linkParams }
       } = action;
-      const { countryName, commodityName, nodeTypeName, indicatorName } = linkInfo;
+      const { countryName, commodityName, nodeTypeName, indicatorName } = linkParams;
       const indicatorNamePart = indicatorName ? ` - ${indicatorName}` : '';
       return `${countryName} - ${commodityName} - ${nodeTypeName}${indicatorNamePart}`;
     }


### PR DESCRIPTION
The page was crashing because the param for linkParams had a wrong name