### PR TITLE
Fix/firefox layer menu

### DIFF
--- a/frontend/scripts/react-components/tool/sankey/node-menu.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/node-menu.component.jsx
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Text from 'react-components/shared/text';
 
 import './node-menu.scss';
 
+const ITEM_HEIGHT = 33;
+
 function NodeMenu(props) {
-  const { options, menuPos, isVisible } = props;
+  const { options, menuPos, isVisible, containerRef } = props;
+  const menuHeight = useMemo(() => ITEM_HEIGHT * options?.length, [options]);
+  const flipped = useMemo(() => {
+    const nodeContainerHeight = containerRef.current?.getBoundingClientRect().height;
+    const menuBottom = menuPos.y + menuHeight;
+    return menuBottom > nodeContainerHeight;
+  }, [containerRef, menuHeight, menuPos.y]);
+
   return (
     <div
       className={cx('c-node-menu', { '-visible': isVisible })}
@@ -15,7 +24,10 @@ function NodeMenu(props) {
       <svg className="icon icon-outside-link">
         <use xmlnsXlink="http://www.w3.org/1999/xlink" xlinkHref="#icon-more-options" />
       </svg>
-      <ul className="options">
+      <ul
+        className={cx('options', { flipped })}
+        style={{ top: `${flipped ? 32 - menuHeight : 2}px` }}
+      >
         {options.map((option, i) => (
           <li key={option.id} className={cx('menu-item', option.className)}>
             <button className="menu-item-button" onClick={option.onClick}>
@@ -38,7 +50,8 @@ function NodeMenu(props) {
 NodeMenu.propTypes = {
   options: PropTypes.array,
   menuPos: PropTypes.shape({ x: PropTypes.number, y: PropTypes.number }),
-  isVisible: PropTypes.bool
+  isVisible: PropTypes.bool,
+  containerRef: PropTypes.node
 };
 
 export default React.memo(NodeMenu);

--- a/frontend/scripts/react-components/tool/sankey/node-menu.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/node-menu.component.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Text from 'react-components/shared/text';
@@ -9,12 +9,10 @@ const ITEM_HEIGHT = 33;
 
 function NodeMenu(props) {
   const { options, menuPos, isVisible, containerRef } = props;
-  const menuHeight = useMemo(() => ITEM_HEIGHT * options?.length, [options]);
-  const flipped = useMemo(() => {
-    const nodeContainerHeight = containerRef.current?.getBoundingClientRect().height;
-    const menuBottom = menuPos.y + menuHeight;
-    return menuBottom > nodeContainerHeight;
-  }, [containerRef, menuHeight, menuPos.y]);
+  const menuHeight = ITEM_HEIGHT * options?.length;
+  const nodeContainerHeight = containerRef.current?.getBoundingClientRect().height;
+  const menuBottom = menuPos.y + menuHeight;
+  const flipped = menuBottom > nodeContainerHeight;
 
   return (
     <div

--- a/frontend/scripts/react-components/tool/sankey/node-menu.scss
+++ b/frontend/scripts/react-components/tool/sankey/node-menu.scss
@@ -24,7 +24,12 @@
       box-shadow: unset;
 
       .options {
-        display: block;
+        display: flex;
+        flex-direction: column;
+
+        &.flipped {
+          flex-direction: column-reverse;
+        }
       }
     }
 

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -320,6 +320,7 @@ function Sankey(props) {
             menuPos={menuPos}
             isVisible={selectedNodesIds.length > 0}
             options={menuOptions}
+            containerRef={scrollContainerRef}
           />
         )}
         <svg

--- a/frontend/scripts/react-components/tool/tool-modal/layer-modal/layers-list/layers-list.component.jsx
+++ b/frontend/scripts/react-components/tool/tool-modal/layer-modal/layers-list/layers-list.component.jsx
@@ -26,7 +26,7 @@ export default function LayersList(props) {
     selectedTab === LAYER_TAB_NAMES.unit
       ? itemProps.item && !itemProps.item.isGroup && selectedItemIds?.includes(itemProps.item.uid)
       : selectedItemIds?.includes(itemProps.item.id);
-  const height = window.innerHeight * 0.9 - 155;
+  const height = window.innerHeight * 0.9 - 250;
   return (
     <GridList
       items={items}


### PR DESCRIPTION
- Fix firefox layer menu. The height was reduced as there was a difference in the calculation between browsers.
- Flip node menu if it crosses the node bounds

![image](https://user-images.githubusercontent.com/9701591/66755238-defb6300-ee97-11e9-9e4e-b2c10e217f76.png)
![image](https://user-images.githubusercontent.com/9701591/66755256-e589da80-ee97-11e9-88a9-1287bdcfed11.png)
