### PR TITLE
Show the Layout Arrows without the redesign flag

### DIFF
--- a/frontend/scripts/react-components/tool/splitted-view/splitted-view.component.jsx
+++ b/frontend/scripts/react-components/tool/splitted-view/splitted-view.component.jsx
@@ -22,7 +22,7 @@ const SplittedView = ({ leftSlot, rightSlot, layout, sidebarOpen, changeLayout }
     )}
     <div className="left">
       {leftSlot}
-      {<LayoutArrows changeLayout={changeLayout} layout={layout} />}
+      <LayoutArrows changeLayout={changeLayout} layout={layout} />
     </div>
     <div className="right">{rightSlot}</div>
   </div>

--- a/frontend/scripts/react-components/tool/splitted-view/splitted-view.component.jsx
+++ b/frontend/scripts/react-components/tool/splitted-view/splitted-view.component.jsx
@@ -22,7 +22,7 @@ const SplittedView = ({ leftSlot, rightSlot, layout, sidebarOpen, changeLayout }
     )}
     <div className="left">
       {leftSlot}
-      {ENABLE_REDESIGN_PAGES && <LayoutArrows changeLayout={changeLayout} layout={layout} />}
+      {<LayoutArrows changeLayout={changeLayout} layout={layout} />}
     </div>
     <div className="right">{rightSlot}</div>
   </div>


### PR DESCRIPTION
We weren't showing the arrows without the ENABLE_REDESIGN_PAGES flag