### PR TITLE
Feature/split companies

### DIFF
--- a/app/controllers/api/v3/dashboards/exporters_controller.rb
+++ b/app/controllers/api/v3/dashboards/exporters_controller.rb
@@ -1,10 +1,7 @@
-# @deprecated Use {Api::V3::Dashboards::ExportersController} or
-# {Api::V3::Dashboards::ImportersController} instead.
-# TODO: remove once dashboards_companies_mv retired
 module Api
   module V3
     module Dashboards
-      class CompaniesController < ApiController
+      class ExportersController < ApiController
         include FilterParams
         include PaginationHeaders
         include PaginatedCollection
@@ -30,7 +27,7 @@ module Api
         private
 
         def filter_klass
-          FilterCompanies
+          FilterExporters
         end
       end
     end

--- a/app/controllers/api/v3/dashboards/importers_controller.rb
+++ b/app/controllers/api/v3/dashboards/importers_controller.rb
@@ -1,10 +1,7 @@
-# @deprecated Use {Api::V3::Dashboards::ExportersController} or
-# {Api::V3::Dashboards::ImportersController} instead.
-# TODO: remove once dashboards_companies_mv retired
 module Api
   module V3
     module Dashboards
-      class CompaniesController < ApiController
+      class ImportersController < ApiController
         include FilterParams
         include PaginationHeaders
         include PaginatedCollection
@@ -30,7 +27,7 @@ module Api
         private
 
         def filter_klass
-          FilterCompanies
+          FilterImporters
         end
       end
     end

--- a/app/controllers/concerns/api/v3/dashboards/chart_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/chart_params.rb
@@ -21,10 +21,16 @@ module Api
             cont_attribute_id: string_to_int(params[:cont_attribute_id]),
             ncont_attribute_id: string_to_int(params[:ncont_attribute_id]),
             sources_ids: cs_string_to_int_array(params[:sources_ids]),
+            # TODO: remove once dashboards_companies_mv retired
             companies_ids: cs_string_to_int_array(params[:companies_ids]),
+            exporters_ids: cs_string_to_int_array(params[:exporters_ids]),
+            importers_ids: cs_string_to_int_array(params[:importers_ids]),
             destinations_ids: cs_string_to_int_array(params[:destinations_ids]),
             excluded_sources_ids: cs_string_to_int_array(params[:excluded_sources_ids]),
+            # TODO: remove once dashboards_companies_mv retired
             excluded_companies_ids: cs_string_to_int_array(params[:excluded_companies_ids]),
+            excluded_exporters_ids: cs_string_to_int_array(params[:excluded_exporters_ids]),
+            excluded_importers_ids: cs_string_to_int_array(params[:excluded_importers_ids]),
             excluded_destinations_ids: cs_string_to_int_array(params[:excluded_destinations_ids]),
             node_type_id: string_to_int(params[:node_type_id]),
             top_n: string_to_int(params[:top_n]),

--- a/app/controllers/concerns/api/v3/dashboards/filter_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/filter_params.rb
@@ -12,7 +12,10 @@ module Api
             countries_ids: cs_string_to_int_array(params[:countries_ids]),
             commodities_ids: cs_string_to_int_array(params[:commodities_ids]),
             sources_ids: cs_string_to_int_array(params[:sources_ids]),
+            # TODO: remove once dashboards_companies_mv retired
             companies_ids: cs_string_to_int_array(params[:companies_ids]),
+            exporters_ids: cs_string_to_int_array(params[:exporters_ids]),
+            importers_ids: cs_string_to_int_array(params[:importers_ids]),
             destinations_ids: cs_string_to_int_array(params[:destinations_ids]),
             node_types_ids: cs_string_to_int_array(params[:node_types_ids]),
             profile_only: ActiveModel::Type::Boolean.new.cast(params[:profile_only]),

--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -74,8 +74,16 @@ module Api
         if roles.include?(SOURCE_ROLE)
           Api::V3::Readonly::Dashboards::Source.refresh_later
         end
+        # TODO: remove once dashboards_companies_mv retired
         if (roles & [EXPORTER_ROLE, IMPORTER_ROLE]).any?
           Api::V3::Readonly::Dashboards::Company.refresh_later
+        end
+        # END TODO
+        if roles.include?(EXPORTER_ROLE)
+          Api::V3::Readonly::Dashboards::Exporter.refresh_later
+        end
+        if roles.include?(IMPORTER_ROLE)
+          Api::V3::Readonly::Dashboards::Importer.refresh_later
         end
         if roles.include?(DESTINATION_ROLE)
           Api::V3::Readonly::Dashboards::Destination.refresh_later

--- a/app/models/api/v3/readonly/dashboards/company.rb
+++ b/app/models/api/v3/readonly/dashboards/company.rb
@@ -22,6 +22,9 @@
 #  dashboards_companies_mv_unique_idx         (id,node_id,country_id,commodity_id) UNIQUE
 #
 
+# @deprecated Use {Api::V3::Readonly::Dashboards::Exporter} or
+# {Api::V3::Readonly::Dashboards::Importer} instead.
+# TODO: remove once dashboards_companies_mv retired
 module Api
   module V3
     module Readonly

--- a/app/models/api/v3/readonly/dashboards/exporter.rb
+++ b/app/models/api/v3/readonly/dashboards/exporter.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: dashboards_exporters_mv
+#
+#  id            :integer          primary key
+#  node_type_id  :integer
+#  country_id    :integer
+#  commodity_id  :integer
+#  node_id       :integer
+#  name          :text
+#  name_tsvector :tsvector
+#  node_type     :text
+#  profile       :text
+#
+# Indexes
+#
+#  dashboards_exporters_mv_commodity_id_idx   (commodity_id)
+#  dashboards_exporters_mv_country_id_idx     (country_id)
+#  dashboards_exporters_mv_name_tsvector_idx  (name_tsvector) USING gin
+#  dashboards_exporters_mv_node_id_idx        (node_id)
+#  dashboards_exporters_mv_node_type_id_idx   (node_type_id)
+#  dashboards_exporters_mv_unique_idx         (id,node_id,country_id,commodity_id) UNIQUE
+#
+
+module Api
+  module V3
+    module Readonly
+      module Dashboards
+        class Exporter < Api::V3::Readonly::BaseModel
+          self.table_name = 'dashboards_exporters_mv'
+          belongs_to :node
+        end
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/dashboards/importer.rb
+++ b/app/models/api/v3/readonly/dashboards/importer.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: dashboards_importers_mv
+#
+#  id            :integer          primary key
+#  node_type_id  :integer
+#  country_id    :integer
+#  commodity_id  :integer
+#  node_id       :integer
+#  name          :text
+#  name_tsvector :tsvector
+#  node_type     :text
+#  profile       :text
+#
+# Indexes
+#
+#  dashboards_importers_mv_commodity_id_idx   (commodity_id)
+#  dashboards_importers_mv_country_id_idx     (country_id)
+#  dashboards_importers_mv_name_tsvector_idx  (name_tsvector) USING gin
+#  dashboards_importers_mv_node_id_idx        (node_id)
+#  dashboards_importers_mv_node_type_id_idx   (node_type_id)
+#  dashboards_importers_mv_unique_idx         (id,node_id,country_id,commodity_id) UNIQUE
+#
+
+module Api
+  module V3
+    module Readonly
+      module Dashboards
+        class Importer < Api::V3::Readonly::BaseModel
+          self.table_name = 'dashboards_importers_mv'
+          belongs_to :node
+        end
+      end
+    end
+  end
+end

--- a/app/models/api/v3/readonly/node.rb
+++ b/app/models/api/v3/readonly/node.rb
@@ -27,7 +27,7 @@ module Api
         self.table_name = 'nodes_mv'
         belongs_to :context
 
-        include PgSearch
+        include PgSearch::Model
         pg_search_scope :search_by_name, lambda { |query|
           {
             query: query,

--- a/app/services/api/v3/dashboards/base_filter.rb
+++ b/app/services/api/v3/dashboards/base_filter.rb
@@ -7,13 +7,18 @@ module Api
         # @option params [Array<Integer>] commodities_ids
         # @option params [Array<Integer>] sources_ids
         # @option params [Array<Integer>] companies_ids
+        # @option params [Array<Integer>] exporters_ids
+        # @option params [Array<Integer>] importers_ids
         # @option params [Array<Integer>] destinations_ids
         # @option params [Array<Integer>] node_types_ids
         def initialize(params)
           @countries_ids = params[:countries_ids] || []
           @commodities_ids = params[:commodities_ids] || []
           @node_ids = (params[:sources_ids] || []) +
+            # TODO: remove once dashboards_companies_mv retired
             (params[:companies_ids] || []) +
+            (params[:exporters_ids] || []) +
+            (params[:importers_ids] || []) +
             (params[:destinations_ids] || [])
           @node_types_ids = params[:node_types_ids] || []
           @profile_only = params.delete(:profile_only) || false

--- a/app/services/api/v3/dashboards/chart_parameters/flow_values.rb
+++ b/app/services/api/v3/dashboards/chart_parameters/flow_values.rb
@@ -8,10 +8,16 @@ module Api
                       :start_year,
                       :end_year,
                       :sources_ids,
+                      # TODO: remove once dashboards_companies_mv retired
                       :companies_ids,
+                      :exporters_ids,
+                      :importers_ids,
                       :destinations_ids,
                       :excluded_sources_ids,
+                      # TODO: remove once dashboards_companies_mv retired
                       :excluded_companies_ids,
+                      :excluded_exporters_ids,
+                      :excluded_importers_ids,
                       :excluded_destinations_ids,
                       :node_type,
                       :top_n,
@@ -22,9 +28,13 @@ module Api
           # @option params [Integer] ncont_attribute_id
           # @option params [Array<Integer>] sources_ids
           # @option params [Array<Integer>] companies_ids
+          # @option params [Array<Integer>] exporters_ids
+          # @option params [Array<Integer>] importers_ids
           # @option params [Array<Integer>] destinations_ids
           # @option params [Array<Integer>] excluded_sources_ids,
           # @option params [Array<Integer>] excluded_companies_ids,
+          # @option params [Array<Integer>] excluded_exporters_ids,
+          # @option params [Array<Integer>] excluded_importers_ids,
           # @option params [Array<Integer>] excluded_destinations_ids,
           # @option params [Integer] node_type_id
           # @option params [Integer] top_n
@@ -36,10 +46,16 @@ module Api
             initialize_ncont_attribute params[:ncont_attribute_id]
 
             @sources_ids = params[:sources_ids] || []
+            # TODO: remove once dashboards_companies_mv retired
             @companies_ids = params[:companies_ids] || []
+            @exporters_ids = params[:exporters_ids] || []
+            @importers_ids = params[:importers_ids] || []
             @destinations_ids = params[:destinations_ids] || []
             @excluded_sources_ids = params[:excluded_sources_ids] || []
+            # TODO: remove once dashboards_companies_mv retired
             @excluded_companies_ids = params[:excluded_companies_ids] || []
+            @excluded_exporters_ids = params[:excluded_exporters_ids] || []
+            @excluded_importers_ids = params[:excluded_importers_ids] || []
             @excluded_destinations_ids = params[:excluded_destinations_ids] || []
             initialize_node_type(params[:node_type_id])
 
@@ -57,7 +73,14 @@ module Api
             return @selected_nodes if defined? @selected_nodes
 
             @selected_nodes = Api::V3::Node.where(
-              id: @sources_ids + @companies_ids + @destinations_ids
+              id: (
+                @sources_ids +
+                # TODO: remove once dashboards_companies_mv retired
+                @companies_ids +
+                @exporters_ids +
+                @importers_ids +
+                @destinations_ids
+              )
             ).includes(:node_type)
           end
 
@@ -76,7 +99,10 @@ module Api
             @excluded_nodes = Api::V3::Node.where(
               id: (
                 @excluded_sources_ids +
+                # TODO: remove once dashboards_companies_mv retired
                 @excluded_companies_ids +
+                @excluded_exporters_ids +
+                @excluded_importers_ids +
                 @excluded_destinations_ids
               )
             ).includes(:node_type)

--- a/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view.rb
@@ -117,7 +117,13 @@ module Api
           end
 
           def top_nodes_break_by_values
-            selected_nodes = @chart_parameters.sources_ids + @chart_parameters.companies_ids + @chart_parameters.destinations_ids
+            selected_nodes =
+              @chart_parameters.sources_ids +
+              # TODO: remove once dashboards_companies_mv retired
+              @chart_parameters.companies_ids +
+              @chart_parameters.exporters_ids +
+              @chart_parameters.importers_ids +
+              @chart_parameters.destinations_ids
             selected_node_types = selected_nodes.map { |id| Api::V3::Node.includes(:node_type).find(id).node_type.id }
             is_current_node_type_in_selected_node_types = selected_node_types.include?(@node_type_idx)
             array = is_current_node_type_in_selected_node_types ? [] : [OTHER]

--- a/app/services/api/v3/dashboards/filter_exporters.rb
+++ b/app/services/api/v3/dashboards/filter_exporters.rb
@@ -1,15 +1,12 @@
-# @deprecated Use {Api::V3::Dashboards::FilterImporters} or
-# {Api::V3::Dashboards::FilterExporters} instead.
-# TODO: remove once dashboards_companies_mv retired
 module Api
   module V3
     module Dashboards
-      class FilterCompanies < BaseFilter
+      class FilterExporters < BaseFilter
         include Query
         include CallWithQueryTerm
 
         def initialize(params)
-          @self_ids = params.delete(:companies_ids)
+          @self_ids = params.delete(:exporters_ids)
           @nodes_to_filter_by = Api::V3::Dashboards::NodesToFilterBy.new(params)
           super(params)
         end
@@ -21,7 +18,7 @@ module Api
         private
 
         def filtered_class
-          Api::V3::Readonly::Dashboards::Company
+          Api::V3::Readonly::Dashboards::Exporter
         end
       end
     end

--- a/app/services/api/v3/dashboards/filter_importers.rb
+++ b/app/services/api/v3/dashboards/filter_importers.rb
@@ -1,15 +1,12 @@
-# @deprecated Use {Api::V3::Dashboards::FilterImporters} or
-# {Api::V3::Dashboards::FilterExporters} instead.
-# TODO: remove once dashboards_companies_mv retired
 module Api
   module V3
     module Dashboards
-      class FilterCompanies < BaseFilter
+      class FilterImporters < BaseFilter
         include Query
         include CallWithQueryTerm
 
         def initialize(params)
-          @self_ids = params.delete(:companies_ids)
+          @self_ids = params.delete(:importers_ids)
           @nodes_to_filter_by = Api::V3::Dashboards::NodesToFilterBy.new(params)
           super(params)
         end
@@ -21,7 +18,7 @@ module Api
         private
 
         def filtered_class
-          Api::V3::Readonly::Dashboards::Company
+          Api::V3::Readonly::Dashboards::Importer
         end
       end
     end

--- a/app/services/api/v3/dashboards/filter_meta.rb
+++ b/app/services/api/v3/dashboards/filter_meta.rb
@@ -31,6 +31,22 @@ module Api
                 ).all
               },
               {
+                section: 'EXPORTERS',
+                tabs: @query.where(
+                  'context_node_type_properties.role' => [
+                    ContextNodeTypeProperty::EXPORTER_ROLE
+                  ]
+                ).all
+              },
+              {
+                section: 'IMPORTERS',
+                tabs: @query.where(
+                  'context_node_type_properties.role' => [
+                    ContextNodeTypeProperty::IMPORTER_ROLE
+                  ]
+                ).all
+              },
+              {
                 section: 'DESTINATIONS',
                 tabs: @query.where(
                   'context_node_type_properties.role' =>

--- a/app/services/api/v3/dashboards/parametrised_charts/flow_values_charts.rb
+++ b/app/services/api/v3/dashboards/parametrised_charts/flow_values_charts.rb
@@ -39,13 +39,23 @@ module Api
 
           def initialize_nodes
             @sources_ids = @chart_params.sources_ids
+            # TODO: remove once dashboards_companies_mv retired
             @companies_ids = @chart_params.companies_ids
+            @exporters_ids = @chart_params.exporters_ids
+            @importers_ids = @chart_params.importers_ids
             @destinations_ids = @chart_params.destinations_ids
             @sources = nodes.select do |node|
               @sources_ids.include? node.id
             end
+            # TODO: remove once dashboards_companies_mv retired
             @companies = nodes.select do |node|
               @companies_ids.include? node.id
+            end
+            @exporters = nodes.select do |node|
+              @exporters_ids.include? node.id
+            end
+            @importers = nodes.select do |node|
+              @importers_ids.include? node.id
             end
             @destinations = nodes.select do |node|
               @destinations_ids.include? node.id
@@ -56,7 +66,12 @@ module Api
             return @nodes if defined?(@nodes)
 
             @nodes = Api::V3::Node.find(
-              @sources_ids + @companies_ids + @destinations_ids
+              @sources_ids +
+              # TODO: remove once dashboards_companies_mv retired
+              @companies_ids +
+              @exporters_ids +
+              @importers_ids +
+              @destinations_ids
             )
           end
 
@@ -178,7 +193,10 @@ module Api
 
             [
               [:sources_ids, @sources],
+              # TODO: remove once dashboards_companies_mv retired
               [:companies_ids, @companies],
+              [:exporters_ids, @exporters],
+              [:importers_ids, @importers],
               [:destinations_ids, @destinations]
             ].each do |nodes_ids_param_name, nodes|
               parametrised_charts += charts_per_selected_node(
@@ -245,10 +263,16 @@ module Api
               country_id: @chart_params.country_id,
               commodity_id: @chart_params.commodity_id,
               sources_ids: @sources_ids.join(','),
+              # TODO: remove once dashboards_companies_mv retired
               companies_ids: @companies_ids.join(','),
+              exporters_ids: @exporters_ids.join(','),
+              importers_ids: @importers_ids.join(','),
               destinations_ids: @destinations_ids.join(','),
               excluded_sources_ids: @chart_params.excluded_sources_ids.join(','),
+              # TODO: remove once dashboards_companies_mv retired
               excluded_companies_ids: @chart_params.excluded_companies_ids.join(','),
+              excluded_exporters_ids: @chart_params.excluded_exporters_ids.join(','),
+              excluded_importers_ids: @chart_params.excluded_importers_ids.join(','),
               excluded_destinations_ids: @chart_params.excluded_destinations_ids.join(','),
               start_year: @start_year,
               end_year: @end_year

--- a/app/services/api/v3/dashboards/parametrised_charts/node_values_charts.rb
+++ b/app/services/api/v3/dashboards/parametrised_charts/node_values_charts.rb
@@ -27,7 +27,10 @@ module Api
 
           def initialize_nodes
             @sources_ids = @chart_params.sources_ids
+            # TODO: remove once dashboards_companies_mv retired
             @companies_ids = @chart_params.companies_ids
+            @exporters_ids = @chart_params.exporters_ids
+            @importers_ids = @chart_params.importers_ids
             @destinations_ids = @chart_params.destinations_ids
             nodes = Api::V3::Node.find(
               @sources_ids + @companies_ids + @destinations_ids
@@ -35,8 +38,15 @@ module Api
             @sources = nodes.select do |node|
               @sources_ids.include? node.id
             end
+            # TODO: remove once dashboards_companies_mv retired
             @companies = nodes.select do |node|
               @companies_ids.include? node.id
+            end
+            @exporters = nodes.select do |node|
+              @exporters_ids.include? node.id
+            end
+            @importers = nodes.select do |node|
+              @importers_ids.include? node.id
             end
             @destinations = nodes.select do |node|
               @destinations_ids.include? node.id
@@ -128,7 +138,13 @@ module Api
           end
 
           def matching_nodes(attribute_node_types_ids)
-            nodes = @sources + @companies + @destinations
+            nodes =
+              @sources +
+              # TODO: remove once dashboards_companies_mv retired
+              @companies +
+              @exporters +
+              @importers +
+              @destinations
             nodes.select do |node|
               attribute_node_types_ids.include? node.node_type_id
             end

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -124,7 +124,10 @@ module Api
             Api::V3::Readonly::Dashboards::Commodity,
             Api::V3::Readonly::Dashboards::Country,
             Api::V3::Readonly::Dashboards::Source,
+            # TODO: remove once dashboards_companies_mv retired
             Api::V3::Readonly::Dashboards::Company,
+            Api::V3::Readonly::Dashboards::Exporter,
+            Api::V3::Readonly::Dashboards::Importer,
             Api::V3::Readonly::Dashboards::Destination,
             Api::V3::Readonly::ContextAttributeProperty,
             Api::V3::Readonly::CountryAttributeProperty,

--- a/app/services/concerns/api/v3/dashboards/query.rb
+++ b/app/services/concerns/api/v3/dashboards/query.rb
@@ -1,0 +1,60 @@
+module Api
+  module V3
+    module Dashboards
+      module Query
+        private
+
+        def nodes_on_matching_paths_subquery
+          # to find all the matching paths, we need to look at node types
+          # of the nodes we're filtering by
+          # and for each node type we check that the path matches at least
+          # one selected node
+          # e.g. if someone selected 3 municipalities and 3 destinations
+          # we look for flows where path matches ANY of the 3 municipalities
+          # AND ANY of the 3 destinatons
+          # no path can match more than pone node id of a given node type
+          path_conditions = @nodes_to_filter_by.node_types_ids.map do |node_type_id|
+            nodes = @nodes_to_filter_by.nodes_by_node_type_id(node_type_id)
+            "flows.path && ARRAY[#{nodes.map(&:id).join(', ')}]"
+          end.join(' AND ')
+
+          # get a list of all matching nodes without checking role / position
+          # because that's more complicated and identical performance-wise
+          # also, ignore the context here - that's going to be filtered out
+          # by the countries / commodities ids (I hope)
+          Api::V3::Flow.
+            select('UNNEST(path) AS node_id').
+            where(path_conditions).
+            distinct
+        end
+
+        def filtered_table_name
+          filtered_class.table_name
+        end
+
+        def initialize_query
+          @query = filtered_class.
+            joins(
+              "JOIN (#{nodes_on_matching_paths_subquery.to_sql}) s
+                ON s.node_id = #{filtered_table_name}.id"
+            ).
+            select(
+              :id,
+              :name,
+              :node_type,
+              :node_type_id,
+              :country_id
+            ).
+            group(
+              :id,
+              :name,
+              :node_type,
+              :node_type_id,
+              :country_id
+            ).
+            order(:name)
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,7 +72,14 @@ Rails.application.routes.draw do
         resources :sources, only: [:index] do
           get :search, on: :collection
         end
+        # TODO: remove once dashboards_companies_mv retired
         resources :companies, only: [:index] do
+          get :search, on: :collection
+        end
+        resources :exporters, only: [:index] do
+          get :search, on: :collection
+        end
+        resources :importers, only: [:index] do
           get :search, on: :collection
         end
         resources :destinations, only: [:index] do

--- a/db/migrate/20191002201000_split_dashboards_companies_mview.rb
+++ b/db/migrate/20191002201000_split_dashboards_companies_mview.rb
@@ -1,0 +1,64 @@
+class SplitDashboardsCompaniesMview < ActiveRecord::Migration[5.2]
+  def up
+    create_view :dashboards_exporters_mv,
+      version: 1,
+      materialized: true
+    add_index :dashboards_exporters_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_exporters_mv_unique_idx'
+    add_index :dashboards_exporters_mv,
+      :context_id,
+      name: 'dashboards_exporters_mv_context_id_idx'
+    add_index :dashboards_exporters_mv,
+      :commodity_id,
+      name: 'dashboards_exporters_mv_commodity_id_idx'
+    add_index :dashboards_exporters_mv,
+      :country_id,
+      name: 'dashboards_exporters_mv_country_id_idx'
+    add_index :dashboards_exporters_mv,
+      :node_id,
+      name: 'dashboards_exporters_mv_node_id_idx'
+    add_index :dashboards_exporters_mv,
+      :node_type_id,
+      name: 'dashboards_exporters_mv_node_type_id_idx'
+    add_index :dashboards_exporters_mv,
+      :name_tsvector,
+      name: 'dashboards_exporters_mv_name_tsvector_idx',
+      using: :gin
+
+    create_view :dashboards_importers_mv,
+      version: 1,
+      materialized: true
+    add_index :dashboards_importers_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_importers_mv_unique_idx'
+    add_index :dashboards_importers_mv,
+      :context_id,
+      name: 'dashboards_importers_mv_context_id_idx'
+    add_index :dashboards_importers_mv,
+      :commodity_id,
+      name: 'dashboards_importers_mv_commodity_id_idx'
+    add_index :dashboards_importers_mv,
+      :country_id,
+      name: 'dashboards_importers_mv_country_id_idx'
+    add_index :dashboards_importers_mv,
+      :node_id,
+      name: 'dashboards_importers_mv_node_id_idx'
+    add_index :dashboards_importers_mv,
+      :node_type_id,
+      name: 'dashboards_importers_mv_node_type_id_idx'
+    add_index :dashboards_importers_mv,
+      :name_tsvector,
+      name: 'dashboards_importers_mv_name_tsvector_idx',
+      using: :gin
+  end
+
+  def down
+    drop_view :dashboards_exporters_mv,
+      materialized: true
+    drop_view :dashboards_importers_mv,
+      materialized: true
+  end
+end

--- a/db/migrate/20191002201000_split_dashboards_companies_mview.rb
+++ b/db/migrate/20191002201000_split_dashboards_companies_mview.rb
@@ -8,9 +8,6 @@ class SplitDashboardsCompaniesMview < ActiveRecord::Migration[5.2]
       unique: true,
       name: 'dashboards_exporters_mv_unique_idx'
     add_index :dashboards_exporters_mv,
-      :context_id,
-      name: 'dashboards_exporters_mv_context_id_idx'
-    add_index :dashboards_exporters_mv,
       :commodity_id,
       name: 'dashboards_exporters_mv_commodity_id_idx'
     add_index :dashboards_exporters_mv,
@@ -34,9 +31,6 @@ class SplitDashboardsCompaniesMview < ActiveRecord::Migration[5.2]
       [:id, :node_id, :country_id, :commodity_id],
       unique: true,
       name: 'dashboards_importers_mv_unique_idx'
-    add_index :dashboards_importers_mv,
-      :context_id,
-      name: 'dashboards_importers_mv_context_id_idx'
     add_index :dashboards_importers_mv,
       :commodity_id,
       name: 'dashboards_importers_mv_commodity_id_idx'

--- a/db/views/dashboards_exporters_mv_v01.sql
+++ b/db/views/dashboards_exporters_mv_v01.sql
@@ -26,7 +26,6 @@ WITH active_cnt AS (
     flow_nodes.flow_id,
     flow_nodes.node_id,
     nodes.node_type_id,
-    contexts.id AS context_id,
     contexts.country_id,
     contexts.commodity_id,
     TRIM(nodes.name) AS name,
@@ -51,7 +50,6 @@ SELECT
   -- fixed width first
   ffn.node_id AS id,
   ffn.node_type_id,
-  ffn.context_id,
   ffn.country_id,
   ffn.commodity_id,
   fn.node_id,
@@ -66,7 +64,6 @@ WHERE ffn.node_id <> fn.node_id
 GROUP BY (
   ffn.node_id,
   ffn.node_type_id,
-  ffn.context_id,
   ffn.country_id,
   ffn.commodity_id,
   fn.node_id,

--- a/db/views/dashboards_exporters_mv_v01.sql
+++ b/db/views/dashboards_exporters_mv_v01.sql
@@ -1,0 +1,77 @@
+WITH active_cnt AS (
+  SELECT context_id, column_position, cnt_props.role, profiles.name AS profile
+  FROM context_node_types cnt
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  WHERE cnt_props.role IS NOT NULL
+), flow_nodes AS (
+  SELECT
+    flow_nodes.context_id,
+    flow_id,
+    node_id,
+    position
+  FROM (
+    SELECT
+      context_id,
+      flow_id,
+      node_id,
+      position
+    FROM flow_nodes_mv
+  ) flow_nodes
+  JOIN active_cnt ON flow_nodes.context_id = active_cnt.context_id
+    AND flow_nodes.position = active_cnt.column_position + 1
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    nodes.node_type_id,
+    contexts.id AS context_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    TRIM(nodes.name) AS name,
+    TO_TSVECTOR('simple', COALESCE(TRIM(nodes.name)::TEXT, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    CASE
+      -- this is the same condition as in nodes_mv
+      WHEN nodes.is_unknown = FALSE AND node_properties.is_domestic_consumption = FALSE AND nodes.name NOT ILIKE 'OTHER'
+      THEN cnt.profile
+      ELSE NULL
+    END AS profile
+  FROM flow_nodes
+  JOIN nodes ON nodes.id = flow_nodes.node_id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN node_types ON node_types.id = nodes.node_type_id
+  JOIN active_cnt cnt ON cnt.context_id = flow_nodes.context_id
+    AND cnt.column_position + 1 = flow_nodes.position
+  JOIN contexts ON contexts.id = flow_nodes.context_id AND contexts.id = cnt.context_id
+  WHERE cnt.role = 'exporter'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.context_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+FROM filtered_flow_nodes ffn
+JOIN flow_nodes fn
+ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.context_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+);

--- a/db/views/dashboards_importers_mv_v01.sql
+++ b/db/views/dashboards_importers_mv_v01.sql
@@ -26,7 +26,6 @@ WITH active_cnt AS (
     flow_nodes.flow_id,
     flow_nodes.node_id,
     nodes.node_type_id,
-    contexts.id AS context_id,
     contexts.country_id,
     contexts.commodity_id,
     TRIM(nodes.name) AS name,
@@ -51,7 +50,6 @@ SELECT
   -- fixed width first
   ffn.node_id AS id,
   ffn.node_type_id,
-  ffn.context_id,
   ffn.country_id,
   ffn.commodity_id,
   fn.node_id,
@@ -66,7 +64,6 @@ WHERE ffn.node_id <> fn.node_id
 GROUP BY (
   ffn.node_id,
   ffn.node_type_id,
-  ffn.context_id,
   ffn.country_id,
   ffn.commodity_id,
   fn.node_id,

--- a/db/views/dashboards_importers_mv_v01.sql
+++ b/db/views/dashboards_importers_mv_v01.sql
@@ -1,0 +1,77 @@
+WITH active_cnt AS (
+  SELECT context_id, column_position, cnt_props.role, profiles.name AS profile
+  FROM context_node_types cnt
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  WHERE cnt_props.role IS NOT NULL
+), flow_nodes AS (
+  SELECT
+    flow_nodes.context_id,
+    flow_id,
+    node_id,
+    position
+  FROM (
+    SELECT
+      context_id,
+      flow_id,
+      node_id,
+      position
+    FROM flow_nodes_mv
+  ) flow_nodes
+  JOIN active_cnt ON flow_nodes.context_id = active_cnt.context_id
+    AND flow_nodes.position = active_cnt.column_position + 1
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    nodes.node_type_id,
+    contexts.id AS context_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    TRIM(nodes.name) AS name,
+    TO_TSVECTOR('simple', COALESCE(TRIM(nodes.name)::TEXT, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    CASE
+      -- this is the same condition as in nodes_mv
+      WHEN nodes.is_unknown = FALSE AND node_properties.is_domestic_consumption = FALSE AND nodes.name NOT ILIKE 'OTHER'
+      THEN cnt.profile
+      ELSE NULL
+    END AS profile
+  FROM flow_nodes
+  JOIN nodes ON nodes.id = flow_nodes.node_id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN node_types ON node_types.id = nodes.node_type_id
+  JOIN active_cnt cnt ON cnt.context_id = flow_nodes.context_id
+    AND cnt.column_position + 1 = flow_nodes.position
+  JOIN contexts ON contexts.id = flow_nodes.context_id AND contexts.id = cnt.context_id
+  WHERE cnt.role = 'importer'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.context_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+FROM filtered_flow_nodes ffn
+JOIN flow_nodes fn
+ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.context_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile
+);

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -780,6 +780,8 @@ paths:
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/profile_only"
       responses:
@@ -806,6 +808,8 @@ paths:
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
       responses:
         "200":
@@ -830,6 +834,8 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/profile_only"
       responses:
@@ -878,6 +884,8 @@ paths:
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
       responses:
         "200":
@@ -902,6 +910,8 @@ paths:
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/profile_only"
@@ -927,11 +937,13 @@ paths:
       summary: Sources matching selected filters with full text search
       parameters:
         - $ref: "#/components/parameters/query"
-        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
@@ -950,14 +962,17 @@ paths:
 
   /dashboards/companies:
     get:
+      deprecated: true
       tags:
         - "dashboards filters"
       summary: Companies matching selected filters
       parameters:
-        - $ref: "#/components/parameters/dashboards_companies_ids"
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/profile_only"
@@ -978,16 +993,139 @@ paths:
 
   /dashboards/companies/search:
     get:
+      deprecated: true
       tags:
         - "dashboards search"
       summary: Companies matching selected filters with full text search
       parameters:
         - $ref: "#/components/parameters/query"
-        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/node_types_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsSearchNode"
+
+  /dashboards/exporters:
+    get:
+      tags:
+        - "dashboards filters"
+      summary: Exporters matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/node_types_ids"
+        - $ref: "#/components/parameters/profile_only"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsCompany"
+
+  /dashboards/exporters/search:
+    get:
+      tags:
+        - "dashboards search"
+      summary: Exporters matching selected filters with full text search
+      parameters:
+        - $ref: "#/components/parameters/query"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/node_types_ids"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsSearchNode"
+
+  /dashboards/importers:
+    get:
+      tags:
+        - "dashboards filters"
+      summary: Importers matching selected filters
+      parameters:
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/node_types_ids"
+        - $ref: "#/components/parameters/profile_only"
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/per_page"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardsCompany"
+
+  /dashboards/importers/search:
+    get:
+      tags:
+        - "dashboards search"
+      summary: Importers matching selected filters with full text search
+      parameters:
+        - $ref: "#/components/parameters/query"
+        - $ref: "#/components/parameters/dashboards_countries_ids"
+        - $ref: "#/components/parameters/dashboards_commodities_ids"
+        - $ref: "#/components/parameters/dashboards_sources_ids"
+        - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
@@ -1010,11 +1148,13 @@ paths:
         - "dashboards filters"
       summary: Destinations matching selected filters
       parameters:
-        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
@@ -1038,11 +1178,13 @@ paths:
       summary: Destinations matching selected filters with full text search
       parameters:
         - $ref: "#/components/parameters/query"
-        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/dashboards_countries_ids"
         - $ref: "#/components/parameters/dashboards_commodities_ids"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
+        - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
@@ -1771,7 +1913,22 @@ components:
       schema:
         type: string
     dashboards_companies_ids:
+      deprecated: true
       name: companies_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_exporters_ids:
+      name: exporters_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    dashboards_importers_ids:
+      name: importers_ids
       in: query
       description: String with comma-separated numeric ids
       required: false

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -1254,9 +1254,13 @@ paths:
         - $ref: "#/components/parameters/dashboards_ncont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
         - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
         - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/start_year_req_query_param"
         - $ref: "#/components/parameters/end_year_opt_query_param"
@@ -1285,7 +1289,14 @@ paths:
         - $ref: "#/components/parameters/dashboards_cont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/start_year_req_query_param"
       responses:
         "200":
@@ -1330,7 +1341,14 @@ paths:
         - $ref: "#/components/parameters/dashboards_mandatory_ncont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/start_year_req_query_param"
       responses:
         "200":
@@ -1377,7 +1395,14 @@ paths:
         - $ref: "#/components/parameters/dashboards_cont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/start_year_req_query_param"
         - $ref: "#/components/parameters/end_year_req_query_param"
       responses:
@@ -1426,7 +1451,14 @@ paths:
         - $ref: "#/components/parameters/dashboards_mandatory_ncont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/start_year_req_query_param"
         - $ref: "#/components/parameters/end_year_req_query_param"
       responses:
@@ -1512,7 +1544,14 @@ paths:
         - $ref: "#/components/parameters/dashboards_cont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/dashboards_node_type_id"
         - $ref: "#/components/parameters/start_year_req_query_param"
         - $ref: "#/components/parameters/dashboards_top_n"
@@ -1562,7 +1601,14 @@ paths:
         - $ref: "#/components/parameters/dashboards_mandatory_ncont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/dashboards_node_type_id"
         - $ref: "#/components/parameters/start_year_req_query_param"
         - $ref: "#/components/parameters/dashboards_top_n"
@@ -1639,7 +1685,14 @@ paths:
         - $ref: "#/components/parameters/dashboards_cont_attribute_id"
         - $ref: "#/components/parameters/dashboards_sources_ids"
         - $ref: "#/components/parameters/dashboards_companies_ids"
+        - $ref: "#/components/parameters/dashboards_exporters_ids"
+        - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_sources_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_companies_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_exporters_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_importers_ids"
+        - $ref: "#/components/parameters/excluded_dashboards_destinations_ids"
         - $ref: "#/components/parameters/dashboards_node_type_id"
         - $ref: "#/components/parameters/start_year_req_query_param"
         - $ref: "#/components/parameters/end_year_req_query_param"
@@ -1949,7 +2002,22 @@ components:
       schema:
         type: string
     excluded_dashboards_companies_ids:
+      deprecated: true
       name: excluded_companies_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    excluded_dashboards_exporters_ids:
+      name: excluded_exporters_ids
+      in: query
+      description: String with comma-separated numeric ids
+      required: false
+      schema:
+        type: string
+    excluded_dashboards_importers_ids:
+      name: excluded_importers_ids
       in: query
       description: String with comma-separated numeric ids
       required: false

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -227,8 +227,7 @@ paths:
         - flow
       summary: Top nodes of given node type per context
       parameters:
-        - $ref: "#/components/parameters/commodity_id_query_param"
-        - $ref: "#/components/parameters/contexts_ids_query_param"
+        - $ref: "#/components/parameters/context_id_path_param"
         - name: column_id
           in: query
           description: Node type id
@@ -382,7 +381,7 @@ paths:
                       items:
                         type: integer
                       example: [2013, 2014, 2015]
-  "/contexts/{context_id}/top_profiles":
+  "/top_profiles":
     get:
       tags:
         - top_profile

--- a/spec/controllers/api/v3/dashboards/exporters_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/exporters_controller_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 paraguay flows quants'
+  include_context 'api v3 brazil soy profiles'
+
+  before(:each) do
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Exporter.refresh(sync: true, skip_dependencies: true)
+  end
+
+  describe 'GET search' do
+    it 'returns companies by name' do
+      get :search, params: {
+        countries_ids: [api_v3_brazil.id].join(','),
+        q: 'afg'
+      }
+      expect(assigns(:collection).map(&:name)).to eq(
+        [api_v3_exporter1_node.name]
+      )
+    end
+  end
+
+  describe 'GET index' do
+    let(:all_results_alphabetically) {
+      [
+        api_v3_exporter1_node,
+        api_v3_other_exporter_node
+      ]
+    }
+
+    it 'returns list in alphabetical order' do
+      get :index, params: {
+        countries_ids: api_v3_brazil.id,
+        node_types_ids: [api_v3_exporter_node_type.id].join(',')
+      }
+      expect(assigns(:collection).map(&:name)).to eq(
+        all_results_alphabetically.map(&:name)
+      )
+    end
+
+    it 'returns companies by id' do
+      get :index, params: {
+        countries_ids: [api_v3_brazil.id].join(','),
+        exporters_ids: api_v3_exporter1_node.id,
+        node_types_ids: [api_v3_exporter_node_type.id].join(',')
+      }
+      expect(assigns(:collection).map(&:id)).to eq(
+        [api_v3_exporter1_node.id]
+      )
+    end
+
+    context 'when filter with node_ids' do
+      it 'returns companies with the specified nodes' do
+        get :index, params: {
+          countries_ids: [api_v3_brazil.id].join(','),
+          sources_ids: [api_v3_biome_node.id].join(','),
+          destinations_ids: [api_v3_country_of_destination1_node.id].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+        )
+      end
+
+      it 'returns companies exporting to country' do
+        get :index, params: {
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id
+          ].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+        )
+      end
+
+      it 'returns companies exporting to country from source' do
+        get :index, params: {
+          sources_ids: [api_v3_municipality2_node.id].join(','),
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id
+          ].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id]
+        )
+      end
+
+      it 'returns companies exporting to either country' do
+        get :index, params: {
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id,
+            api_v3_other_country_of_destination_node.id
+          ].join(','),
+          node_types_ids: [api_v3_exporter_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+        )
+      end
+    end
+
+    let(:per_page) { 1 }
+
+    it 'accepts per_page' do
+      get :index, params: {countries_ids: api_v3_brazil.id, per_page: per_page}
+      expect(assigns(:collection).size).to eq(per_page)
+    end
+
+    context 'when profile_only' do
+      it 'returns companies with profiles' do
+        get :index, params: {profile_only: true}
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_exporter1_node.id]
+        )
+      end
+    end
+  end
+end

--- a/spec/controllers/api/v3/dashboards/importers_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/importers_controller_spec.rb
@@ -1,0 +1,124 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 paraguay flows quants'
+  include_context 'api v3 brazil soy profiles'
+
+  before(:each) do
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Importer.refresh(sync: true, skip_dependencies: true)
+  end
+
+  describe 'GET search' do
+    it 'returns companies by name' do
+      get :search, params: {
+        countries_ids: [api_v3_brazil.id].join(','),
+        q: 'agr'
+      }
+      expect(assigns(:collection).map(&:name)).to eq(
+        [api_v3_importer1_node.name]
+      )
+    end
+  end
+
+  describe 'GET index' do
+    let(:all_results_alphabetically) {
+      [
+        api_v3_importer1_node,
+        api_v3_other_importer_node
+      ]
+    }
+
+    it 'returns list in alphabetical order' do
+      get :index, params: {
+        countries_ids: api_v3_brazil.id,
+        node_types_ids: [api_v3_importer_node_type.id].join(',')
+      }
+      expect(assigns(:collection).map(&:name)).to eq(
+        all_results_alphabetically.map(&:name)
+      )
+    end
+
+    it 'returns companies by id' do
+      get :index, params: {
+        countries_ids: [api_v3_brazil.id].join(','),
+        importers_ids: api_v3_importer1_node.id,
+        node_types_ids: [api_v3_importer_node_type.id].join(',')
+      }
+      expect(assigns(:collection).map(&:id)).to eq(
+        [api_v3_importer1_node.id]
+      )
+    end
+
+    context 'when filter with node_ids' do
+      it 'returns companies with the specified nodes' do
+        get :index, params: {
+          countries_ids: [api_v3_brazil.id].join(','),
+          sources_ids: [api_v3_biome_node.id].join(','),
+          destinations_ids: [api_v3_country_of_destination1_node.id].join(','),
+          node_types_ids: [api_v3_importer_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_importer1_node.id, api_v3_other_importer_node.id]
+        )
+      end
+
+      it 'returns companies importing to country' do
+        get :index, params: {
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id
+          ].join(','),
+          node_types_ids: [api_v3_importer_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_importer1_node.id, api_v3_other_importer_node.id]
+        )
+      end
+
+      it 'returns companies importing to country from source' do
+        get :index, params: {
+          sources_ids: [api_v3_municipality2_node.id].join(','),
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id
+          ].join(','),
+          node_types_ids: [api_v3_importer_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_importer1_node.id]
+        )
+      end
+
+      it 'returns companies importing to either country' do
+        get :index, params: {
+          destinations_ids: [
+            api_v3_country_of_destination1_node.id,
+            api_v3_other_country_of_destination_node.id
+          ].join(','),
+          node_types_ids: [api_v3_importer_node_type.id].join(',')
+        }
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_importer1_node.id, api_v3_other_importer_node.id]
+        )
+      end
+    end
+
+    let(:per_page) { 1 }
+
+    it 'accepts per_page' do
+      get :index, params: {countries_ids: api_v3_brazil.id, per_page: per_page}
+      expect(assigns(:collection).size).to eq(per_page)
+    end
+
+    context 'when profile_only' do
+      it 'returns companies with profiles' do
+        get :index, params: {profile_only: true}
+        expect(assigns(:collection).map(&:id)).to eq(
+          [api_v3_importer1_node.id]
+        )
+      end
+    end
+  end
+end

--- a/spec/models/api/v3/context_node_type_property_spec.rb
+++ b/spec/models/api/v3/context_node_type_property_spec.rb
@@ -57,12 +57,14 @@ RSpec.describe Api::V3::ContextNodeTypeProperty, type: :model do
       it 'dashboards_sources_mv and dashboards_companies_mv are refreshed' do
         allow(Api::V3::Readonly::Dashboards::Source).to receive(:refresh_later)
         allow(Api::V3::Readonly::Dashboards::Company).to receive(:refresh_later)
+        allow(Api::V3::Readonly::Dashboards::Exporter).to receive(:refresh_later)
         property = FactoryBot.create(
           :api_v3_context_node_type_property,
           role: Api::V3::ContextNodeTypeProperty::SOURCE_ROLE
         )
         expect(Api::V3::Readonly::Dashboards::Source).to receive(:refresh_later)
         expect(Api::V3::Readonly::Dashboards::Company).to receive(:refresh_later)
+        expect(Api::V3::Readonly::Dashboards::Exporter).to receive(:refresh_later)
         property.update(role: Api::V3::ContextNodeTypeProperty::EXPORTER_ROLE)
       end
     end

--- a/spec/responses/api/v3/dashboards/exporters_spec.rb
+++ b/spec/responses/api/v3/dashboards/exporters_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Exporters', type: :request do
+  include_context 'api v3 brazil flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Exporter.refresh(sync: true, skip_dependencies: true)
+  end
+
+  describe 'GET /api/v3/dashboards/exporters' do
+    it 'has the correct response structure' do
+      get '/api/v3/dashboards/exporters'
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_companies')
+    end
+  end
+
+  describe 'GET /api/v3/dashboards/exporters/search' do
+    it 'has the correct response structure' do
+      get '/api/v3/dashboards/exporters/search?q=a'
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_companies_search')
+    end
+  end
+end

--- a/spec/responses/api/v3/dashboards/importers_spec.rb
+++ b/spec/responses/api/v3/dashboards/importers_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Importers', type: :request do
+  include_context 'api v3 brazil flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Importer.refresh(sync: true, skip_dependencies: true)
+  end
+
+  describe 'GET /api/v3/dashboards/importers' do
+    it 'has the correct response structure' do
+      get '/api/v3/dashboards/importers'
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_companies')
+    end
+  end
+
+  describe 'GET /api/v3/dashboards/importers/search' do
+    it 'has the correct response structure' do
+      get '/api/v3/dashboards/importers/search?q=a'
+
+      expect(@response).to have_http_status(:ok)
+      expect(@response).to match_response_schema('dashboards_companies_search')
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
+++ b/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
@@ -25,9 +25,13 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
     {
       sources_ids: [],
       companies_ids: [],
+      exporters_ids: [],
+      importers_ids: [],
       destinations_ids: [],
       excluded_sources_ids: [],
       excluded_companies_ids: [],
+      excluded_exporters_ids: [],
+      excluded_importers_ids: [],
       excluded_destinations_ids: []
     }
   }
@@ -208,6 +212,7 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
     end
   end
 
+  # TODO: remove once dashboards_companies_mv retired
   context 'when multiple years, non-cont indicator, 1 exporter' do
     let(:overview_parameters) {
       mandatory_parameters.merge(multi_year).merge(
@@ -266,6 +271,65 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
     end
   end
 
+  context 'when multiple years, non-cont indicator, 1 exporter' do
+    let(:overview_parameters) {
+      mandatory_parameters.merge(multi_year).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:parameters) {
+      overview_parameters.
+        merge(no_flow_path_filters).
+        merge(
+          exporters_ids: [
+            api_v3_exporter1_node.id
+          ]
+        )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute
+        },
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          node_type_id: api_v3_exporter_node_type.id,
+          exporters_ids: [api_v3_exporter1_node.id],
+          single_filter_key: :exporters,
+          grouping_key: :cont_attribute_id,
+          grouping_label: api_v3_exporter1_node.name
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_node_type_view,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+
+    it 'returns expected chart types' do
+      expect(chart_types).to match_array(expected_chart_types)
+    end
+  end
+
+  # TODO: remove once dashboards_companies_mv retired
   context 'when multiple years, non-cont indicator, 1 exporter, 1 excluded source' do
     let(:overview_parameters) {
       mandatory_parameters.merge(multi_year).merge(
@@ -326,6 +390,67 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
     end
   end
 
+  context 'when multiple years, non-cont indicator, 1 exporter, 1 excluded source' do
+    let(:overview_parameters) {
+      mandatory_parameters.merge(multi_year).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:parameters) {
+      overview_parameters.
+        merge(no_flow_path_filters).
+        merge(
+          exporters_ids: [
+            api_v3_exporter1_node.id
+          ],
+          excluded_sources_ids: [api_v3_municipality_node.id]
+        )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute
+        },
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          node_type_id: api_v3_exporter_node_type.id,
+          exporters_ids: [api_v3_exporter1_node.id],
+          excluded_sources_ids: [api_v3_municipality_node.id],
+          single_filter_key: :exporters,
+          grouping_key: :cont_attribute_id,
+          grouping_label: api_v3_exporter1_node.name
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_importer_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_node_type_view,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+
+    it 'returns expected chart types' do
+      expect(chart_types).to match_array(expected_chart_types)
+    end
+  end
+
+  # TODO: remove once dashboards_companies_mv retired
   context 'when multiple years, non-cont indicator, 2 exporters' do
     let(:overview_parameters) {
       mandatory_parameters.merge(multi_year).merge(
@@ -368,6 +493,76 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
           node_type_id: api_v3_exporter_node_type.id,
           companies_ids: [api_v3_other_exporter_node.id],
           single_filter_key: :companies,
+          grouping_key: :cont_attribute_id,
+          grouping_label: api_v3_other_exporter_node.name
+        }
+      ] + [
+        api_v3_biome_node_type,
+        api_v3_state_node_type,
+        api_v3_municipality_node_type,
+        api_v3_logistics_hub_node_type,
+        api_v3_port_node_type,
+        api_v3_importer_node_type,
+        api_v3_exporter_node_type,
+        api_v3_country_node_type
+      ].map do |node_type|
+        {
+          source: :multi_year_no_ncont_node_type_view,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :node_type,
+          node_type_id: node_type.id
+        }
+      end
+    }
+
+    it 'returns expected chart types' do
+      expect(chart_types).to match_array(expected_chart_types)
+    end
+  end
+
+  context 'when multiple years, non-cont indicator, 2 exporters' do
+    let(:overview_parameters) {
+      mandatory_parameters.merge(multi_year).merge(
+        ncont_attribute_id: ncont_attribute.id
+      )
+    }
+    let(:parameters) {
+      overview_parameters.
+        merge(no_flow_path_filters).
+        merge(
+          exporters_ids: [
+            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+          ]
+        )
+    }
+    let(:simplified_expected_chart_types) {
+      [
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute
+        },
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          node_type_id: api_v3_exporter_node_type.id,
+          exporters_ids: [api_v3_exporter1_node.id],
+          single_filter_key: :exporters,
+          grouping_key: :cont_attribute_id,
+          grouping_label: api_v3_exporter1_node.name
+        },
+        {
+          source: :multi_year_ncont_overview,
+          type: Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts::STACKED_BAR_CHART,
+          x: :year,
+          break_by: :ncont_attribute,
+          node_type_id: api_v3_exporter_node_type.id,
+          exporters_ids: [api_v3_other_exporter_node.id],
+          single_filter_key: :exporters,
           grouping_key: :cont_attribute_id,
           grouping_label: api_v3_other_exporter_node.name
         }


### PR DESCRIPTION
For backwards compatibility both the old "companies" and new "exporters / importers" endpoints / parameters work for now.

So for example this works:
/api/v3/dashboards/**companies**?page=1&node_types_ids=6&countries_ids=27&commodities_ids=46

and this works (and returns the same result):
/api/v3/dashboards/**exporters**?page=1&node_types_ids=6&countries_ids=27&commodities_ids=46

In terms of parameters, this works:
/api/v3/dashboards/parametrised_charts?**companies_ids=13952**&country_id=27&commodity_id=46&cont_attribute_id=28&start_year=2017&end_year=2017

And this works:
/api/v3/dashboards/parametrised_charts?**exporters_ids=13952**&country_id=27&commodity_id=46&cont_attribute_id=28&start_year=2017&end_year=2017