### PR TITLE
Removed restriction for assigning top profile images

### DIFF
--- a/app/admin/api/v3/top_profile.rb
+++ b/app/admin/api/v3/top_profile.rb
@@ -54,8 +54,7 @@ ActiveAdmin.register Api::V3::TopProfile, as: 'Top Profile' do
       available_top_profile_images =
         Api::V3::TopProfileImage.includes(:top_profiles).where(
           commodity_id: resource.context.commodity_id,
-          profile_type: resource.profile_type,
-          top_profiles: {top_profile_image_id: nil}
+          profile_type: resource.profile_type
         )
       render partial: 'admin/form_select_top_profile_images', locals: {
         available_top_profile_images: available_top_profile_images,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/169118685

The restriction was in place possibly by design rather than a bug, but I agree it is not helpful to be very restrictive in this case.