### PR TITLE
Add default volume attribute for nodes_stats

### DIFF
--- a/app/services/api/v3/nodes_stats/response_builder.rb
+++ b/app/services/api/v3/nodes_stats/response_builder.rb
@@ -39,10 +39,7 @@ module Api
             raise 'Either commodity or contexts but not both'
           end
 
-          @attribute = Api::V3::Readonly::Attribute.find_by(
-            id: @attribute_id, original_type: 'Quant'
-          )
-          raise "Attribute #{@attribute_id} not found" unless @attribute
+          @attribute = initialize_attribute
 
           @other_attributes = @other_attributes_ids.map do |attribute_id|
             attribute = Api::V3::Readonly::Attribute.find_by(
@@ -53,6 +50,22 @@ module Api
 
             attribute
           end
+        end
+
+        def initialize_attribute
+          if @attribute_id
+            attribute = Api::V3::Readonly::Attribute.find_by(
+              id: @attribute_id, original_type: 'Quant'
+            )
+            raise "Attribute #{@attribute_id} not found" unless attribute
+          else
+            volume_quant = Dictionary::Quant.instance.get('Volume')
+            attribute = Api::V3::Readonly::Attribute.find_by(
+              original_id: volume_quant.id, original_type: 'Quant'
+            )
+            raise 'Quant Volume not found' unless attribute
+          end
+          attribute
         end
 
         def formatted_nodes_stats

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -284,7 +284,7 @@ paths:
             type: integer
         - name: attribute_id
           in: query
-          description: Attribute id
+          description: Attribute id (default volume)
           required: false
           schema:
             type: string

--- a/spec/responses/api/v3/nodes_stats_spec.rb
+++ b/spec/responses/api/v3/nodes_stats_spec.rb
@@ -9,6 +9,29 @@ RSpec.describe 'Nodes stats', type: :request do
   end
 
   describe 'GET /api/v3/nodes_stats' do
+    context 'when an attribute_id is not specified' do
+      it 'return the nodes stats for volume attribute' do
+        get '/api/v3/nodes_stats', params: {
+          start_year: 2003,
+          end_year: 2019,
+          other_attributes_ids: api_v3_deforestation_v2.readonly_attribute.id,
+          column_id: api_v3_country_node_type.id,
+          contexts_ids: api_v3_context.id.to_s
+        }
+
+        expect(@response).to have_http_status(:ok)
+        expect(@response).to match_response_schema('v3_nodes_stats')
+
+        parsed_response = JSON.parse(@response.body)
+        nodes_ids =
+          parsed_response['data'].first['top_nodes'].map { |a| a['id'] }
+        expect(nodes_ids).to eql([
+          api_v3_country_of_destination1_node.id,
+          api_v3_other_country_of_destination_node.id
+        ])
+      end
+    end
+
     context 'when a list of context is specified' do
       it 'returns the nodes stats for those contexts' do
         get '/api/v3/nodes_stats', params: {


### PR DESCRIPTION
Fix the error when `attribute_id` is not sent in `nodes_stats` endpoint. Now, the volume attribute is used by default if `attribute_id` is not specified.