### PR TITLE
Feature/quick sankey cards

### DIFF
--- a/app/admin/api/v3/sankey_card_link.rb
+++ b/app/admin/api/v3/sankey_card_link.rb
@@ -15,11 +15,12 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
     f.semantic_errors
     inputs do
       input :link_param, input_html: {value: f.object.link}, as: :string, required: true
-      input :title, as: :string, required: true
-      input :subtitle, as: :string
-      input :level1, as: :boolean
-      input :level2, as: :boolean
-      input :level3, as: :boolean
+      input :title, as: :string, required: true,
+                    hint: object.class.column_comment('title')
+      input :subtitle, as: :string, hint: object.class.column_comment('subtitle')
+      input :level1, as: :boolean, hint: object.class.column_comment('level1')
+      input :level2, as: :boolean, hint: object.class.column_comment('level2')
+      input :level3, as: :boolean, hint: object.class.column_comment('level3')
     end
     f.actions
   end
@@ -31,7 +32,7 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
       link_to(sankey_card_link.link, sankey_card_link.link)
     end
     column :level do |sankey_card_link|
-      [1, 2, 3].select { |n| sankey_card_link.send("level#{n}") }.join(', ')
+      Api::V3::SankeyCardLink::LEVELS.select { |n| sankey_card_link.send("level#{n}") }.join(', ')
     end
     actions
   end
@@ -44,7 +45,7 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
       row :title
       row :subtitle
       row :level do |sankey_card_link|
-        [1, 2, 3].select { |n| sankey_card_link.send("level#{n}") }.join(', ')
+        Api::V3::SankeyCardLink::LEVELS.select { |n| sankey_card_link.send("level#{n}") }.join(', ')
       end
       row :created_at
       row :updated_at

--- a/app/admin/api/v3/sankey_card_link.rb
+++ b/app/admin/api/v3/sankey_card_link.rb
@@ -1,0 +1,46 @@
+ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
+  menu parent: 'Sankey & Map'
+
+  permit_params :link_param, :title, :subtitle
+
+  after_action :clear_cache, only: [:create, :update, :destroy]
+
+  controller do
+    def clear_cache
+      clear_cache_for_regexp('/api/v3/contexts')
+    end
+  end
+
+  form do |f|
+    f.semantic_errors
+    inputs do
+      input :link_param, input_html: {value: f.object.link}, as: :string, required: true
+      input :title, as: :string, required: true
+      input :subtitle, as: :string
+    end
+    f.actions
+  end
+
+  index do
+    column('Title', sortable: true, &:title)
+    column :subtitle
+    column('Link', sortable: true) do |sankey_card_link|
+      link_to(sankey_card_link.link, sankey_card_link.link)
+    end
+    actions
+  end
+
+  filter :link_contains, as: :string, label: 'Link'
+
+  show do
+    attributes_table do
+      row :link do |sankey_card_link|
+        link_to(sankey_card_link.link, sankey_card_link.link)
+      end
+      row :title
+      row :subtitle
+      row :created_at
+      row :updated_at
+    end
+  end
+end

--- a/app/admin/api/v3/sankey_card_link.rb
+++ b/app/admin/api/v3/sankey_card_link.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
   menu parent: 'Sankey & Map'
 
-  permit_params :link_param, :title, :subtitle
+  permit_params :link_param, :title, :subtitle, :level
 
   after_action :clear_cache, only: [:create, :update, :destroy]
 
@@ -17,6 +17,7 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
       input :link_param, input_html: {value: f.object.link}, as: :string, required: true
       input :title, as: :string, required: true
       input :subtitle, as: :string
+      input :level, as: :select, required: true, collection: [[1, 1], [2, 2], [3, 3]]
     end
     f.actions
   end
@@ -27,6 +28,7 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
     column('Link', sortable: true) do |sankey_card_link|
       link_to(sankey_card_link.link, sankey_card_link.link)
     end
+    column :level
     actions
   end
 
@@ -37,6 +39,7 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
       end
       row :title
       row :subtitle
+      row :level
       row :created_at
       row :updated_at
     end

--- a/app/admin/api/v3/sankey_card_link.rb
+++ b/app/admin/api/v3/sankey_card_link.rb
@@ -30,8 +30,6 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
     actions
   end
 
-  filter :link_contains, as: :string, label: 'Link'
-
   show do
     attributes_table do
       row :link do |sankey_card_link|

--- a/app/admin/api/v3/sankey_card_link.rb
+++ b/app/admin/api/v3/sankey_card_link.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
   menu parent: 'Sankey & Map'
 
-  permit_params :link_param, :title, :subtitle, :level
+  permit_params :link_param, :title, :subtitle, :level1, :level2, :level3
 
   after_action :clear_cache, only: [:create, :update, :destroy]
 
@@ -17,7 +17,9 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
       input :link_param, input_html: {value: f.object.link}, as: :string, required: true
       input :title, as: :string, required: true
       input :subtitle, as: :string
-      input :level, as: :select, required: true, collection: [[1, 1], [2, 2], [3, 3]]
+      input :level1, as: :boolean
+      input :level2, as: :boolean
+      input :level3, as: :boolean
     end
     f.actions
   end
@@ -28,7 +30,9 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
     column('Link', sortable: true) do |sankey_card_link|
       link_to(sankey_card_link.link, sankey_card_link.link)
     end
-    column :level
+    column :level do |sankey_card_link|
+      [1, 2, 3].select { |n| sankey_card_link.send("level#{n}") }.join(', ')
+    end
     actions
   end
 
@@ -39,7 +43,9 @@ ActiveAdmin.register Api::V3::SankeyCardLink, as: 'SankeyCardLinks' do
       end
       row :title
       row :subtitle
-      row :level
+      row :level do |sankey_card_link|
+        [1, 2, 3].select { |n| sankey_card_link.send("level#{n}") }.join(', ')
+      end
       row :created_at
       row :updated_at
     end

--- a/app/controllers/api/v3/sankey_card_links_controller.rb
+++ b/app/controllers/api/v3/sankey_card_links_controller.rb
@@ -19,11 +19,11 @@ module Api
       def ensure_required_params
         ensure_required_param_present(:level)
 
-        if [2, 3].include? params[:level]
+        if %w[2 3].include? params[:level]
           ensure_required_param_present(:commodity_id)
         end
 
-        ensure_required_param_present(:country_id) if params[:level] == 3
+        ensure_required_param_present(:country_id) if params[:level].include? '3'
       end
 
       def set_filter_params

--- a/app/controllers/api/v3/sankey_card_links_controller.rb
+++ b/app/controllers/api/v3/sankey_card_links_controller.rb
@@ -1,0 +1,38 @@
+module Api
+  module V3
+    class SankeyCardLinksController < ApiController
+      skip_before_action :load_context
+
+      before_action :set_filter_params, only: :index
+
+      def index
+        sankey_card_links = Api::V3::SankeyCardLinks::ResponseBuilder.new(
+          @filter_params
+        )
+        sankey_card_links.call
+
+        render json: {data: sankey_card_links.data, meta: sankey_card_links.meta}
+      end
+
+      private
+
+      def ensure_required_params
+        ensure_required_param_present(:level)
+
+        if [2, 3].include? params[:level]
+          ensure_required_param_present(:commodity_id)
+        end
+
+        ensure_required_param_present(:country_id) if params[:level] == 3
+      end
+
+      def set_filter_params
+        @filter_params = {
+          country_id: params[:country_id],
+          commodity_id: params[:commodity_id],
+          level: params[:level]
+        }
+      end
+    end
+  end
+end

--- a/app/models/api/v3/commodity.rb
+++ b/app/models/api/v3/commodity.rb
@@ -22,6 +22,8 @@ module Api
       has_many :quant_commodity_properties
       has_many :qual_commodity_properties
 
+      has_many :sankey_card_links
+
       validates :name, presence: true, uniqueness: true
 
       def self.import_key

--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -40,6 +40,7 @@ module Api
       # TODO: there should be only one default per group
 
       belongs_to :context_node_type
+      has_many :sankey_card_link_node_types
 
       validates :context_node_type, presence: true, uniqueness: true
       validates :column_group, presence: true, inclusion: COLUMN_GROUP

--- a/app/models/api/v3/country.rb
+++ b/app/models/api/v3/country.rb
@@ -24,6 +24,8 @@ module Api
       has_many :quant_country_properties
       has_many :qual_country_properties
 
+      has_many :sankey_card_links
+
       delegate :latitude, to: :country_property
       delegate :longitude, to: :country_property
       delegate :zoom, to: :country_property

--- a/app/models/api/v3/node.rb
+++ b/app/models/api/v3/node.rb
@@ -39,6 +39,9 @@ module Api
 
       has_many :nodes_stats
 
+      has_many :sankey_card_link_nodes
+      has_many :sankey_card_links, through: :sankey_card_link_nodes
+
       def stringify
         name + ' - ' + node_type.name + ' - ' + node_type&.context_node_types&.first&.context&.country&.name + ' ' + node_type&.context_node_types&.first&.context&.commodity&.name
       end

--- a/app/models/api/v3/node.rb
+++ b/app/models/api/v3/node.rb
@@ -39,6 +39,7 @@ module Api
 
       has_many :nodes_stats
 
+      has_many :sankey_card_links
       has_many :sankey_card_link_nodes
       has_many :sankey_card_links, through: :sankey_card_link_nodes
 

--- a/app/models/api/v3/node_type.rb
+++ b/app/models/api/v3/node_type.rb
@@ -16,6 +16,8 @@ module Api
       has_many :context_node_types
       has_many :nodes
       has_many :nodes_stats
+      has_many :sankey_card_link_node_types
+      has_many :sankey_card_links, through: :sankey_card_link_node_types
 
       def self.node_index_for_name(context, node_type_name)
         zero_based_idx = ContextNodeType.

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -25,6 +25,13 @@ module Api
       class Attribute < Api::V3::Readonly::BaseModel
         self.table_name = 'attributes'
 
+        has_many :cont_attribute_sankey_card_links,
+          class_name: 'Api::V3::SankeyCardLink',
+          inverse_of: :cont_attribute
+        has_many :ncont_attribute_sankey_card_links,
+          class_name: 'Api::V3::SankeyCardLink',
+          inverse_of: :ncont_attribute
+
         delegate :values_meta, to: :original_attribute
 
         class << self

--- a/app/models/api/v3/readonly/attribute.rb
+++ b/app/models/api/v3/readonly/attribute.rb
@@ -26,11 +26,11 @@ module Api
         self.table_name = 'attributes'
 
         has_many :cont_attribute_sankey_card_links,
-          class_name: 'Api::V3::SankeyCardLink',
-          inverse_of: :cont_attribute
+                 class_name: 'Api::V3::SankeyCardLink',
+                 inverse_of: :cont_attribute
         has_many :ncont_attribute_sankey_card_links,
-          class_name: 'Api::V3::SankeyCardLink',
-          inverse_of: :ncont_attribute
+                 class_name: 'Api::V3::SankeyCardLink',
+                 inverse_of: :ncont_attribute
 
         delegate :values_meta, to: :original_attribute
 

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -100,7 +100,7 @@ module Api
       def link
         return '' unless host && query_params
 
-        "http://#{host}?#{query_params&.to_query}"
+        "http://#{host}?#{query_params.to_query}"
       end
 
       private
@@ -125,29 +125,29 @@ module Api
       def extract_selected_country_id
         self.country_id =
           query_params['selectedCountryId'] ||
-          Api::V3::Country.where(name: 'BRAZIL').first&.id
+          Api::V3::Country.find_by(name: 'BRAZIL')&.id
       end
 
       def extract_selected_commodity_id
         self.commodity_id =
           query_params['selectedCommodityId'] ||
-          Api::V3::Commodity.where(name: 'SOY').first&.id
+          Api::V3::Commodity.find_by(name: 'SOY')&.id
       end
 
       def extract_selected_context_id
         return unless query_params['selectedContextId']
 
         context = Api::V3::Context.find(query_params['selectedContextId'])
-        self.country_id = context&.country_id
-        self.commodity_id = context&.commodity_id
+        self.country_id = context.country_id
+        self.commodity_id = context.commodity_id
       end
 
       def extract_selected_resize_by
         self.cont_attribute_id =
           query_params['selectedResizeBy'] ||
-          Api::V3::Readonly::Attribute.where(
+          Api::V3::Readonly::Attribute.find_by(
             original_type: 'Quant', name: 'Volume'
-          ).first&.id
+          )&.id
       end
 
       def extract_selected_recolor_by

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -1,8 +1,37 @@
+# == Schema Information
+#
+# Table name: sankey_card_links
+#
+#  id         :bigint(8)        not null, primary key
+#  link       :json             not null
+#  title      :text             not null
+#  subtitle   :text
+#
+
 module Api
   module V3
     class SankeyCardLink < YellowTable
-      validates :link, presence: true
+      attr_accessor :link_param
+
+      validates :host, presence: true
+      validates :query_params, presence: true
       validates :title, presence: true
+
+      before_save :extract_link_params
+
+      def link
+        "#{self.host}?#{self.query_params.to_query}"
+      end
+
+      private
+
+      def extract_link_params
+        uri = URI.parse link_param
+        self.host = uri.host
+
+        ary = URI.decode_www_form(uri.query).to_h
+        self.query_params = ary
+      end
     end
   end
 end

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -14,6 +14,7 @@
 #  start_year         :integer          not null
 #  end_year           :integer          not null
 #  biome_id           :bigint(8)
+#  level              :integer          not null
 #
 # Indexes
 #
@@ -205,7 +206,7 @@ module Api
       def add_node_types_relations
         context_id = Api::V3::Context.
           find_by(commodity_id: commodity_id, country_id: country_id)
-        columns = (query_params['selectedColumnsIds'] || []).split('-')
+        columns = (query_params['selectedColumnsIds'] || '').split('-')
         columns = Hash[*columns.map { |c| c.split('_') }.flatten]
         [0, 1, 2, 3].each do |column_group|
           node_type_id = columns[column_group] ||

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -51,6 +51,10 @@ module Api
         "http://#{self.host}?#{self.query_params&.to_query}"
       end
 
+      def self.ransackable_scopes(*)
+        %i(link_contains)
+      end
+
       private
 
       def extract_link_params

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -1,0 +1,8 @@
+module Api
+  module V3
+    class SankeyCardLink < YellowTable
+      validates :link, presence: true
+      validates :title, presence: true
+    end
+  end
+end

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -82,9 +82,9 @@ module Api
 
       validates :host, presence: true
       validates :title, presence: true
-      validates :level1, presence: true, if: -> {!level2 && !level3}
-      validates :level2, presence: true, if: -> {!level1 && !level3}
-      validates :level3, presence: true, if: -> {!level1 && !level2}
+      validates :level1, presence: true, if: -> { !level2 && !level3 }
+      validates :level2, presence: true, if: -> { !level1 && !level3 }
+      validates :level3, presence: true, if: -> { !level1 && !level2 }
 
       validate :validate_max_links_per_level
 

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -2,21 +2,21 @@
 #
 # Table name: sankey_card_links
 #
-#  id                 :bigint(8)        not null, primary key
-#  host               :text             not null
-#  query_params       :json             not null
-#  title              :text             not null
-#  subtitle           :text
-#  commodity_id       :bigint(8)
-#  country_id         :bigint(8)
-#  cont_attribute_id  :bigint(8)
-#  ncont_attribute_id :bigint(8)
-#  start_year         :integer          not null
-#  end_year           :integer          not null
-#  biome_id           :bigint(8)
-#  level1             :boolean          default(FALSE), not null
-#  level2             :boolean          default(FALSE), not null
-#  level3             :boolean          default(FALSE), not null
+#  id                                                                       :bigint(8)        not null, primary key
+#  host                                                                     :text             not null
+#  query_params(query params included on the link of the quick sankey card) :json             not null
+#  title(title of the quick sankey card)                                    :text             not null
+#  subtitle(subtitle of the quick sankey card)                              :text
+#  start_year                                                               :integer          not null
+#  end_year                                                                 :integer          not null
+#  biome_id                                                                 :bigint(8)
+#  level1(level used when commodity and country are not selected)           :boolean          default(FALSE), not null
+#  level2(level used when commodity is selected)                            :boolean          default(FALSE), not null
+#  level3(level used when commodity and country are selected)               :boolean          default(FALSE), not null
+#  country_id                                                               :bigint(8)
+#  commodity_id                                                             :bigint(8)
+#  cont_attribute_id                                                        :bigint(8)
+#  ncont_attribute_id                                                       :bigint(8)
 #
 # Indexes
 #
@@ -29,10 +29,10 @@
 # Foreign Keys
 #
 #  fk_rails_...  (biome_id => nodes.id)
-#  fk_rails_...  (commodity_id => commodities.id)
-#  fk_rails_...  (cont_attribute_id => attributes.id)
-#  fk_rails_...  (country_id => countries.id)
-#  fk_rails_...  (ncont_attribute_id => attributes.id)
+#  fk_rails_...  (commodity_id => commodities.id) ON DELETE => cascade
+#  fk_rails_...  (cont_attribute_id => attributes.id) ON DELETE => cascade
+#  fk_rails_...  (country_id => countries.id) ON DELETE => cascade
+#  fk_rails_...  (ncont_attribute_id => attributes.id) ON DELETE => cascade
 #
 
 module Api
@@ -113,7 +113,7 @@ module Api
 
       def validate_max_links_per_level
         LEVELS.each do |n|
-          next unless send("level#{n}_max_sankey_card_links?")
+          next if !send("level#{n}") || !send("level#{n}_max_sankey_card_links?")
 
           message = "cannot be more than #{MAX_PER_LEVEL} sankey card links "\
                     "for level#{n}"
@@ -245,9 +245,11 @@ module Api
 
           Api::V3::SankeyCardLinkNodeType.find_or_initialize_by(
             column_group: column_group,
-            sankey_card_link_id: id,
+            sankey_card_link_id: id
+          ).update!(
+            node_type_id: node_type_id,
             context_node_type_property_id: context_node_type_property_id
-          ).update!(node_type_id: node_type_id)
+          )
         end
       end
 

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -2,11 +2,29 @@
 #
 # Table name: sankey_card_links
 #
-#  id           :bigint(8)        not null, primary key
-#  host         :text             not null
-#  query_params :json             not null
-#  title        :text             not null
-#  subtitle     :text
+#  id                 :bigint(8)        not null, primary key
+#  host               :text             not null
+#  query_params       :json             not null
+#  title              :text             not null
+#  subtitle           :text
+#  commodity_id       :bigint(8)
+#  country_id         :bigint(8)
+#  cont_attribute_id  :bigint(8)
+#  ncont_attribute_id :bigint(8)
+#
+# Indexes
+#
+#  index_sankey_card_links_on_commodity_id        (commodity_id)
+#  index_sankey_card_links_on_cont_attribute_id   (cont_attribute_id)
+#  index_sankey_card_links_on_country_id          (country_id)
+#  index_sankey_card_links_on_ncont_attribute_id  (ncont_attribute_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (commodity_id => commodities.id)
+#  fk_rails_...  (cont_attribute_id => attributes.id)
+#  fk_rails_...  (country_id => countries.id)
+#  fk_rails_...  (ncont_attribute_id => attributes.id)
 #
 
 module Api
@@ -14,7 +32,7 @@ module Api
     class SankeyCardLink < YellowTable
       attr_accessor :link_param
 
-      VALID_QUERY_PARAMS =%w[
+      VALID_QUERY_PARAMS = %w[
         commodity_id
         country_id
         nodes_ids
@@ -24,18 +42,42 @@ module Api
         end_year
       ]
 
+      REQUIRED_QUERY_PARAMS = %w[
+        commodity_id
+        country_id
+        cont_attribute_id
+        ncont_attribute_id
+      ]
+
       scope :link_contains, ->(link) {
         where("host LIKE '%#{link}%' OR
                query_params->>'#{link}' IS NOT NULL OR
-               query_params->>'commodity_id' LIKE '%#{link}%' OR
-               query_params->>'country_id' LIKE '%#{link}%' OR
+               commodity_id = '%#{link}%' OR
+               country_id = '%#{link}%' OR
+               cont_attribute_id = '%#{link}%' OR
+               ncont_attribute_id = '%#{link}%' OR
                query_params->>'nodes_ids' LIKE '%#{link}%' OR
-               query_params->>'cont_attribute_id' LIKE '%#{link}%' OR
-               query_params->>'ncont_attribute_id' LIKE '%#{link}%' OR
                query_params->>'start_year' LIKE '%#{link}%' OR
                query_params->>'end_year' LIKE '%#{link}%'"
         )
       }
+
+      belongs_to :commodity
+      belongs_to :country
+      belongs_to :cont_attribute,
+        class_name: 'Api::V3::Readonly::Attribute',
+        foreign_key: 'cont_attribute_id',
+        inverse_of: :cont_attribute_sankey_card_links,
+        dependent: :destroy
+      belongs_to :ncont_attribute,
+        class_name: 'Api::V3::Readonly::Attribute',
+        foreign_key: 'ncont_attribute_id',
+        inverse_of: :ncont_attribute_sankey_card_links,
+        dependent: :destroy
+      has_many :sankey_card_link_nodes
+      has_many :nodes,
+        class_name: 'Api::V3::SankeyCardLinkNode',
+        through: :sankey_card_link_nodes
 
       validates :host, presence: true
       validates :query_params, presence: true
@@ -44,6 +86,8 @@ module Api
       validate :check_valid_query_params
 
       before_validation :extract_link_params
+      before_validation :extract_required_params
+      after_commit :add_nodes_relations
 
       def link
         return '' unless self.host && self.query_params
@@ -55,22 +99,64 @@ module Api
         %i(link_contains)
       end
 
+      def self.blue_foreign_keys
+        [
+          {name: :commodity_id, table_class: Api::V3::Commodity},
+          {name: :country_id, table_class: Api::V3::Country},
+          {name: :cont_attribute_id, table_class: Api::V3::Readonly::Attribute},
+          {name: :ncont_attribute_id, table_class: Api::V3::Readonly::Attribute}
+        ]
+      end
+
       private
 
       def extract_link_params
         return unless link_param
-
         uri = URI.parse link_param
         self.host = uri.host
 
+        return unless uri.query
         ary = URI.decode_www_form(uri.query).to_h
         self.query_params = ary
       end
 
-      def check_valid_query_params
-        return unless ((query_params || {}).keys - VALID_QUERY_PARAMS).any?
+      def extract_required_params
+        return unless self.query_params
 
-        errors.add(:query_params, 'includes invalid parameters')
+        REQUIRED_QUERY_PARAMS.each do |required_parameter|
+          self.send("#{required_parameter}=", self.query_params[required_parameter])
+        end
+      end
+
+      def add_nodes_relations
+        nodes_ids = self.query_params['nodes_ids'].split(',')
+        nodes_ids.each do |node_id|
+          Api::V3::SankeyCardLinkNode.find_or_create_by!(
+            node_id: node_id,
+            sankey_card_link_id: self.id
+          )
+        end
+
+        # Remove old sankey card link nodes relations
+        Api::V3::SankeyCardLinkNode.
+          where(sankey_card_link_id: self.id).
+          where.not(node_id: nodes_ids).
+          destroy_all
+      end
+
+      def check_valid_query_params
+        # Check if we are indicating only permitted params
+        if ((query_params || {}).keys - VALID_QUERY_PARAMS).any?
+          errors.add(:link_param, 'includes invalid parameters')
+        end
+
+        # Check if we are including all obligatory params
+        if (REQUIRED_QUERY_PARAMS - (query_params || {}).keys).any?
+          errors.add(
+            :link_param,
+            'must specify commodity, country, cont_attribute and ncont_attribute'
+          )
+        end
       end
     end
   end

--- a/app/models/api/v3/sankey_card_link.rb
+++ b/app/models/api/v3/sankey_card_link.rb
@@ -2,10 +2,11 @@
 #
 # Table name: sankey_card_links
 #
-#  id         :bigint(8)        not null, primary key
-#  link       :json             not null
-#  title      :text             not null
-#  subtitle   :text
+#  id           :bigint(8)        not null, primary key
+#  host         :text             not null
+#  query_params :json             not null
+#  title        :text             not null
+#  subtitle     :text
 #
 
 module Api
@@ -13,24 +14,59 @@ module Api
     class SankeyCardLink < YellowTable
       attr_accessor :link_param
 
+      VALID_QUERY_PARAMS =%w[
+        commodity_id
+        country_id
+        nodes_ids
+        cont_attribute_id
+        ncont_attribute_id
+        start_year
+        end_year
+      ]
+
+      scope :link_contains, ->(link) {
+        where("host LIKE '%#{link}%' OR
+               query_params->>'#{link}' IS NOT NULL OR
+               query_params->>'commodity_id' LIKE '%#{link}%' OR
+               query_params->>'country_id' LIKE '%#{link}%' OR
+               query_params->>'nodes_ids' LIKE '%#{link}%' OR
+               query_params->>'cont_attribute_id' LIKE '%#{link}%' OR
+               query_params->>'ncont_attribute_id' LIKE '%#{link}%' OR
+               query_params->>'start_year' LIKE '%#{link}%' OR
+               query_params->>'end_year' LIKE '%#{link}%'"
+        )
+      }
+
       validates :host, presence: true
       validates :query_params, presence: true
       validates :title, presence: true
 
-      before_save :extract_link_params
+      validate :check_valid_query_params
+
+      before_validation :extract_link_params
 
       def link
-        "#{self.host}?#{self.query_params.to_query}"
+        return '' unless self.host && self.query_params
+
+        "http://#{self.host}?#{self.query_params&.to_query}"
       end
 
       private
 
       def extract_link_params
+        return unless link_param
+
         uri = URI.parse link_param
         self.host = uri.host
 
         ary = URI.decode_www_form(uri.query).to_h
         self.query_params = ary
+      end
+
+      def check_valid_query_params
+        return unless ((query_params || {}).keys - VALID_QUERY_PARAMS).any?
+
+        errors.add(:query_params, 'includes invalid parameters')
       end
     end
   end

--- a/app/models/api/v3/sankey_card_link_node.rb
+++ b/app/models/api/v3/sankey_card_link_node.rb
@@ -28,6 +28,20 @@ module Api
                  inverse_of: :sankey_card_link_nodes
 
       validates :sankey_card_link_id, uniqueness: {scope: :node_id}
+
+      after_commit :update_query_params
+
+      private
+
+      # After an import process, we update query params if nodes has changed
+      def update_query_params
+        return if sankey_card_link.query_params['selectedNodesIds']&.include?(node_id)
+
+        query_params = sankey_card_link.query_params
+        query_params['selectedNodesIds'].delete node_id_was
+        query_params['selectedNodesIds'].push node_id
+        sankey_card_link.update_attribute(:query_params, query_params)
+      end
     end
   end
 end

--- a/app/models/api/v3/sankey_card_link_node.rb
+++ b/app/models/api/v3/sankey_card_link_node.rb
@@ -1,0 +1,33 @@
+# == Schema Information
+#
+# Table name: sankey_card_link_nodes
+#
+#  id                  :bigint(8)        not null, primary key
+#  sankey_card_link_id :bigint(8)
+#  node_id             :bigint(8)
+#
+# Indexes
+#
+#  index_sankey_card_link_nodes_on_node_id              (node_id)
+#  index_sankey_card_link_nodes_on_sankey_card_link_id  (sankey_card_link_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (node_id => nodes.id)
+#  fk_rails_...  (sankey_card_link_id => sankey_card_links.id)
+#
+
+module Api
+  module V3
+    class SankeyCardLinkNode < YellowTable
+      belongs_to :sankey_card_link,
+        class_name: 'Api::V3::SankeyCardLink',
+        inverse_of: :sankey_card_link_nodes
+      belongs_to :node,
+        class_name: 'Api::V3::Node',
+        inverse_of: :sankey_card_link_nodes
+
+      validates :sankey_card_link_id, uniqueness: {scope: :node_id}
+    end
+  end
+end

--- a/app/models/api/v3/sankey_card_link_node.rb
+++ b/app/models/api/v3/sankey_card_link_node.rb
@@ -21,11 +21,11 @@ module Api
   module V3
     class SankeyCardLinkNode < YellowTable
       belongs_to :sankey_card_link,
-        class_name: 'Api::V3::SankeyCardLink',
-        inverse_of: :sankey_card_link_nodes
+                 class_name: 'Api::V3::SankeyCardLink',
+                 inverse_of: :sankey_card_link_nodes
       belongs_to :node,
-        class_name: 'Api::V3::Node',
-        inverse_of: :sankey_card_link_nodes
+                 class_name: 'Api::V3::Node',
+                 inverse_of: :sankey_card_link_nodes
 
       validates :sankey_card_link_id, uniqueness: {scope: :node_id}
     end

--- a/app/models/api/v3/sankey_card_link_node_type.rb
+++ b/app/models/api/v3/sankey_card_link_node_type.rb
@@ -36,7 +36,7 @@ module Api
                 presence: true,
                 inclusion: 0..3,
                 uniqueness: {scope: :sankey_card_link_id}
-      validates :sankey_card_link_id, uniqueness: {scope: :node_type_id}
+      validates :sankey_card_link_id, uniqueness: {scope: [:column_group, :node_type_id]}
 
       after_commit :update_query_params
 

--- a/app/models/api/v3/sankey_card_link_node_type.rb
+++ b/app/models/api/v3/sankey_card_link_node_type.rb
@@ -6,6 +6,7 @@
 #  context_node_type_property_id :bigint(8)
 #  sankey_card_link_id           :bigint(8)
 #  node_type_id                  :bigint(8)
+#  column_group                  :integer          not null
 #
 # Indexes
 #

--- a/app/models/api/v3/sankey_card_link_node_type.rb
+++ b/app/models/api/v3/sankey_card_link_node_type.rb
@@ -31,6 +31,10 @@ module Api
                  class_name: 'Api::V3::NodeType',
                  inverse_of: :sankey_card_link_node_types
 
+      validates :column_group,
+                presence: true,
+                inclusion: 0..3,
+                uniqueness: {scope: :sankey_card_link_id}
       validates :sankey_card_link_id, uniqueness: {scope: :node_type_id}
     end
   end

--- a/app/models/api/v3/sankey_card_link_node_type.rb
+++ b/app/models/api/v3/sankey_card_link_node_type.rb
@@ -37,6 +37,24 @@ module Api
                 inclusion: 0..3,
                 uniqueness: {scope: :sankey_card_link_id}
       validates :sankey_card_link_id, uniqueness: {scope: :node_type_id}
+
+      after_commit :update_query_params
+
+      private
+
+      # After an import process, we update query params if nodes has changed
+      def update_query_params
+        column = "#{column_group}_#{node_type_id}"
+        return if sankey_card_link.query_params['selectedColumnsIds']&.include?(column)
+
+        query_params = sankey_card_link.query_params
+        columns = (query_params['selectedColumnsIds'] || '').split('-')
+        column_was = "#{column_group_was}_#{node_type_id_was}"
+        columns.delete column_was
+        columns.push column
+        query_params['selectedColumnsIds'] = columns.join('-')
+        sankey_card_link.update_attribute(:query_params, query_params)
+      end
     end
   end
 end

--- a/app/models/api/v3/sankey_card_link_node_type.rb
+++ b/app/models/api/v3/sankey_card_link_node_type.rb
@@ -1,0 +1,15 @@
+module Api
+  module V3
+    class SankeyCardLinkNodeType < YellowTable
+      belongs_to :context_node_type_property
+      belongs_to :sankey_card_link,
+                 class_name: 'Api::V3::SankeyCardLink',
+                 inverse_of: :sankey_card_link_node_types
+      belongs_to :node_type,
+                 class_name: 'Api::V3::NodeType',
+                 inverse_of: :sankey_card_link_node_types
+
+      validates :sankey_card_link_id, uniqueness: {scope: :node_type_id}
+    end
+  end
+end

--- a/app/models/api/v3/sankey_card_link_node_type.rb
+++ b/app/models/api/v3/sankey_card_link_node_type.rb
@@ -1,3 +1,25 @@
+# == Schema Information
+#
+# Table name: sankey_card_link_node_types
+#
+#  id                            :bigint(8)        not null, primary key
+#  context_node_type_property_id :bigint(8)
+#  sankey_card_link_id           :bigint(8)
+#  node_type_id                  :bigint(8)
+#
+# Indexes
+#
+#  index_sankey_card_link_node_types_on_node_type_id              (node_type_id)
+#  index_sankey_card_link_node_types_on_sankey_card_link_id       (sankey_card_link_id)
+#  sankey_card_link_node_types_context_node_type_property_id_idx  (context_node_type_property_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (context_node_type_property_id => context_node_type_properties.id)
+#  fk_rails_...  (node_type_id => node_types.id)
+#  fk_rails_...  (sankey_card_link_id => sankey_card_links.id)
+#
+
 module Api
   module V3
     class SankeyCardLinkNodeType < YellowTable

--- a/app/serializers/api/v3/sankey_card_links/column_serializer.rb
+++ b/app/serializers/api/v3/sankey_card_links/column_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module V3
+    module SankeyCardLinks
+      class ColumnSerializer < ActiveModel::Serializer
+        attribute :column_group
+        attribute :node_type_id
+        attribute :node_type do
+          object.node_type&.name
+        end
+        attribute :role do
+          object.context_node_type_property.role
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/sankey_card_links/node_serializer.rb
+++ b/app/serializers/api/v3/sankey_card_links/node_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module V3
+    module SankeyCardLinks
+      class NodeSerializer < ActiveModel::Serializer
+        attribute :node_id, key: :id
+        attribute :node_type_id do
+          object.node&.node_type_id
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/v3/sankey_card_links/sankey_card_link_serializer.rb
+++ b/app/serializers/api/v3/sankey_card_links/sankey_card_link_serializer.rb
@@ -5,7 +5,9 @@ module Api
         attributes :id,
                    :host,
                    :query_params,
-                   :link
+                   :link,
+                   :title,
+                   :subtitle
 
         belongs_to :country_id
         belongs_to :commodity_id

--- a/app/serializers/api/v3/sankey_card_links/sankey_card_link_serializer.rb
+++ b/app/serializers/api/v3/sankey_card_links/sankey_card_link_serializer.rb
@@ -6,21 +6,9 @@ module Api
                    :host,
                    :query_params,
                    :link
-      end
 
-      class NodeSerializer < ActiveModel::Serializer
-        attribute :node_id, key: :id
-        attribute :node_type do
-          object.node&.node_type&.name
-        end
-      end
-
-      class ColumnSerializer < ActiveModel::Serializer
-        attribute :column_group
-        attribute :node_type_id
-        attribute :role do
-          object.context_node_type_property.role
-        end
+        belongs_to :country_id
+        belongs_to :commodity_id
       end
     end
   end

--- a/app/serializers/api/v3/sankey_card_links/sankey_card_link_serializer.rb
+++ b/app/serializers/api/v3/sankey_card_links/sankey_card_link_serializer.rb
@@ -1,0 +1,27 @@
+module Api
+  module V3
+    module SankeyCardLinks
+      class SankeyCardLinkSerializer < ActiveModel::Serializer
+        attributes :id,
+                   :host,
+                   :query_params,
+                   :link
+      end
+
+      class NodeSerializer < ActiveModel::Serializer
+        attribute :node_id, key: :id
+        attribute :node_type do
+          object.node&.node_type&.name
+        end
+      end
+
+      class ColumnSerializer < ActiveModel::Serializer
+        attribute :column_group
+        attribute :node_type_id
+        attribute :role do
+          object.context_node_type_property.role
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/import/tables.rb
+++ b/app/services/api/v3/import/tables.rb
@@ -8,14 +8,16 @@ module Api
             table_class: Api::V3::Country,
             yellow_tables: [
               Api::V3::CountryProperty,
-              Api::V3::DashboardTemplateCountry
+              Api::V3::DashboardTemplateCountry,
+              Api::V3::SankeyCardLink
             ]
           },
           {
             table_class: Api::V3::Commodity,
             yellow_tables: [
               Api::V3::DashboardTemplateCommodity,
-              Api::V3::TopProfileImage
+              Api::V3::TopProfileImage,
+              Api::V3::SankeyCardLink
             ]
           },
           {
@@ -52,8 +54,8 @@ module Api
               Api::V3::TopProfile,
               Api::V3::DashboardTemplateSource,
               Api::V3::DashboardTemplateCompany,
-              Api::V3::DashboardTemplateDestination
-
+              Api::V3::DashboardTemplateDestination,
+              Api::V3::SankeyCardLinkNode
             ]
           },
           {

--- a/app/services/api/v3/import/tables.rb
+++ b/app/services/api/v3/import/tables.rb
@@ -35,7 +35,12 @@ module Api
               Api::V3::DashboardsAttribute
             ]
           },
-          {table_class: Api::V3::NodeType},
+          {
+            table_class: Api::V3::NodeType,
+            yellow_tables: [
+              Api::V3::SankeyCardLinkNodeType
+            ]
+          },
           {
             table_class: Api::V3::ContextNodeType,
             yellow_tables: [

--- a/app/services/api/v3/sankey_card_links/response_builder.rb
+++ b/app/services/api/v3/sankey_card_links/response_builder.rb
@@ -32,10 +32,11 @@ module Api
         end
 
         def initialize_data
-          @data = ActiveModel::Serializer::CollectionSerializer.new(
+          @data = ActiveModelSerializers::SerializableResource.new(
             @sankey_card_links,
-            serializer: Api::V3::SankeyCardLinks::SankeyCardLinkSerializer
-          ).as_json
+            each_serializer: Api::V3::SankeyCardLinks::SankeyCardLinkSerializer,
+            root: 'data'
+          ).serializable_hash[:data]
         end
 
         def initialize_meta
@@ -45,21 +46,23 @@ module Api
             @sankey_card_links.map(&:sankey_card_link_node_ids).flatten.uniq
           sankey_card_link_nodes =
             Api::V3::SankeyCardLinkNode.where(id: sankey_card_link_nodes_ids)
-          @meta[:nodes] = ActiveModel::Serializer::CollectionSerializer.new(
+          @meta[:nodes] = ActiveModelSerializers::SerializableResource.new(
             sankey_card_link_nodes,
-            serializer: Api::V3::SankeyCardLinks::NodeSerializer
-          ).as_json
+            each_serializer: Api::V3::SankeyCardLinks::NodeSerializer,
+            root: 'nodes'
+          ).serializable_hash[:nodes]
 
           sankey_card_link_node_type_ids =
             @sankey_card_links.map(&:sankey_card_link_node_type_ids).flatten.uniq
           sankey_card_link_node_types = Api::V3::SankeyCardLinkNodeType.
             where(id: sankey_card_link_node_type_ids)
-          columns = ActiveModel::Serializer::CollectionSerializer.new(
+          columns = ActiveModelSerializers::SerializableResource.new(
             sankey_card_link_node_types,
-            serializer: Api::V3::SankeyCardLinks::ColumnSerializer
-          ).as_json
+            each_serializer: Api::V3::SankeyCardLinks::ColumnSerializer,
+            root: 'columns'
+          ).serializable_hash[:columns]
           @meta[:columns] = {}
-          columns.each { |col| @meta[:columns][col[:node_type_id]] = col }
+          columns.each { |col| @meta[:columns][col[:nodeTypeId]] = col }
         end
       end
     end

--- a/app/services/api/v3/sankey_card_links/response_builder.rb
+++ b/app/services/api/v3/sankey_card_links/response_builder.rb
@@ -1,0 +1,64 @@
+module Api
+  module V3
+    module SankeyCardLinks
+      class ResponseBuilder
+        attr_reader :data, :meta
+
+        def initialize(params)
+          initialize_params(params)
+        end
+
+        def call
+          initialize_sankey_card_links
+
+          initialize_data
+          initialize_meta
+        end
+
+        private
+
+        def initialize_params(params)
+          @level = params[:level]
+          @country_id = params[:country_id]
+          @commodity_id = params[:commodity_id]
+        end
+
+        def initialize_sankey_card_links
+          query = Api::V3::SankeyCardLink.where(level: @level)
+          query = query.where(country_id: @country_id) if @country_id
+          query = query.where(commodity_id: @commodity_id) if @commodity_id
+          @sankey_card_links = query
+        end
+
+        def initialize_data
+          @data = ActiveModel::Serializer::CollectionSerializer.new(
+            @sankey_card_links,
+            serializer: Api::V3::SankeyCardLinks::SankeyCardLinkSerializer
+          ).as_json
+        end
+
+        def initialize_meta
+          @meta = {}
+
+          sankey_card_link_nodes_ids =
+            @sankey_card_links.map(&:sankey_card_link_node_ids).flatten.uniq
+          sankey_card_link_nodes =
+            Api::V3::SankeyCardLinkNode.where(id: sankey_card_link_nodes_ids)
+          @meta[:nodes] = ActiveModel::Serializer::CollectionSerializer.new(
+            sankey_card_link_nodes,
+            serializer: Api::V3::SankeyCardLinks::NodeSerializer
+          ).as_json
+
+          sankey_card_link_node_type_ids =
+            @sankey_card_links.map(&:sankey_card_link_node_type_ids).flatten.uniq
+          sankey_card_link_node_types = Api::V3::SankeyCardLinkNodeType.
+            where(id: sankey_card_link_node_type_ids)
+          @meta[:columns] = ActiveModel::Serializer::CollectionSerializer.new(
+            sankey_card_link_node_types,
+            serializer: Api::V3::SankeyCardLinks::ColumnSerializer
+          ).as_json
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
         get :countries_facts, on: :member
       end
       #resources :countries_facts, only: [:index]
+      resources :sankey_card_links, only: [:index]
     end
     namespace :v2 do
       resources :geo_id, only: :index

--- a/db/migrate/20190920090440_create_sankey_card_links.rb
+++ b/db/migrate/20190920090440_create_sankey_card_links.rb
@@ -1,7 +1,8 @@
 class CreateSankeyCardLinks < ActiveRecord::Migration[5.2]
   def change
     create_table :sankey_card_links do |t|
-      t.json :link, null: false
+      t.text :host, null: false
+      t.json :query_params, null: false
       t.text :title, null: false
       t.text :subtitle
 

--- a/db/migrate/20190920090440_create_sankey_card_links.rb
+++ b/db/migrate/20190920090440_create_sankey_card_links.rb
@@ -1,0 +1,11 @@
+class CreateSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sankey_card_links do |t|
+      t.json :link, null: false
+      t.text :title, null: false
+      t.text :subtitle
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190923143224_add_relations_to_sankey_card_links.rb
+++ b/db/migrate/20190923143224_add_relations_to_sankey_card_links.rb
@@ -1,0 +1,13 @@
+class AddRelationsToSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :sankey_card_links, :commodity, foreign_key: true
+    add_reference :sankey_card_links, :country, foreign_key: true
+    add_reference :sankey_card_links, :cont_attribute, foreign_key: {to_table: :attributes}
+    add_reference :sankey_card_links, :ncont_attribute, foreign_key: {to_table: :attributes}
+
+    create_table :sankey_card_link_nodes do |t|
+      t.references :sankey_card_link, foreign_key: true
+      t.references :node, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20191003080052_add_sankey_card_query_params_to_sankey_card_links.rb
+++ b/db/migrate/20191003080052_add_sankey_card_query_params_to_sankey_card_links.rb
@@ -1,0 +1,16 @@
+class AddSankeyCardQueryParamsToSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sankey_card_links, :start_year, :integer, null: false
+    add_column :sankey_card_links, :end_year, :integer, null: false
+
+    add_reference :sankey_card_links, :biome, foreign_key: {to_table: :nodes}
+
+    create_table :sankey_card_link_node_types do |t|
+      t.references :context_node_type_property,
+        foreign_key: true,
+        index: {name: 'sankey_card_link_node_types_context_node_type_property_id_idx'}
+      t.references :sankey_card_link, foreign_key: true
+      t.references :node_type, foreign_key: true
+    end
+  end
+end

--- a/db/migrate/20191003152614_add_levels_to_sankey_card_links.rb
+++ b/db/migrate/20191003152614_add_levels_to_sankey_card_links.rb
@@ -1,0 +1,5 @@
+class AddLevelsToSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sankey_card_links, :level, :integer, null: false
+  end
+end

--- a/db/migrate/20191004083620_add_column_group_to_sankey_card_link_node_types.rb
+++ b/db/migrate/20191004083620_add_column_group_to_sankey_card_link_node_types.rb
@@ -1,0 +1,5 @@
+class AddColumnGroupToSankeyCardLinkNodeTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sankey_card_link_node_types, :column_group, :integer, null: false
+  end
+end

--- a/db/migrate/20191007090648_make_level_multiple_on_sankey_card_links.rb
+++ b/db/migrate/20191007090648_make_level_multiple_on_sankey_card_links.rb
@@ -1,0 +1,9 @@
+class MakeLevelMultipleOnSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :sankey_card_links, :level
+
+    add_column :sankey_card_links, :level1, :boolean, null: false, default: false
+    add_column :sankey_card_links, :level2, :boolean, null: false, default: false
+    add_column :sankey_card_links, :level3, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20191008083758_add_delete_cascade_to_foreign_keys_on_sankey_card_links.rb
+++ b/db/migrate/20191008083758_add_delete_cascade_to_foreign_keys_on_sankey_card_links.rb
@@ -1,0 +1,13 @@
+class AddDeleteCascadeToForeignKeysOnSankeyCardLinks < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :sankey_card_links, :country, foreign_key: true
+    remove_reference :sankey_card_links, :commodity, foreign_key: true
+    remove_reference :sankey_card_links, :cont_attribute, foreign_key: {to_table: :attributes}
+    remove_reference :sankey_card_links, :ncont_attribute, foreign_key: {to_table: :attributes}
+
+    add_reference :sankey_card_links, :country, foreign_key: {on_delete: :cascade}
+    add_reference :sankey_card_links, :commodity, foreign_key: {on_delete: :cascade}
+    add_reference :sankey_card_links, :cont_attribute, foreign_key: {to_table: :attributes, on_delete: :cascade}
+    add_reference :sankey_card_links, :ncont_attribute, foreign_key: {to_table: :attributes, on_delete: :cascade}
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -506,6 +506,21 @@ tables:
         comment: Type of the original entity (Ind / Qual / Quant)
       - name: original_id
         comment: Id from the original table (inds / quals / quants)
+  - name: sankey_card_links
+    comment: Quick sankey cards
+    columns:
+      - name: query_params
+        comment: query params included on the link of the quick sankey card
+      - name: title
+        comment: title of the quick sankey card
+      - name: subtitle
+        comment: subtitle of the quick sankey card
+      - name: level1
+        comment: level used when commodity and country are not selected
+      - name: level2
+        comment: level used when commodity is selected
+      - name: level3
+        comment: level used when commodity and country are selected
 materialized_views:
   - name: chart_attributes_mv
     comment: Materialized view which merges chart_inds, chart_quals and chart_quants with chart_attributes.

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5907,6 +5907,39 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
+-- Name: sankey_card_links; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sankey_card_links (
+    id bigint NOT NULL,
+    link json NOT NULL,
+    title text NOT NULL,
+    subtitle text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sankey_card_links_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sankey_card_links_id_seq OWNED BY public.sankey_card_links.id;
+
+
+--
 -- Name: sankey_nodes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -6548,6 +6581,13 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: sankey_card_links id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_links_id_seq'::regclass);
 
 
 --
@@ -7639,6 +7679,14 @@ ALTER TABLE ONLY public.resize_by_quants
 
 ALTER TABLE ONLY public.resize_by_quants
     ADD CONSTRAINT resize_by_quants_resize_by_attribute_id_quant_id_key UNIQUE (resize_by_attribute_id, quant_id);
+
+
+--
+-- Name: sankey_card_links sankey_card_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT sankey_card_links_pkey PRIMARY KEY (id);
 
 
 --
@@ -9338,9 +9386,9 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190823135415'),
 ('20190919063754'),
 ('20190919211340'),
+('20190920090440'),
 ('20190923074833'),
 ('20190924075531'),
 ('20190924102948'),
 ('20191002200900');
-
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3573,6 +3573,41 @@ ALTER SEQUENCE public.dashboards_quants_id_seq OWNED BY public.dashboards_quants
 
 
 --
+-- Name: node_quals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.node_quals (
+    id integer NOT NULL,
+    node_id integer NOT NULL,
+    qual_id integer NOT NULL,
+    year integer,
+    value text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
+
+
+--
+-- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
+
+
+--
+-- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
+
+
+--
 -- Name: dashboards_sources_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -4936,41 +4971,6 @@ ALTER SEQUENCE public.node_properties_id_seq OWNED BY public.node_properties.id;
 
 
 --
--- Name: node_quals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.node_quals (
-    id integer NOT NULL,
-    node_id integer NOT NULL,
-    qual_id integer NOT NULL,
-    year integer,
-    value text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
-
-
---
--- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
-
-
---
--- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
-
-
---
 -- Name: node_quals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -5907,39 +5907,6 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
--- Name: sankey_card_links; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sankey_card_links (
-    id bigint NOT NULL,
-    link json NOT NULL,
-    title text NOT NULL,
-    subtitle text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: sankey_card_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sankey_card_links_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sankey_card_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sankey_card_links_id_seq OWNED BY public.sankey_card_links.id;
-
-
---
 -- Name: sankey_nodes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -6581,13 +6548,6 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
-
-
---
--- Name: sankey_card_links id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sankey_card_links ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_links_id_seq'::regclass);
 
 
 --
@@ -7679,14 +7639,6 @@ ALTER TABLE ONLY public.resize_by_quants
 
 ALTER TABLE ONLY public.resize_by_quants
     ADD CONSTRAINT resize_by_quants_resize_by_attribute_id_quant_id_key UNIQUE (resize_by_attribute_id, quant_id);
-
-
---
--- Name: sankey_card_links sankey_card_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sankey_card_links
-    ADD CONSTRAINT sankey_card_links_pkey PRIMARY KEY (id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5986,7 +5986,8 @@ CREATE TABLE public.sankey_card_links (
     ncont_attribute_id bigint,
     start_year integer NOT NULL,
     end_year integer NOT NULL,
-    biome_id bigint
+    biome_id bigint,
+    level integer NOT NULL
 );
 
 
@@ -9642,4 +9643,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190924075531'),
 ('20190924102948'),
 ('20191002200900'),
-('20191003080052');
+('20191003080052'),
+('20191003152614');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5908,6 +5908,37 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
+-- Name: sankey_card_link_node_types; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sankey_card_link_node_types (
+    id bigint NOT NULL,
+    context_node_type_property_id bigint,
+    sankey_card_link_id bigint,
+    node_type_id bigint
+);
+
+
+--
+-- Name: sankey_card_link_node_types_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sankey_card_link_node_types_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sankey_card_link_node_types_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sankey_card_link_node_types_id_seq OWNED BY public.sankey_card_link_node_types.id;
+
+
+--
 -- Name: sankey_card_link_nodes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5952,7 +5983,10 @@ CREATE TABLE public.sankey_card_links (
     commodity_id bigint,
     country_id bigint,
     cont_attribute_id bigint,
-    ncont_attribute_id bigint
+    ncont_attribute_id bigint,
+    start_year integer NOT NULL,
+    end_year integer NOT NULL,
+    biome_id bigint
 );
 
 
@@ -6617,6 +6651,13 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: sankey_card_link_node_types id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_node_types ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_link_node_types_id_seq'::regclass);
 
 
 --
@@ -7725,6 +7766,14 @@ ALTER TABLE ONLY public.resize_by_quants
 
 
 --
+-- Name: sankey_card_link_node_types sankey_card_link_node_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_node_types
+    ADD CONSTRAINT sankey_card_link_node_types_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: sankey_card_link_nodes sankey_card_link_nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8360,6 +8409,20 @@ CREATE UNIQUE INDEX ind_values_meta_mv_ind_id_idx ON public.ind_values_meta_mv U
 
 
 --
+-- Name: index_sankey_card_link_node_types_on_node_type_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_link_node_types_on_node_type_id ON public.sankey_card_link_node_types USING btree (node_type_id);
+
+
+--
+-- Name: index_sankey_card_link_node_types_on_sankey_card_link_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_link_node_types_on_sankey_card_link_id ON public.sankey_card_link_node_types USING btree (sankey_card_link_id);
+
+
+--
 -- Name: index_sankey_card_link_nodes_on_node_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8371,6 +8434,13 @@ CREATE INDEX index_sankey_card_link_nodes_on_node_id ON public.sankey_card_link_
 --
 
 CREATE INDEX index_sankey_card_link_nodes_on_sankey_card_link_id ON public.sankey_card_link_nodes USING btree (sankey_card_link_id);
+
+
+--
+-- Name: index_sankey_card_links_on_biome_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_links_on_biome_id ON public.sankey_card_links USING btree (biome_id);
 
 
 --
@@ -8689,6 +8759,13 @@ CREATE INDEX resize_by_quants_resize_by_attribute_id_idx ON public.resize_by_qua
 
 
 --
+-- Name: sankey_card_link_node_types_context_node_type_property_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sankey_card_link_node_types_context_node_type_property_id_idx ON public.sankey_card_link_node_types USING btree (context_node_type_property_id);
+
+
+--
 -- Name: sankey_nodes_mv_context_id_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8796,6 +8873,14 @@ ALTER TABLE ONLY public.download_attributes
 
 ALTER TABLE ONLY public.chart_attributes
     ADD CONSTRAINT fk_rails_18fff2d805 FOREIGN KEY (chart_id) REFERENCES public.charts(id) ON DELETE CASCADE;
+
+
+--
+-- Name: sankey_card_link_node_types fk_rails_1a85ec11cd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_node_types
+    ADD CONSTRAINT fk_rails_1a85ec11cd FOREIGN KEY (sankey_card_link_id) REFERENCES public.sankey_card_links(id);
 
 
 --
@@ -9023,6 +9108,14 @@ ALTER TABLE ONLY public.contextual_layers
 
 
 --
+-- Name: sankey_card_link_node_types fk_rails_610fd60c08; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_node_types
+    ADD CONSTRAINT fk_rails_610fd60c08 FOREIGN KEY (node_type_id) REFERENCES public.node_types(id);
+
+
+--
 -- Name: country_properties fk_rails_668b355aa6; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9180,6 +9273,14 @@ ALTER TABLE ONLY public.dashboards_attributes
 
 ALTER TABLE ONLY public.carto_layers
     ADD CONSTRAINT fk_rails_9b2f0fa157 FOREIGN KEY (contextual_layer_id) REFERENCES public.contextual_layers(id) ON DELETE CASCADE;
+
+
+--
+-- Name: sankey_card_link_node_types fk_rails_a152a2cab3; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_node_types
+    ADD CONSTRAINT fk_rails_a152a2cab3 FOREIGN KEY (context_node_type_property_id) REFERENCES public.context_node_type_properties(id);
 
 
 --
@@ -9359,6 +9460,14 @@ ALTER TABLE ONLY public.download_quants
 
 
 --
+-- Name: sankey_card_links fk_rails_e3c8c4d772; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT fk_rails_e3c8c4d772 FOREIGN KEY (biome_id) REFERENCES public.nodes(id);
+
+
+--
 -- Name: node_quants fk_rails_e5f4cc54e9; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9532,5 +9641,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190923143224'),
 ('20190924075531'),
 ('20190924102948'),
-('20191002200900');
-
+('20191002200900'),
+('20191003080052');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5915,7 +5915,8 @@ CREATE TABLE public.sankey_card_link_node_types (
     id bigint NOT NULL,
     context_node_type_property_id bigint,
     sankey_card_link_id bigint,
-    node_type_id bigint
+    node_type_id bigint,
+    column_group integer NOT NULL
 );
 
 
@@ -9644,4 +9645,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190924102948'),
 ('20191002200900'),
 ('20191003080052'),
-('20191003152614');
+('20191003152614'),
+('20191004083620');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5,6 +5,7 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
@@ -899,7 +900,7 @@ CREATE VIEW public.attributes_v AS
              LEFT JOIN public.quant_properties qp ON ((qp.quant_id = quants.id)))
         UNION ALL
          SELECT inds.id,
-            'Ind'::text,
+            'Ind'::text AS text,
             inds.name,
             ip.display_name,
             inds.unit,
@@ -909,11 +910,11 @@ CREATE VIEW public.attributes_v AS
              LEFT JOIN public.ind_properties ip ON ((ip.ind_id = inds.id)))
         UNION ALL
          SELECT quals.id,
-            'Qual'::text,
+            'Qual'::text AS text,
             quals.name,
             qp.display_name,
-            NULL::text,
-            NULL::text,
+            NULL::text AS text,
+            NULL::text AS text,
             qp.tooltip_text
            FROM (public.quals
              LEFT JOIN public.qual_properties qp ON ((qp.qual_id = quals.id)))) s;
@@ -5907,6 +5908,36 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
+-- Name: sankey_card_link_nodes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sankey_card_link_nodes (
+    id bigint NOT NULL,
+    sankey_card_link_id bigint,
+    node_id bigint
+);
+
+
+--
+-- Name: sankey_card_link_nodes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sankey_card_link_nodes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sankey_card_link_nodes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sankey_card_link_nodes_id_seq OWNED BY public.sankey_card_link_nodes.id;
+
+
+--
 -- Name: sankey_card_links; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5917,7 +5948,11 @@ CREATE TABLE public.sankey_card_links (
     title text NOT NULL,
     subtitle text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    commodity_id bigint,
+    country_id bigint,
+    cont_attribute_id bigint,
+    ncont_attribute_id bigint
 );
 
 
@@ -6582,6 +6617,13 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: sankey_card_link_nodes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_nodes ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_link_nodes_id_seq'::regclass);
 
 
 --
@@ -7683,6 +7725,14 @@ ALTER TABLE ONLY public.resize_by_quants
 
 
 --
+-- Name: sankey_card_link_nodes sankey_card_link_nodes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_nodes
+    ADD CONSTRAINT sankey_card_link_nodes_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: sankey_card_links sankey_card_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8310,6 +8360,48 @@ CREATE UNIQUE INDEX ind_values_meta_mv_ind_id_idx ON public.ind_values_meta_mv U
 
 
 --
+-- Name: index_sankey_card_link_nodes_on_node_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_link_nodes_on_node_id ON public.sankey_card_link_nodes USING btree (node_id);
+
+
+--
+-- Name: index_sankey_card_link_nodes_on_sankey_card_link_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_link_nodes_on_sankey_card_link_id ON public.sankey_card_link_nodes USING btree (sankey_card_link_id);
+
+
+--
+-- Name: index_sankey_card_links_on_commodity_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_links_on_commodity_id ON public.sankey_card_links USING btree (commodity_id);
+
+
+--
+-- Name: index_sankey_card_links_on_cont_attribute_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_links_on_cont_attribute_id ON public.sankey_card_links USING btree (cont_attribute_id);
+
+
+--
+-- Name: index_sankey_card_links_on_country_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_links_on_country_id ON public.sankey_card_links USING btree (country_id);
+
+
+--
+-- Name: index_sankey_card_links_on_ncont_attribute_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sankey_card_links_on_ncont_attribute_id ON public.sankey_card_links USING btree (ncont_attribute_id);
+
+
+--
 -- Name: index_top_profile_images_on_commodity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8651,6 +8743,14 @@ ALTER TABLE ONLY public.dashboards_quals
 
 
 --
+-- Name: sankey_card_link_nodes fk_rails_1428ad7ffd; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_nodes
+    ADD CONSTRAINT fk_rails_1428ad7ffd FOREIGN KEY (node_id) REFERENCES public.nodes(id);
+
+
+--
 -- Name: node_quals fk_rails_14ebb50b5a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8760,6 +8860,14 @@ ALTER TABLE ONLY public.recolor_by_inds
 
 ALTER TABLE ONLY public.top_profile_images
     ADD CONSTRAINT fk_rails_29f1862b03 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: sankey_card_links fk_rails_2c41bcb873; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT fk_rails_2c41bcb873 FOREIGN KEY (cont_attribute_id) REFERENCES public.attributes(id);
 
 
 --
@@ -8891,6 +8999,14 @@ ALTER TABLE ONLY public.qual_context_properties
 
 
 --
+-- Name: sankey_card_links fk_rails_5b56ba10d2; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT fk_rails_5b56ba10d2 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id);
+
+
+--
 -- Name: ind_commodity_properties fk_rails_5c0dcf9d64; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8947,6 +9063,14 @@ ALTER TABLE ONLY public.flow_quals
 
 
 --
+-- Name: sankey_card_link_nodes fk_rails_70f69f2537; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_link_nodes
+    ADD CONSTRAINT fk_rails_70f69f2537 FOREIGN KEY (sankey_card_link_id) REFERENCES public.sankey_card_links(id);
+
+
+--
 -- Name: ind_properties fk_rails_720a88d4b2; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -8984,6 +9108,14 @@ ALTER TABLE ONLY public.quant_context_properties
 
 ALTER TABLE ONLY public.quant_country_properties
     ADD CONSTRAINT fk_rails_90fcd1e231 FOREIGN KEY (country_id) REFERENCES public.countries(id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
+-- Name: sankey_card_links fk_rails_9113195b2d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT fk_rails_9113195b2d FOREIGN KEY (country_id) REFERENCES public.countries(id);
 
 
 --
@@ -9251,6 +9383,14 @@ ALTER TABLE ONLY public.top_profiles
 
 
 --
+-- Name: sankey_card_links fk_rails_ec3ba51bdb; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT fk_rails_ec3ba51bdb FOREIGN KEY (ncont_attribute_id) REFERENCES public.attributes(id);
+
+
+--
 -- Name: contexts fk_rails_eea78f436e; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -9389,6 +9529,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190919211340'),
 ('20190920090440'),
 ('20190923074833'),
+('20190923143224'),
 ('20190924075531'),
 ('20190924102948'),
 ('20191002200900');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3573,41 +3573,6 @@ ALTER SEQUENCE public.dashboards_quants_id_seq OWNED BY public.dashboards_quants
 
 
 --
--- Name: node_quals; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.node_quals (
-    id integer NOT NULL,
-    node_id integer NOT NULL,
-    qual_id integer NOT NULL,
-    year integer,
-    value text NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
-
-
---
--- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
-
-
---
--- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
-
-
---
 -- Name: dashboards_sources_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -4971,6 +4936,41 @@ ALTER SEQUENCE public.node_properties_id_seq OWNED BY public.node_properties.id;
 
 
 --
+-- Name: node_quals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.node_quals (
+    id integer NOT NULL,
+    node_id integer NOT NULL,
+    qual_id integer NOT NULL,
+    year integer,
+    value text NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE node_quals; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.node_quals IS 'Values of quals for node';
+
+
+--
+-- Name: COLUMN node_quals.year; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.year IS 'Year; empty (NULL) for all years';
+
+
+--
+-- Name: COLUMN node_quals.value; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.node_quals.value IS 'Textual value';
+
+
+--
 -- Name: node_quals_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -5907,6 +5907,40 @@ ALTER SEQUENCE public.resize_by_quants_id_seq OWNED BY public.resize_by_quants.i
 
 
 --
+-- Name: sankey_card_links; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sankey_card_links (
+    id bigint NOT NULL,
+    host text NOT NULL,
+    query_params json NOT NULL,
+    title text NOT NULL,
+    subtitle text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sankey_card_links_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sankey_card_links_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sankey_card_links_id_seq OWNED BY public.sankey_card_links.id;
+
+
+--
 -- Name: sankey_nodes_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
@@ -6548,6 +6582,13 @@ ALTER TABLE ONLY public.resize_by_attributes ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.resize_by_quants ALTER COLUMN id SET DEFAULT nextval('public.resize_by_quants_id_seq'::regclass);
+
+
+--
+-- Name: sankey_card_links id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links ALTER COLUMN id SET DEFAULT nextval('public.sankey_card_links_id_seq'::regclass);
 
 
 --
@@ -7639,6 +7680,14 @@ ALTER TABLE ONLY public.resize_by_quants
 
 ALTER TABLE ONLY public.resize_by_quants
     ADD CONSTRAINT resize_by_quants_resize_by_attribute_id_quant_id_key UNIQUE (resize_by_attribute_id, quant_id);
+
+
+--
+-- Name: sankey_card_links sankey_card_links_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sankey_card_links
+    ADD CONSTRAINT sankey_card_links_pkey PRIMARY KEY (id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5988,7 +5988,9 @@ CREATE TABLE public.sankey_card_links (
     start_year integer NOT NULL,
     end_year integer NOT NULL,
     biome_id bigint,
-    level integer NOT NULL
+    level1 boolean DEFAULT false NOT NULL,
+    level2 boolean DEFAULT false NOT NULL,
+    level3 boolean DEFAULT false NOT NULL
 );
 
 
@@ -9646,4 +9648,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191002200900'),
 ('20191003080052'),
 ('20191003152614'),
-('20191004083620');
+('20191004083620'),
+('20191007090648');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5981,17 +5981,66 @@ CREATE TABLE public.sankey_card_links (
     subtitle text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    commodity_id bigint,
-    country_id bigint,
-    cont_attribute_id bigint,
-    ncont_attribute_id bigint,
     start_year integer NOT NULL,
     end_year integer NOT NULL,
     biome_id bigint,
     level1 boolean DEFAULT false NOT NULL,
     level2 boolean DEFAULT false NOT NULL,
-    level3 boolean DEFAULT false NOT NULL
+    level3 boolean DEFAULT false NOT NULL,
+    country_id bigint,
+    commodity_id bigint,
+    cont_attribute_id bigint,
+    ncont_attribute_id bigint
 );
+
+
+--
+-- Name: TABLE sankey_card_links; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.sankey_card_links IS 'Quick sankey cards';
+
+
+--
+-- Name: COLUMN sankey_card_links.query_params; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sankey_card_links.query_params IS 'query params included on the link of the quick sankey card';
+
+
+--
+-- Name: COLUMN sankey_card_links.title; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sankey_card_links.title IS 'title of the quick sankey card';
+
+
+--
+-- Name: COLUMN sankey_card_links.subtitle; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sankey_card_links.subtitle IS 'subtitle of the quick sankey card';
+
+
+--
+-- Name: COLUMN sankey_card_links.level1; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sankey_card_links.level1 IS 'level used when commodity and country are not selected';
+
+
+--
+-- Name: COLUMN sankey_card_links.level2; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sankey_card_links.level2 IS 'level used when commodity is selected';
+
+
+--
+-- Name: COLUMN sankey_card_links.level3; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sankey_card_links.level3 IS 'level used when commodity and country are selected';
 
 
 --
@@ -8956,7 +9005,7 @@ ALTER TABLE ONLY public.top_profile_images
 --
 
 ALTER TABLE ONLY public.sankey_card_links
-    ADD CONSTRAINT fk_rails_2c41bcb873 FOREIGN KEY (cont_attribute_id) REFERENCES public.attributes(id);
+    ADD CONSTRAINT fk_rails_2c41bcb873 FOREIGN KEY (cont_attribute_id) REFERENCES public.attributes(id) ON DELETE CASCADE;
 
 
 --
@@ -9092,7 +9141,7 @@ ALTER TABLE ONLY public.qual_context_properties
 --
 
 ALTER TABLE ONLY public.sankey_card_links
-    ADD CONSTRAINT fk_rails_5b56ba10d2 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id);
+    ADD CONSTRAINT fk_rails_5b56ba10d2 FOREIGN KEY (commodity_id) REFERENCES public.commodities(id) ON DELETE CASCADE;
 
 
 --
@@ -9212,7 +9261,7 @@ ALTER TABLE ONLY public.quant_country_properties
 --
 
 ALTER TABLE ONLY public.sankey_card_links
-    ADD CONSTRAINT fk_rails_9113195b2d FOREIGN KEY (country_id) REFERENCES public.countries(id);
+    ADD CONSTRAINT fk_rails_9113195b2d FOREIGN KEY (country_id) REFERENCES public.countries(id) ON DELETE CASCADE;
 
 
 --
@@ -9500,7 +9549,7 @@ ALTER TABLE ONLY public.top_profiles
 --
 
 ALTER TABLE ONLY public.sankey_card_links
-    ADD CONSTRAINT fk_rails_ec3ba51bdb FOREIGN KEY (ncont_attribute_id) REFERENCES public.attributes(id);
+    ADD CONSTRAINT fk_rails_ec3ba51bdb FOREIGN KEY (ncont_attribute_id) REFERENCES public.attributes(id) ON DELETE CASCADE;
 
 
 --
@@ -9649,4 +9698,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191003080052'),
 ('20191003152614'),
 ('20191004083620'),
-('20191007090648');
+('20191007090648'),
+('20191008083758');

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -305,6 +305,29 @@ paths:
                   data:
                     $ref: "#/components/schemas/NodesStats"
 
+  "/sankey_card_links":
+    get:
+      summary: Data for the sankey card links
+      parameters:
+        - $ref: "#/components/parameters/country_id_query_param"
+        - $ref: "#/components/parameters/commodity_id_query_param"
+        - name: level
+          in: query
+          description: Level
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: "#/components/schemas/SankeyCardLinks"
+
   /nodes/search:
     get:
       tags:
@@ -1626,6 +1649,13 @@ servers:
   - url: https://trase.earth/api/v3
 components:
   parameters:
+    country_id_query_param:
+      name: country_id
+      in: query
+      description: "Country id"
+      required: false
+      schema:
+        type: integer
     commodity_id_query_param:
       name: commodity_id
       in: query
@@ -2289,6 +2319,69 @@ components:
                             type: number
                           height:
                             type: number
+
+    SankeyCardLinks:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+              host:
+                type: string
+              link:
+                type: string
+              query_params:
+                type: object
+                properties:
+                  selectedCountryId:
+                    type: integer
+                  selectedCommodityId:
+                    type: integer
+                  selectedContextId:
+                    type: integer
+                  selectedResizeBy:
+                    type: integer
+                  selectedRecolorBy:
+                    type: integer
+                  selectedYears:
+                    type: array
+                    items:
+                      type: integer
+                  selectedColumnsIds:
+                    type: string
+                  selectedNodesIds:
+                    type: array
+                    items:
+                      type: integer
+                  selectedBiomeFilterName:
+                    type: string
+        meta:
+          type: object
+          properties:
+            nodes:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                  node_type:
+                    type: string
+            columns:
+              type: array
+              items:
+                type: object
+                properties:
+                  column_group:
+                    type: integer
+                  node_type_id:
+                    type: integer
+                  role:
+                    type: string
 
     Node:
       type: object

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -307,6 +307,8 @@ paths:
 
   "/sankey_card_links":
     get:
+      tags:
+        - explore
       summary: Data for the sankey card links
       parameters:
         - $ref: "#/components/parameters/country_id_query_param"
@@ -316,7 +318,7 @@ paths:
           description: Level
           required: true
           schema:
-            type: integer
+            type: string
       responses:
         "200":
           description: OK
@@ -2359,6 +2361,10 @@ components:
                       type: integer
                   selectedBiomeFilterName:
                     type: string
+              commodity_id:
+                type: integer
+              country_id:
+                type: integer
         meta:
           type: object
           properties:
@@ -2369,19 +2375,11 @@ components:
                 properties:
                   id:
                     type: integer
-                  node_type:
-                    type: string
-            columns:
-              type: array
-              items:
-                type: object
-                properties:
-                  column_group:
-                    type: integer
                   node_type_id:
                     type: integer
-                  role:
-                    type: string
+            columns:
+              type: object
+              # In normal JSON Schema you could use patternProperties for dynamic object keys, but OpenAPI forbids it
 
     Node:
       type: object

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
     sequence(:host) { |n| "host#{n}.com" }
-    sequence(:query_params) { |n| {property: n} }
+    sequence(:query_params) { |n| {nodes_ids: [n]} }
   end
 end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -2,11 +2,13 @@ FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
     sequence(:host) { |n| "host#{n}.com" }
-    query_params { {
-      commodity_id: Api::V3::Commodity.first.id,
-      country_id: Api::V3::Country.first.id,
-      cont_attribute_id: Api::V3::Readonly::Attribute.first.id,
-      ncont_attribute_id: Api::V3::Readonly::Attribute.first.id
-    } }
+    query_params {
+      {
+        'selectedCommodityId' => Api::V3::Commodity.find_by(name: 'BEEF').id,
+        'selectedCountryId' => Api::V3::Country.find_by(name: 'BRAZIL').id,
+        'selectedResizeBy' => Api::V3::Readonly::Attribute.first.id,
+        'selectedRecolorBy' => Api::V3::Readonly::Attribute.first.id
+      }
+    }
   end
 end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
     sequence(:host) { |n| "host#{n}.com" }
-    level { rand(1..3) }
+    level3 { true }
     query_params {
       {
         'selectedCommodityId' => Api::V3::Commodity.find_by(name: 'BEEF').id,

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
-    sequence(:link) { |n| {property: n} }
+    sequence(:host) { |n| "host#{n}.com" }
+    sequence(:query_params) { |n| {property: n} }
   end
 end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
+    sequence(:title) { |n| "Title#{n}" }
+    sequence(:link) { |n| {property: n} }
+  end
+end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
     sequence(:host) { |n| "host#{n}.com" }
-    sequence(:query_params) { |n| {nodes_ids: [n]} }
+    query_params { {
+      commodity_id: Api::V3::Commodity.first.id,
+      country_id: Api::V3::Country.first.id,
+      cont_attribute_id: Api::V3::Readonly::Attribute.first.id,
+      ncont_attribute_id: Api::V3::Readonly::Attribute.first.id
+    } }
   end
 end

--- a/spec/factories/api/v3/api_v3_sankey_card_link.rb
+++ b/spec/factories/api/v3/api_v3_sankey_card_link.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :api_v3_sankey_card_link, class: 'Api::V3::SankeyCardLink' do
     sequence(:title) { |n| "Title#{n}" }
     sequence(:host) { |n| "host#{n}.com" }
+    level { rand(1..3) }
     query_params {
       {
         'selectedCommodityId' => Api::V3::Commodity.find_by(name: 'BEEF').id,

--- a/spec/models/api/v3/sankey_card_link_node_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_node_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::SankeyCardLinkNode, type: :model do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil beef nodes'
+  include_context 'api v3 brazil flows quals'
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil beef context node types'
+
+  before do
+    Api::V3::Readonly::Node.refresh(sync: true)
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:sankey_card_link) do
+    sankey_card_link = FactoryBot.build(:api_v3_sankey_card_link)
+    sankey_card_link.query_params['selectedNodesIds'] =
+      [api_v3_brazil_beef_country_of_production_node.id]
+    sankey_card_link.save
+
+    sankey_card_link
+  end
+
+  describe :callbacks do
+    describe 'after_commit' do
+      describe '#update_query_params' do
+        it 'update "selectedNodesIds" on query_params attribute of Sankey card links' do
+          Api::V3::SankeyCardLinkNode.find_or_create_by!(
+            node_id: api_v3_country_of_destination_node.id,
+            sankey_card_link_id: sankey_card_link.id
+          )
+
+          sankey_card_link.reload
+          expect(sankey_card_link.query_params).to include('selectedNodesIds' => [
+            api_v3_brazil_beef_country_of_production_node.id,
+            api_v3_country_of_destination_node.id
+          ])
+        end
+      end
+    end
+  end
+end

--- a/spec/models/api/v3/sankey_card_link_node_type_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_node_type_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::SankeyCardLinkNodeType, type: :model do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil beef nodes'
+  include_context 'api v3 brazil flows quals'
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil beef context node types'
+
+  before do
+    Api::V3::Readonly::Node.refresh(sync: true)
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  let(:sankey_card_link) { FactoryBot.create(:api_v3_sankey_card_link) }
+
+  describe :callbacks do
+    describe 'after_commit' do
+      describe '#update_query_params' do
+        it 'update "selectedColumnsIds" on query_params attribute of Sankey card links' do
+          context_id = Api::V3::Context.find_by(
+            country_id: sankey_card_link.country_id,
+            commodity_id: sankey_card_link.commodity_id
+          )
+          node_type_id = api_v3_brazil_beef_port_of_export_context_node_type.
+            node_type_id
+          context_node_type_property_id = Api::V3::NodeType.
+            select('context_node_type_properties.id AS context_node_type_property_id').
+            joins('JOIN context_node_types ON context_node_types.node_type_id = node_types.id').
+            joins('JOIN context_node_type_properties ON context_node_type_properties.context_node_type_id = context_node_types.id').
+            find_by(
+              'node_types.id': node_type_id,
+              'context_node_types.context_id': context_id,
+              'context_node_type_properties.column_group': 1
+            )&.context_node_type_property_id
+          Api::V3::SankeyCardLinkNodeType.find_or_create_by!(
+            column_group: 1,
+            sankey_card_link_id: sankey_card_link.id,
+            context_node_type_property_id: context_node_type_property_id
+          )
+
+          sankey_card_link.reload
+          expect(sankey_card_link.query_params['selectedColumnsIds']).to include(
+            "1_#{node_type_id}"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V3::SankeyCardLink, type: :model do
   include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil beef nodes'
+  include_context 'api v3 brazil flows quals'
   include_context 'api v3 brazil resize by attributes'
 
   before do
@@ -26,9 +28,6 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     let(:sankey_card_link_with_invalid_query_params) {
       FactoryBot.build(:api_v3_sankey_card_link, link_param: 'http://test.com?one=1')
     }
-    let(:sankey_card_link_without_required_params) {
-      FactoryBot.build(:api_v3_sankey_card_link, query_params: {commodity_id: 1})
-    }
 
     it 'fails when host blank' do
       expect(sankey_card_link_without_host).to have(1).errors_on(:host)
@@ -39,11 +38,7 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     end
 
     it 'fails when query_params include invalid parameters' do
-      expect(sankey_card_link_with_invalid_query_params).to have(2).errors_on(:link_param)
-    end
-
-    it 'fails when query_params doesnt include all required parameters' do
-      expect(sankey_card_link_without_required_params).to have(1).errors_on(:link_param)
+      expect(sankey_card_link_with_invalid_query_params).to have(1).errors_on(:link_param)
     end
 
     it 'fails when title blank' do
@@ -65,17 +60,35 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     describe 'before_validation' do
       describe '#extract_link_params' do
         it 'extract parameters from link' do
-          sankey_card_link.update_attributes(link_param: 'http://test.com?start_year=1')
+          sankey_card_link.update_attributes(
+            link_param: 'http://test.com?selectedYears%5B%5D=2009'
+          )
           expect(sankey_card_link.host).to eql 'test.com'
-          expect(sankey_card_link.query_params).to eql({'start_year' => '1'})
+          expect(sankey_card_link.query_params).to eql(
+            'selectedYears' => ['2009']
+          )
         end
       end
 
-      describe '#extract_required_params' do
-        it 'extract relations from the required params' do
-          sankey_card_link.update_attributes(link_param: 'http://test.com?commodity_id=1')
+      describe '#extract_relations' do
+        it 'extract relations from the params' do
+          sankey_card_link.update_attributes(
+            link_param: "http://test.com?selectedCommodityId=#{api_v3_beef.id}&"\
+                        "selectedCountryId=#{api_v3_brazil.id}&"\
+                        "selectedResizeBy=#{api_v3_volume.readonly_attribute.id}&"\
+                        "selectedRecolorBy=#{api_v3_biome.readonly_attribute.id}&"\
+                        'selectedYears%5B%5D=2015&selectedYears%5B%5D=2017&'\
+                        "selectedBiomeFilterName=#{api_v3_biome_node.name}"
+          )
+
           expect(sankey_card_link.host).to eql 'test.com'
-          expect(sankey_card_link.commodity_id).to eql 1
+          expect(sankey_card_link.commodity_id).to eql api_v3_beef.id
+          expect(sankey_card_link.country_id).to eql api_v3_brazil.id
+          expect(sankey_card_link.cont_attribute_id).to eql api_v3_volume.readonly_attribute.id
+          expect(sankey_card_link.ncont_attribute_id).to eql api_v3_biome.readonly_attribute.id
+          expect(sankey_card_link.start_year).to eql 2015
+          expect(sankey_card_link.end_year).to eql 2017
+          expect(sankey_card_link.biome_id).to eql api_v3_biome_node.id
         end
       end
     end
@@ -84,25 +97,57 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
       describe '#add_nodes_relations' do
         it 'extract new nodes relations' do
           expect do
-            node = Api::V3::Node.first
             sankey_card_link.update_attributes(
-              link_param: "#{sankey_card_link.link}&nodes_ids=#{node.id}"
+              link_param: "#{sankey_card_link.link}&" \
+                          "selectedNodesIds%5B%5D=#{api_v3_brazil_beef_country_of_production_node.id}&" \
+                          "selectedNodesIds%5B%5D=#{api_v3_country_of_destination_node.id}"
             )
-          end.to change { Api::V3::SankeyCardLinkNode.count }.by(1)
+          end.to change { Api::V3::SankeyCardLinkNode.count }.by(2)
         end
 
         it 'removes old nodes relations' do
           base_link = sankey_card_link.link
-          nodes = Api::V3::Node.all
           sankey_card_link.update_attributes(
-            link_param: "#{base_link}&nodes_ids=#{nodes.first.id},#{nodes.second.id}"
+            link_param: "#{base_link}&"\
+                        "selectedNodesIds%5B%5D=#{api_v3_brazil_beef_country_of_production_node.id}&"\
+                        "selectedNodesIds%5B%5D=#{api_v3_country_of_destination_node.id}"
           )
 
           expect do
             sankey_card_link.update_attributes(
-              link_param: "#{base_link}&nodes_ids=#{nodes.first.id}"
+              link_param: "#{base_link}&"\
+                          "selectedNodesIds%5B%5D=#{api_v3_brazil_beef_country_of_production_node.id}"
             )
           end.to change { Api::V3::SankeyCardLinkNode.count }.by(-1)
+        end
+      end
+
+      describe '#add_node_types_relations' do
+        it 'extract new node types relations' do
+          expect do
+            column_id = api_v3_brazil_beef_port_of_export_context_node_type.
+              node_type_id
+            sankey_card_link.update_attributes(
+              link_param: "#{sankey_card_link.link}&" \
+                          "selectedColumnsIds=1_#{column_id}"
+            )
+          end.to change { Api::V3::SankeyCardLinkNodeType.count }.by(1)
+        end
+
+        it 'removes old nodes relations' do
+          base_link = sankey_card_link.link
+          column_id = api_v3_brazil_beef_port_of_export_context_node_type.
+            node_type_id
+          sankey_card_link.update_attributes(
+            link_param: "#{base_link}&"\
+                        "selectedColumnsIds=1_#{column_id}"
+          )
+
+          expect do
+            sankey_card_link.update_attributes(
+              link_param: "#{base_link}&selectedColumnsIds="
+            )
+          end.to change { Api::V3::SankeyCardLinkNodeType.count }.by(-1)
         end
       end
     end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
     let(:sankey_card_link_without_level) {
-      FactoryBot.build(:api_v3_sankey_card_link, level: nil)
+      FactoryBot.build(:api_v3_sankey_card_link, level3: nil)
     }
 
     it 'fails when host blank' do
@@ -36,11 +36,11 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     end
 
     [1, 2, 3].each do |n|
-      it "fails when there is more than #{Api::V3::SankeyCardLink::MAX_PER_LEVEL} for level #{n}" do
-        FactoryBot.create_list(:api_v3_sankey_card_link, 4, level: n)
+      it "fails when there is more than #{Api::V3::SankeyCardLink::MAX_PER_LEVEL} for level#{n}" do
+        FactoryBot.create_list(:api_v3_sankey_card_link, 4, "level#{n}": true)
 
-        sankey_card_link = FactoryBot.build(:api_v3_sankey_card_link, level: n)
-        expect(sankey_card_link).to have(1).errors_on(:level)
+        sankey_card_link = FactoryBot.build(:api_v3_sankey_card_link, "level#{n}": true)
+        expect(sankey_card_link).to have(1).errors_on(:"level#{n}")
       end
     end
   end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::SankeyCardLink, type: :model do
+  describe :validate do
+    let(:sankey_card_link_without_link) {
+      FactoryBot.build(:api_v3_sankey_card_link, link: nil)
+    }
+    let(:sankey_card_link_without_title) {
+      FactoryBot.build(:api_v3_sankey_card_link, title: nil)
+    }
+
+    it 'fails when link blank' do
+      expect(sankey_card_link_without_link).to have(1).errors_on(:link)
+    end
+
+    it 'fails when title blank' do
+      expect(sankey_card_link_without_title).to have(1).errors_on(:title)
+    end
+  end
+end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::SankeyCardLink, type: :model do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil resize by attributes'
+
+  before do
+    Api::V3::Readonly::Node.refresh(sync: true)
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+  end
+
   let(:sankey_card_link) {
     FactoryBot.build(:api_v3_sankey_card_link)
   }
@@ -10,13 +18,16 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
       FactoryBot.build(:api_v3_sankey_card_link, host: nil)
     }
     let(:sankey_card_link_without_query_params) {
-      FactoryBot.build(:api_v3_sankey_card_link, query_params: nil)
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: nil, link_param: 'http://test.com')
     }
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
     let(:sankey_card_link_with_invalid_query_params) {
-      FactoryBot.build(:api_v3_sankey_card_link, query_params: {one: 1})
+      FactoryBot.build(:api_v3_sankey_card_link, link_param: 'http://test.com?one=1')
+    }
+    let(:sankey_card_link_without_required_params) {
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: {commodity_id: 1})
     }
 
     it 'fails when host blank' do
@@ -28,7 +39,11 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     end
 
     it 'fails when query_params include invalid parameters' do
-      expect(sankey_card_link_with_invalid_query_params).to have(1).errors_on(:query_params)
+      expect(sankey_card_link_with_invalid_query_params).to have(2).errors_on(:link_param)
+    end
+
+    it 'fails when query_params doesnt include all required parameters' do
+      expect(sankey_card_link_without_required_params).to have(1).errors_on(:link_param)
     end
 
     it 'fails when title blank' do
@@ -47,12 +62,47 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
   end
 
   describe :callbacks do
-    describe 'before_save' do
+    describe 'before_validation' do
       describe '#extract_link_params' do
         it 'extract parameters from link' do
-          sankey_card_link.update_attributes(link_param: 'http://test.com?one=1')
+          sankey_card_link.update_attributes(link_param: 'http://test.com?start_year=1')
           expect(sankey_card_link.host).to eql 'test.com'
-          expect(sankey_card_link.query_params).to eql({'one' => '1'})
+          expect(sankey_card_link.query_params).to eql({'start_year' => '1'})
+        end
+      end
+
+      describe '#extract_required_params' do
+        it 'extract relations from the required params' do
+          sankey_card_link.update_attributes(link_param: 'http://test.com?commodity_id=1')
+          expect(sankey_card_link.host).to eql 'test.com'
+          expect(sankey_card_link.commodity_id).to eql 1
+        end
+      end
+    end
+
+    describe 'after_commit' do
+      describe '#add_nodes_relations' do
+        it 'extract new nodes relations' do
+          expect do
+            node = Api::V3::Node.first
+            sankey_card_link.update_attributes(
+              link_param: "#{sankey_card_link.link}&nodes_ids=#{node.id}"
+            )
+          end.to change { Api::V3::SankeyCardLinkNode.count }.by(1)
+        end
+
+        it 'removes old nodes relations' do
+          base_link = sankey_card_link.link
+          nodes = Api::V3::Node.all
+          sankey_card_link.update_attributes(
+            link_param: "#{base_link}&nodes_ids=#{nodes.first.id},#{nodes.second.id}"
+          )
+
+          expect do
+            sankey_card_link.update_attributes(
+              link_param: "#{base_link}&nodes_ids=#{nodes.first.id}"
+            )
+          end.to change { Api::V3::SankeyCardLinkNode.count }.by(-1)
         end
       end
     end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -1,20 +1,53 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::SankeyCardLink, type: :model do
+  let(:sankey_card_link) {
+    FactoryBot.build(:api_v3_sankey_card_link)
+  }
+
   describe :validate do
-    let(:sankey_card_link_without_link) {
-      FactoryBot.build(:api_v3_sankey_card_link, link: nil)
+    let(:sankey_card_link_without_host) {
+      FactoryBot.build(:api_v3_sankey_card_link, host: nil)
+    }
+    let(:sankey_card_link_without_query_params) {
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: nil)
     }
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
 
-    it 'fails when link blank' do
-      expect(sankey_card_link_without_link).to have(1).errors_on(:link)
+    it 'fails when host blank' do
+      expect(sankey_card_link_without_host).to have(1).errors_on(:host)
+    end
+
+    it 'fails when query_params blank' do
+      expect(sankey_card_link_without_query_params).to have(1).errors_on(:query_params)
     end
 
     it 'fails when title blank' do
       expect(sankey_card_link_without_title).to have(1).errors_on(:title)
+    end
+  end
+
+  describe :methods do
+    describe '#link' do
+      it 'return complete link' do
+        expect(sankey_card_link.link).to eql(
+          "#{sankey_card_link.host}?#{sankey_card_link.query_params.to_query}"
+        )
+      end
+    end
+  end
+
+  describe :callbacks do
+    describe 'before_save' do
+      describe '#extract_link_params' do
+        it 'extract parameters from link' do
+          sankey_card_link.update_attributes(title: 'test', link_param: 'http://test.com?one=1')
+          expect(sankey_card_link.host).to eql 'test.com'
+          expect(sankey_card_link.query_params).to eql({'one' => '1'})
+        end
+      end
     end
   end
 end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
+    let(:sankey_card_link_with_invalid_query_params) {
+      FactoryBot.build(:api_v3_sankey_card_link, query_params: {one: 1})
+    }
 
     it 'fails when host blank' do
       expect(sankey_card_link_without_host).to have(1).errors_on(:host)
@@ -22,6 +25,10 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
 
     it 'fails when query_params blank' do
       expect(sankey_card_link_without_query_params).to have(1).errors_on(:query_params)
+    end
+
+    it 'fails when query_params include invalid parameters' do
+      expect(sankey_card_link_with_invalid_query_params).to have(1).errors_on(:query_params)
     end
 
     it 'fails when title blank' do
@@ -33,7 +40,7 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     describe '#link' do
       it 'return complete link' do
         expect(sankey_card_link.link).to eql(
-          "#{sankey_card_link.host}?#{sankey_card_link.query_params.to_query}"
+          "http://#{sankey_card_link.host}?#{sankey_card_link.query_params.to_query}"
         )
       end
     end
@@ -43,7 +50,7 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     describe 'before_save' do
       describe '#extract_link_params' do
         it 'extract parameters from link' do
-          sankey_card_link.update_attributes(title: 'test', link_param: 'http://test.com?one=1')
+          sankey_card_link.update_attributes(link_param: 'http://test.com?one=1')
           expect(sankey_card_link.host).to eql 'test.com'
           expect(sankey_card_link.query_params).to eql({'one' => '1'})
         end

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -19,26 +19,12 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     let(:sankey_card_link_without_host) {
       FactoryBot.build(:api_v3_sankey_card_link, host: nil)
     }
-    let(:sankey_card_link_without_query_params) {
-      FactoryBot.build(:api_v3_sankey_card_link, query_params: nil, link_param: 'http://test.com')
-    }
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
-    }
-    let(:sankey_card_link_with_invalid_query_params) {
-      FactoryBot.build(:api_v3_sankey_card_link, link_param: 'http://test.com?one=1')
     }
 
     it 'fails when host blank' do
       expect(sankey_card_link_without_host).to have(1).errors_on(:host)
-    end
-
-    it 'fails when query_params blank' do
-      expect(sankey_card_link_without_query_params).to have(1).errors_on(:query_params)
-    end
-
-    it 'fails when query_params include invalid parameters' do
-      expect(sankey_card_link_with_invalid_query_params).to have(1).errors_on(:link_param)
     end
 
     it 'fails when title blank' do

--- a/spec/models/api/v3/sankey_card_link_spec.rb
+++ b/spec/models/api/v3/sankey_card_link_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
     let(:sankey_card_link_without_title) {
       FactoryBot.build(:api_v3_sankey_card_link, title: nil)
     }
+    let(:sankey_card_link_without_level) {
+      FactoryBot.build(:api_v3_sankey_card_link, level: nil)
+    }
 
     it 'fails when host blank' do
       expect(sankey_card_link_without_host).to have(1).errors_on(:host)
@@ -29,6 +32,15 @@ RSpec.describe Api::V3::SankeyCardLink, type: :model do
 
     it 'fails when title blank' do
       expect(sankey_card_link_without_title).to have(1).errors_on(:title)
+    end
+
+    [1, 2, 3].each do |n|
+      it "fails when there is more than #{Api::V3::SankeyCardLink::MAX_PER_LEVEL} for level #{n}" do
+        FactoryBot.create_list(:api_v3_sankey_card_link, 4, level: n)
+
+        sankey_card_link = FactoryBot.build(:api_v3_sankey_card_link, level: n)
+        expect(sankey_card_link).to have(1).errors_on(:level)
+      end
     end
   end
 

--- a/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
+++ b/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
@@ -14,21 +14,21 @@ RSpec.describe Api::V3::SankeyCardLinks::ResponseBuilder do
 
   describe :sankey_card_links do
     before do
-      @node_type_id = api_v3_brazil_beef_port_of_export_context_node_type.
-        node_type_id
-      @sankey_card_link = FactoryBot.create :api_v3_sankey_card_link, level: 1,query_params: {
+      @node_type = api_v3_brazil_beef_port_of_export_context_node_type.
+        node_type
+      @sankey_card_link = FactoryBot.create :api_v3_sankey_card_link, level1: true, query_params: {
         'selectedCommodityId' => api_v3_beef.id,
         'selectedCountryId' => api_v3_brazil.id,
         'selectedResizeBy' => api_v3_volume.readonly_attribute.id,
         'selectedRecolorBy' => api_v3_biome.readonly_attribute.id,
         'selectedYears' => [2015, 2017],
         'selectedBiomeFilterName' => api_v3_biome_node.name,
-        'selectedColumnsIds' => "1_#{@node_type_id}",
+        'selectedColumnsIds' => "1_#{@node_type.id}",
         'selectedNodesIds' => [api_v3_brazil_beef_country_of_production_node.id,
                                api_v3_country_of_destination_node.id]
       }
 
-      @builder = Api::V3::SankeyCardLinks::ResponseBuilder.new(level: 1)
+      @builder = Api::V3::SankeyCardLinks::ResponseBuilder.new(level: '1')
       @builder.call
     end
 
@@ -46,15 +46,15 @@ RSpec.describe Api::V3::SankeyCardLinks::ResponseBuilder do
         api_v3_brazil_beef_country_of_production_node.id,
         api_v3_country_of_destination_node.id
       ])
-      expect(nodes.map { |n| n[:node_type] }).to eql([
-        api_v3_brazil_beef_country_of_production_node.node_type.name,
-        api_v3_country_of_destination_node.node_type.name
+      expect(nodes.map { |n| n[:node_type_id] }).to eql([
+        api_v3_brazil_beef_country_of_production_node.node_type_id,
+        api_v3_country_of_destination_node.node_type_id
       ])
 
-      column = @builder.meta[:columns].find { |c| c[:column_group] == 1 }
-      pp column
-      pp @node_type_id
-      expect(column[:node_type_id]).to eq(@node_type_id)
+      column = @builder.meta[:columns].
+        find { |_ntid, c| c[:column_group] == 1 }.last
+      expect(column[:node_type_id]).to eq(@node_type.id)
+      expect(column[:node_type]).to eq(@node_type.name)
     end
   end
 end

--- a/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
+++ b/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe Api::V3::SankeyCardLinks::ResponseBuilder do
         api_v3_country_of_destination_node.node_type.name
       ])
 
-      column = @builder.meta[:columns].select { |c| c[:column_group] == 1 }.first
+      column = @builder.meta[:columns].find { |c| c[:column_group] == 1 }
+      pp column
+      pp @node_type_id
       expect(column[:node_type_id]).to eq(@node_type_id)
     end
   end

--- a/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
+++ b/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
@@ -36,8 +36,12 @@ RSpec.describe Api::V3::SankeyCardLinks::ResponseBuilder do
       data = @builder.data.first
       expect(data[:id]).to eq(@sankey_card_link.id)
       expect(data[:host]).to eq(@sankey_card_link.host)
-      expect(data[:query_params]).to eq(@sankey_card_link.query_params)
-      expect(data[:link]).to eq(@sankey_card_link.link)
+      %w[selectedCountryId selectedCommodityId selectedRecolorBy
+         selectedResizeBy selectedBiomeFilterName selectedYears].each do |attribute|
+        expect(data[:query_params][attribute]).to eq(
+          @sankey_card_link.query_params[attribute]
+        )
+      end
     end
 
     it 'should return meta' do

--- a/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
+++ b/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::SankeyCardLinks::ResponseBuilder do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil beef nodes'
+  include_context 'api v3 brazil flows quals'
+  include_context 'api v3 brazil resize by attributes'
+  include_context 'api v3 brazil beef context node types'
+
+  before do
+    Api::V3::Readonly::Node.refresh(sync: true)
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+  end
+
+  describe :sankey_card_links do
+    before do
+      @node_type_id = api_v3_brazil_beef_port_of_export_context_node_type.
+        node_type_id
+      @sankey_card_link = FactoryBot.create :api_v3_sankey_card_link, level: 1,query_params: {
+        'selectedCommodityId' => api_v3_beef.id,
+        'selectedCountryId' => api_v3_brazil.id,
+        'selectedResizeBy' => api_v3_volume.readonly_attribute.id,
+        'selectedRecolorBy' => api_v3_biome.readonly_attribute.id,
+        'selectedYears' => [2015, 2017],
+        'selectedBiomeFilterName' => api_v3_biome_node.name,
+        'selectedColumnsIds' => "1_#{@node_type_id}",
+        'selectedNodesIds' => [api_v3_brazil_beef_country_of_production_node.id,
+                               api_v3_country_of_destination_node.id]
+      }
+
+      @builder = Api::V3::SankeyCardLinks::ResponseBuilder.new(level: 1)
+      @builder.call
+    end
+
+    it 'should return data' do
+      data = @builder.data.first
+      expect(data[:id]).to eq(@sankey_card_link.id)
+      expect(data[:host]).to eq(@sankey_card_link.host)
+      expect(data[:query_params]).to eq(@sankey_card_link.query_params)
+      expect(data[:link]).to eq(@sankey_card_link.link)
+    end
+
+    it 'should return meta' do
+      nodes = @builder.meta[:nodes]
+      expect(nodes.map { |n| n[:id] }).to eql([
+        api_v3_brazil_beef_country_of_production_node.id,
+        api_v3_country_of_destination_node.id
+      ])
+      expect(nodes.map { |n| n[:node_type] }).to eql([
+        api_v3_brazil_beef_country_of_production_node.node_type.name,
+        api_v3_country_of_destination_node.node_type.name
+      ])
+
+      column = @builder.meta[:columns].select { |c| c[:column_group] == 1 }.first
+      expect(column[:node_type_id]).to eq(@node_type_id)
+    end
+  end
+end

--- a/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
+++ b/spec/services/api/v3/sankey_card_links/response_builder_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Api::V3::SankeyCardLinks::ResponseBuilder do
       expect(data[:host]).to eq(@sankey_card_link.host)
       %w[selectedCountryId selectedCommodityId selectedRecolorBy
          selectedResizeBy selectedBiomeFilterName selectedYears].each do |attribute|
-        expect(data[:query_params][attribute]).to eq(
+        expect(data[:queryParams][attribute]).to eq(
           @sankey_card_link.query_params[attribute]
         )
       end
@@ -50,15 +50,15 @@ RSpec.describe Api::V3::SankeyCardLinks::ResponseBuilder do
         api_v3_brazil_beef_country_of_production_node.id,
         api_v3_country_of_destination_node.id
       ])
-      expect(nodes.map { |n| n[:node_type_id] }).to eql([
+      expect(nodes.map { |n| n[:nodeTypeId] }).to eql([
         api_v3_brazil_beef_country_of_production_node.node_type_id,
         api_v3_country_of_destination_node.node_type_id
       ])
 
       column = @builder.meta[:columns].
-        find { |_ntid, c| c[:column_group] == 1 }.last
-      expect(column[:node_type_id]).to eq(@node_type.id)
-      expect(column[:node_type]).to eq(@node_type.name)
+        find { |_ntid, c| c[:columnGroup] == 1 }.last
+      expect(column[:nodeTypeId]).to eq(@node_type.id)
+      expect(column[:nodeType]).to eq(@node_type.name)
     end
   end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_beef_context_node_types.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_beef_context_node_types.rb
@@ -40,7 +40,8 @@ shared_context 'api v3 brazil beef context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 1,
-        role: 'exporter'
+        role: 'exporter',
+        is_default: true
       )
     end
     cnt
@@ -82,7 +83,8 @@ shared_context 'api v3 brazil beef context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 2,
-        role: 'importer'
+        role: 'importer',
+        is_default: true
       )
     end
     cnt
@@ -103,7 +105,8 @@ shared_context 'api v3 brazil beef context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 3,
-        role: 'destination'
+        role: 'destination',
+        is_default: true
       )
     end
     cnt


### PR DESCRIPTION
Sankey card links entity has the `level` field to represent the three levels available through the design. There is a maximum number of sankey card links for each level, so:
- `level = 1` - This level is used when the user has not selected commodity and country. It permits a maximum of 4 Sankey card links.
- `level = 2` - When the user has selected the commodity. It permits a maximum of 4 Sankey card links for each commodity.
- `level = 3` - When the user has selected commodity and country (context). It permits a maximum of 4 Sankey card links for each context.