### PR TITLE
Fix/dashboards issue when filtering by path

### DIFF
--- a/app/models/api/v3/readonly/dashboards/company.rb
+++ b/app/models/api/v3/readonly/dashboards/company.rb
@@ -3,21 +3,19 @@
 # Table name: dashboards_companies_mv
 #
 #  id(id of company node (not unique))                              :integer          primary key
-#  name                                                             :text
-#  name_tsvector                                                    :tsvector
 #  node_type_id                                                     :integer
-#  node_type                                                        :text
-#  profile                                                          :text
 #  country_id(id of country sourcing commodity traded by this node) :integer
 #  commodity_id(id of commodity traded by this node)                :integer
 #  node_id(id of another node from the same supply chain)           :integer
+#  name                                                             :text
+#  name_tsvector                                                    :tsvector
+#  node_type                                                        :text
+#  profile                                                          :text
 #
 # Indexes
 #
 #  dashboards_companies_mv_commodity_id_idx   (commodity_id)
 #  dashboards_companies_mv_country_id_idx     (country_id)
-#  dashboards_companies_mv_group_columns_idx  (id,name,node_type)
-#  dashboards_companies_mv_name_idx           (name)
 #  dashboards_companies_mv_name_tsvector_idx  (name_tsvector) USING gin
 #  dashboards_companies_mv_node_id_idx        (node_id)
 #  dashboards_companies_mv_node_type_id_idx   (node_type_id)

--- a/app/models/api/v3/readonly/dashboards/destination.rb
+++ b/app/models/api/v3/readonly/dashboards/destination.rb
@@ -3,21 +3,19 @@
 # Table name: dashboards_destinations_mv
 #
 #  id(id of destination node (not unique))                         :integer          primary key
-#  name                                                            :text
-#  name_tsvector                                                   :tsvector
 #  node_type_id                                                    :integer
-#  node_type                                                       :text
-#  profile                                                         :text
 #  country_id(id of country sourcing commodity going to this node) :integer
 #  commodity_id(id of commodity going to this node)                :integer
 #  node_id(id of another node from the same supply chain)          :integer
+#  name                                                            :text
+#  name_tsvector                                                   :tsvector
+#  node_type                                                       :text
+#  profile                                                         :text
 #
 # Indexes
 #
 #  dashboards_destinations_mv_commodity_id_idx   (commodity_id)
 #  dashboards_destinations_mv_country_id_idx     (country_id)
-#  dashboards_destinations_mv_group_columns_idx  (id,name,node_type)
-#  dashboards_destinations_mv_name_idx           (name)
 #  dashboards_destinations_mv_name_tsvector_idx  (name_tsvector) USING gin
 #  dashboards_destinations_mv_node_id_idx        (node_id)
 #  dashboards_destinations_mv_node_type_id_idx   (node_type_id)

--- a/app/models/api/v3/readonly/dashboards/source.rb
+++ b/app/models/api/v3/readonly/dashboards/source.rb
@@ -3,20 +3,19 @@
 # Table name: dashboards_sources_mv
 #
 #  id(id of source node (not unique))                                 :integer          primary key
-#  name                                                               :text
-#  name_tsvector                                                      :tsvector
 #  node_type_id                                                       :integer
-#  node_type                                                          :text
-#  profile                                                            :text
 #  country_id(id of country sourcing commodity coming from this node) :integer
 #  commodity_id(id of commodity coming from this node)                :integer
 #  node_id(id of another node from the same supply chain)             :integer
+#  name                                                               :text
+#  name_tsvector                                                      :tsvector
+#  node_type                                                          :text
+#  profile                                                            :text
 #
 # Indexes
 #
 #  dashboards_sources_mv_commodity_id_idx   (commodity_id)
 #  dashboards_sources_mv_country_id_idx     (country_id)
-#  dashboards_sources_mv_name_idx           (name)
 #  dashboards_sources_mv_name_tsvector_idx  (name_tsvector) USING gin
 #  dashboards_sources_mv_node_id_idx        (node_id)
 #  dashboards_sources_mv_node_type_id_idx   (node_type_id)

--- a/app/services/api/v3/dashboards/filter_companies.rb
+++ b/app/services/api/v3/dashboards/filter_companies.rb
@@ -6,66 +6,58 @@ module Api
 
         def initialize(params)
           @self_ids = params.delete(:companies_ids)
+          @nodes_to_filter_by = Api::V3::Dashboards::NodesToFilterBy.new(params)
           super(params)
         end
 
-        def call
-          return @query if @node_ids.none?
-
-          @query = Api::V3::Readonly::Dashboards::Company.
-            select(
-              'companies.id',
-              'companies.name',
-              'companies.node_type',
-              'companies.node_type_id',
-              'companies.country_id',
-              'companies.profile',
-              'companies.commodity_id'
-            ).
-            from("(#{@query.to_sql}) AS companies").
-            joins('INNER JOIN contexts ON contexts.country_id = companies.country_id AND
-                                          contexts.commodity_id = companies.commodity_id').
-            joins("INNER JOIN flows ON flows.context_id = contexts.id AND
-                                       flows.path @> ARRAY[#{@node_ids.join(', ')}, companies.id]").
-            group(
-              'companies.id',
-              'companies.name',
-              'companies.node_type',
-              'companies.node_type_id',
-              'companies.country_id',
-              'companies.profile',
-              'companies.commodity_id'
-            )
+        def call_with_query_term(query_term)
+          super(query_term, {include_country_id: true})
         end
 
         private
 
         def initialize_query
+          # to find all the matching paths, we need to look at node types
+          # of the nodes we're filtering by
+          # and for each node type we check that the path matches at least
+          # one selected node
+          # e.g. if someone selected 3 municipalities and 3 destinations
+          # we look for flows where path matches ANY of the 3 municipalities
+          # AND ANY of the 3 destinatons
+          # no path can match more than pone node id of a given node type
+          path_conditions = @nodes_to_filter_by.node_types_ids.map do |node_type_id|
+            nodes = @nodes_to_filter_by.nodes_by_node_type_id(node_type_id)
+            "flows.path && ARRAY[#{nodes.map(&:id).join(', ')}]"
+          end.join(' AND ')
+
+          # get a list of all matching nodes without checking role / position
+          # because that's more complicated and identical performance-wise
+          # also, ignore the context here - that's going to be filtered out
+          # by the countries / commodities ids (I hope)
+          nodes_on_matching_paths = Api::V3::Flow.
+            select('UNNEST(path) AS node_id').
+            where(path_conditions).
+            distinct
+
           @query = Api::V3::Readonly::Dashboards::Company.
+            joins(
+              "JOIN (#{nodes_on_matching_paths.to_sql}) s ON s.node_id = dashboards_companies_mv.id"
+            ).
             select(
               :id,
               :name,
               :node_type,
               :node_type_id,
-              :country_id,
-              :profile,
-              :commodity_id
+              :country_id
             ).
             group(
               :id,
               :name,
               :node_type,
               :node_type_id,
-              :country_id,
-              :profile,
-              :commodity_id
+              :country_id
             ).
             order(:name)
-
-          return if @node_ids.none?
-
-          @query = @query.
-            having("COUNT(DISTINCT dashboards_companies_mv.node_id) = #{@node_ids.size}")
         end
       end
     end

--- a/app/services/api/v3/dashboards/nodes_to_filter_by.rb
+++ b/app/services/api/v3/dashboards/nodes_to_filter_by.rb
@@ -1,0 +1,66 @@
+module Api
+  module V3
+    module Dashboards
+      class NodesToFilterBy
+        WHITELISTED_KEYS = [
+          :sources_ids,
+          :companies_ids,
+          :exporters_ids,
+          :importers_ids,
+          :destinations_ids
+        ].freeze
+
+        attr_reader :keys, :node_types_ids, :nodes
+
+        # @param node_filters [Hash]
+        # @option node_filters [Array<Integer>] sources_ids
+        # @option node_filters [Array<Integer>] companies_ids
+        # @option node_filters [Array<Integer>] exporters_ids
+        # @option node_filters [Array<Integer>] importers_ids
+        # @option node_filters [Array<Integer>] destinations_ids
+        def initialize(node_filters)
+          @keys = node_filters.compact.keys & WHITELISTED_KEYS
+          @node_filters = node_filters.slice(*@keys)
+
+          initialize_nodes
+          initialize_nodes_by_key
+          initialize_nodes_by_node_type_id
+        end
+
+        def nodes_by_key(key)
+          @nodes_by_key[key]
+        end
+
+        def nodes_by_node_type_id(node_type_id)
+          @nodes_by_node_type_id[node_type_id]
+        end
+
+        private
+
+        def initialize_nodes
+          nodes_ids = []
+          @keys.each do |key|
+            nodes_ids += @node_filters[key]
+          end
+          @nodes = Api::V3::Node.find(nodes_ids)
+        end
+
+        def initialize_nodes_by_key
+          @nodes_by_key = Hash[
+            @keys.map do |key|
+              [
+                key,
+                @nodes.select { |node| @node_filters[key].include?(node.id) }
+              ]
+            end
+          ]
+        end
+
+        def initialize_nodes_by_node_type_id
+          @nodes_by_node_type_id = @nodes.group_by(&:node_type_id)
+          @node_types_ids = @nodes.map(&:node_type_id).uniq
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20191002200900_reorder_columns_in_dashboards_nodes_mviews.rb
+++ b/db/migrate/20191002200900_reorder_columns_in_dashboards_nodes_mviews.rb
@@ -1,0 +1,60 @@
+class ReorderColumnsInDashboardsNodesMviews < ActiveRecord::Migration[5.2]
+  def up
+    # drop unnecessary indexes
+    remove_index :dashboards_sources_mv,
+                 column: [:name]
+    remove_index :dashboards_companies_mv,
+                 column: [:name]
+    remove_index :dashboards_destinations_mv,
+                 column: [:name]
+    remove_index :dashboards_companies_mv,
+               column: [:id, :name, :node_type]
+    remove_index :dashboards_destinations_mv,
+               column: [:id, :name, :node_type]
+
+    # reorder columns to reduce padding
+    update_view :dashboards_sources_mv,
+      version: 8,
+      revert_to_version: 7,
+      materialized: true
+    update_view :dashboards_companies_mv,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+    update_view :dashboards_destinations_mv,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+  end
+
+  def down
+    update_view :dashboards_sources_mv,
+      version: 7,
+      revert_to_version: 6,
+      materialized: true
+    update_view :dashboards_companies_mv,
+      version: 6,
+      revert_to_version: 5,
+      materialized: true
+    update_view :dashboards_destinations_mv,
+      version: 6,
+      revert_to_version: 5,
+      materialized: true
+
+    add_index :dashboards_sources_mv,
+      :name,
+      name: 'dashboards_sources_mv_name_idx'
+    add_index :dashboards_companies_mv,
+      :name,
+      name: 'dashboards_companies_mv_name_idx'
+    add_index :dashboards_destinations_mv,
+      :name,
+      name: 'dashboards_destinations_mv_name_idx'
+    add_index :dashboards_companies_mv,
+      [:id, :name, :node_type],
+      name: 'dashboards_companies_mv_group_columns_idx'
+    add_index :dashboards_destinations_mv,
+      [:id, :name, :node_type],
+      name: 'dashboards_destinations_mv_group_columns_idx'
+  end
+end

--- a/db/views/dashboards_companies_mv_v07.sql
+++ b/db/views/dashboards_companies_mv_v07.sql
@@ -1,0 +1,74 @@
+WITH active_cnt AS (
+  SELECT context_id, column_position, cnt_props.role, profiles.name AS profile
+  FROM context_node_types cnt
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  WHERE cnt_props.role IS NOT NULL
+), flow_nodes AS (
+  SELECT
+    flow_nodes.context_id,
+    flow_id,
+    node_id,
+    position
+  FROM (
+    SELECT
+      context_id,
+      flow_id,
+      node_id,
+      position
+    FROM flow_nodes_mv
+  ) flow_nodes
+  JOIN active_cnt ON flow_nodes.context_id = active_cnt.context_id
+    AND flow_nodes.position = active_cnt.column_position + 1
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    nodes.node_type_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    TRIM(nodes.name) AS name,
+    TO_TSVECTOR('simple', COALESCE(TRIM(nodes.name)::TEXT, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    CASE
+      -- this is the same condition as in nodes_mv
+      WHEN nodes.is_unknown = FALSE AND node_properties.is_domestic_consumption = FALSE AND nodes.name NOT ILIKE 'OTHER'
+      THEN cnt.profile
+      ELSE NULL
+    END AS profile
+  FROM flow_nodes
+  JOIN nodes ON nodes.id = flow_nodes.node_id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN node_types ON node_types.id = nodes.node_type_id
+  JOIN active_cnt cnt ON cnt.context_id = flow_nodes.context_id
+    AND cnt.column_position + 1 = flow_nodes.position
+  JOIN contexts ON contexts.id = flow_nodes.context_id AND contexts.id = cnt.context_id
+  WHERE cnt.role IN ('exporter', 'importer')
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+FROM filtered_flow_nodes ffn
+JOIN flow_nodes fn
+ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+);

--- a/db/views/dashboards_destinations_mv_v07.sql
+++ b/db/views/dashboards_destinations_mv_v07.sql
@@ -1,0 +1,74 @@
+WITH active_cnt AS (
+  SELECT context_id, column_position, cnt_props.role, profiles.name AS profile
+  FROM context_node_types cnt
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  WHERE cnt_props.role IS NOT NULL
+), flow_nodes AS (
+  SELECT
+    flow_nodes.context_id,
+    flow_id,
+    node_id,
+    position
+  FROM (
+    SELECT
+      context_id,
+      flow_id,
+      node_id,
+      position
+    FROM flow_nodes_mv
+  ) flow_nodes
+  JOIN active_cnt ON flow_nodes.context_id = active_cnt.context_id
+    AND flow_nodes.position = active_cnt.column_position + 1
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    nodes.node_type_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    TRIM(nodes.name) AS name,
+    TO_TSVECTOR('simple', COALESCE(TRIM(nodes.name)::TEXT, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    CASE
+      -- this is the same condition as in nodes_mv
+      WHEN nodes.is_unknown = FALSE AND node_properties.is_domestic_consumption = FALSE AND nodes.name NOT ILIKE 'OTHER'
+      THEN cnt.profile
+      ELSE NULL
+    END AS profile
+  FROM flow_nodes
+  JOIN nodes ON nodes.id = flow_nodes.node_id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN node_types ON node_types.id = nodes.node_type_id
+  JOIN active_cnt cnt ON cnt.context_id = flow_nodes.context_id
+    AND cnt.column_position + 1 = flow_nodes.position
+  JOIN contexts ON contexts.id = flow_nodes.context_id AND contexts.id = cnt.context_id
+  WHERE cnt.role = 'destination'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+FROM filtered_flow_nodes ffn
+JOIN flow_nodes fn
+ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+);

--- a/db/views/dashboards_sources_mv_v08.sql
+++ b/db/views/dashboards_sources_mv_v08.sql
@@ -1,0 +1,74 @@
+WITH active_cnt AS (
+  SELECT context_id, column_position, cnt_props.role, profiles.name AS profile
+  FROM context_node_types cnt
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  WHERE cnt_props.role IS NOT NULL
+), flow_nodes AS (
+  SELECT
+    flow_nodes.context_id,
+    flow_id,
+    node_id,
+    position
+  FROM (
+    SELECT
+      context_id,
+      flow_id,
+      node_id,
+      position
+    FROM flow_nodes_mv
+  ) flow_nodes
+  JOIN active_cnt ON flow_nodes.context_id = active_cnt.context_id
+    AND flow_nodes.position = active_cnt.column_position + 1
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    nodes.node_type_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    TRIM(nodes.name) AS name,
+    TO_TSVECTOR('simple', COALESCE(TRIM(nodes.name)::TEXT, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    CASE
+      -- this is the same condition as in nodes_mv
+      WHEN nodes.is_unknown = FALSE AND node_properties.is_domestic_consumption = FALSE AND nodes.name NOT ILIKE 'OTHER'
+      THEN cnt.profile
+      ELSE NULL
+    END AS profile
+  FROM flow_nodes
+  JOIN nodes ON nodes.id = flow_nodes.node_id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN node_types ON node_types.id = nodes.node_type_id
+  JOIN active_cnt cnt ON cnt.context_id = flow_nodes.context_id
+    AND cnt.column_position + 1 = flow_nodes.position
+  JOIN contexts ON contexts.id = flow_nodes.context_id AND contexts.id = cnt.context_id
+  WHERE cnt.role = 'source'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+FROM filtered_flow_nodes ffn
+JOIN flow_nodes fn
+ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+);

--- a/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
@@ -68,6 +68,44 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
           [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
         )
       end
+
+      it 'returns companies exporting to country' do
+        get :index, params: {
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id
+          ].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+        )
+      end
+
+      it 'returns companies exporting to country from source' do
+        get :index, params: {
+          sources_ids: [api_v3_municipality2_node.id].join(','),
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id
+          ].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id]
+        )
+      end
+
+      it 'returns companies exporting to either country' do
+        get :index, params: {
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id,
+            api_v3_other_country_of_destination_node.id
+          ].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+        )
+      end
     end
 
     let(:per_page) { 1 }

--- a/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe Api::V3::Dashboards::SourcesController, type: :controller do
       [
         api_v3_biome_node,
         api_v3_state_node,
-        api_v3_municipality_node
+        api_v3_municipality_node,
+        api_v3_municipality2_node
       ]
     }
 

--- a/spec/support/contexts/api/v3/brazil/brazil_flows.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows.rb
@@ -92,4 +92,23 @@ shared_context 'api v3 brazil flows' do
       year: 2015
     )
   end
+
+  # other municipality
+  let!(:api_v3_flow6) do
+    FactoryBot.create(
+      :api_v3_flow,
+      context: api_v3_context,
+      path: [
+        api_v3_biome_node,
+        api_v3_state_node,
+        api_v3_municipality2_node,
+        api_v3_logistics_hub_node,
+        api_v3_port1_node,
+        api_v3_exporter1_node,
+        api_v3_importer1_node,
+        api_v3_country_of_destination1_node
+      ].map(&:id),
+      year: 2015
+    )
+  end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
@@ -60,6 +60,25 @@ shared_context 'api v3 brazil soy nodes' do
     node
   end
 
+  let!(:api_v3_municipality2_node) do
+    node = Api::V3::Node.where(
+      name: 'SORRISO', node_type_id: api_v3_municipality_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node,
+        name: 'SORRISO',
+        node_type: api_v3_municipality_node_type,
+        geo_id: 'BR-5107925'
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
+  end
+
   let!(:api_v3_other_municipality_node) do
     node = Api::V3::Node.where(
       name: 'OTHER', node_type_id: api_v3_municipality_node_type.id


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/168506779

To reproduce: go to staging, filter Brazil, soy, Netherlands + China - no companies to select from, but if you follow through to the dashboards you get charts with top exporters

The problem was the condition for the companies query, which is taking into account other selected nodes, so that we get results that go though source X AND destination Y; however, when more than one node of a given node type is selected, we need to adapt so that it is e.g. source X AND (dest Y or dest Z), otherwise we'll be getting no results.

I took the opportunity to cleanup the materialized views a bit, i.e. by reordering the columns and removing unused indexes to save space (and refresh time).