### PR TITLE
Recover the logistics map tooltip

### DIFF
--- a/frontend/scripts/react-components/logistics-map/logistics-map.component.jsx
+++ b/frontend/scripts/react-components/logistics-map/logistics-map.component.jsx
@@ -10,7 +10,7 @@ import WRIIcons from 'vizzuality-components/dist/icons';
 import { Layer, LayerManager } from 'layer-manager/dist/components';
 import { PluginLeaflet } from 'layer-manager';
 import { BASEMAPS } from 'constants';
-import UnitsTooltip from 'react-components/shared/units-tooltip/units-tooltip.component';
+import LogisticsMapTooltip from 'react-components/shared/logistics-map-tooltip/logistics-map-tooltip.component';
 import SimpleModal from 'react-components/shared/simple-modal/simple-modal.component';
 import LogisticsMapLegend from 'react-components/logistics-map/logistics-map-legend/logistics-map-legend.component';
 import LogisticsMapPanel from 'react-components/logistics-map/logistics-map-panel/logistics-map-panel.container';
@@ -37,7 +37,7 @@ function LogisticsMap(props) {
     setLayerActive,
     getCurrentPopUp
   } = props;
-  const Tooltip = p => <UnitsTooltip {...p.data} />;
+  const Tooltip = p => <LogisticsMapTooltip {...p.data} />;
   return (
     <div className="l-logistics-map">
       <div className="c-logistics-map">

--- a/frontend/scripts/react-components/shared/logistics-map-tooltip/logistics-map-tooltip.component.jsx
+++ b/frontend/scripts/react-components/shared/logistics-map-tooltip/logistics-map-tooltip.component.jsx
@@ -1,0 +1,67 @@
+import React, { useRef, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+import './logistics-map-tooltip.scss';
+
+function LogisticsMapTooltip(props) {
+  const { className, text, items, show, x, y } = props;
+  const ref = useRef(null);
+  const position = useMemo(() => {
+    if (!ref.current || typeof x === 'undefined' || typeof y === 'undefined') {
+      return null;
+    }
+
+    const canDisplayOnRight =
+      x < document.documentElement.clientWidth - ref.current.clientWidth - 10;
+    const canDisplayOnBottom =
+      y < document.documentElement.clientHeight - ref.current.clientHeight - 10;
+    const leftPos = canDisplayOnRight ? x + 10 : x - ref.current.clientWidth - 10;
+    const topPos = canDisplayOnBottom ? y + 10 : y - ref.current.clientHeight - 10;
+
+    return {
+      left: Number.isNaN(leftPos) ? 0 : leftPos,
+      top: Number.isNaN(topPos) ? 0 : topPos
+    };
+  }, [x, y]);
+
+  const visibility = show ? 'visible' : 'hidden';
+
+  return (
+    <div
+      ref={ref}
+      className={cx('c-logistics-map-tooltip', className)}
+      style={{
+        left: position ? position.left : undefined,
+        top: position ? position.top : undefined,
+        visibility
+      }}
+    >
+      <div className="logistics-map-tooltip-text">{text}</div>
+      {items.map(item => (
+        <div key={item.title} className="logistics-map-tooltip-value">
+          <div className="logistics-map-tooltip-title">{item.title}</div>
+          <div className="logistics-map-tooltip-data">
+            {item.value}
+            {item.unit && <span className="logistics-map-tooltip-value-unit"> {item.unit}</span>}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+LogisticsMapTooltip.defaultProps = {
+  items: []
+};
+
+LogisticsMapTooltip.propTypes = {
+  className: PropTypes.string,
+  x: PropTypes.number,
+  y: PropTypes.number,
+  text: PropTypes.string,
+  items: PropTypes.array,
+  show: PropTypes.bool
+};
+
+export default React.memo(LogisticsMapTooltip);

--- a/frontend/scripts/react-components/shared/logistics-map-tooltip/logistics-map-tooltip.scss
+++ b/frontend/scripts/react-components/shared/logistics-map-tooltip/logistics-map-tooltip.scss
@@ -1,0 +1,58 @@
+@import 'styles/settings';
+
+.c-logistics-map-tooltip {
+  position: absolute;
+  box-shadow: $box-shadow-big;
+  font-family: $font-family-1;
+  background-color: $white;
+  color: $charcoal-grey;
+  z-index: $z-above-veil-below-nav;
+
+  .logistics-map-tooltip-text {
+    font-family: $font-family-1;
+    font-size: $font-size-regular;
+    line-height: 1;
+    letter-spacing: -0.6px;
+    min-height: 32px;
+    padding: 12px 8px;
+    background-color: $egg-shell;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .logistics-map-tooltip-value {
+    padding: 10px 8px;
+
+    .logistics-map-tooltip-title {
+      font-family: $font-family-1;
+      font-size: $font-size-small;
+      letter-spacing: -0.5px;
+      opacity: 0.6;
+      text-transform: uppercase;
+      line-height: 1;
+    }
+
+    .logistics-map-tooltip-data {
+      font-family: $font-family-1;
+      font-size: 18px;
+      letter-spacing: -0.9px;
+      line-height: 1;
+      padding-top: 2px;
+      white-space: nowrap;
+
+      span {
+        opacity: 0.6;
+        font-size: 16px;
+        letter-spacing: -0.8px;
+      }
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid $metal-grey;
+    }
+
+    .logistics-map-tooltip-unit {
+      color: rgba($charcoal-grey, .5);
+    }
+  }
+}


### PR DESCRIPTION
The units tooltip changes broke the logistics map tooltip lets recover the old code as a new component. This page will go away with the new changes so it will be removed at some point

![image](https://user-images.githubusercontent.com/9701591/66648087-f71a7a80-ec2a-11e9-9d35-db0d256afc7b.png)
