### PR TITLE
Feat: update sandbox demo indonesiademo node12

### DIFF
--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -1,4 +1,8 @@
 server 'demo.trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: true
 set :ssh_options, forward_agent: true
 
+set :nvm_type, :user
+set :nvm_node, 'v12.12.0'
+set :nvm_map_bins, %w{node npm yarn}
+
 set :branch, 'develop'

--- a/config/deploy/demo.rb
+++ b/config/deploy/demo.rb
@@ -2,7 +2,7 @@ server 'demo.trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: true
 set :ssh_options, forward_agent: true
 
 set :nvm_type, :user
-set :nvm_node, 'v12.12.0'
+set :nvm_node, '12'
 set :nvm_map_bins, %w{node npm yarn}
 
 set :branch, 'develop'

--- a/config/deploy/indonesiademo.rb
+++ b/config/deploy/indonesiademo.rb
@@ -1,4 +1,8 @@
 server 'indonesiademo.trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: true
 set :ssh_options, forward_agent: true
 
+set :nvm_type, :user
+set :nvm_node, 'v12.12.0'
+set :nvm_map_bins, %w{node npm yarn}
+
 set :branch, 'develop'

--- a/config/deploy/indonesiademo.rb
+++ b/config/deploy/indonesiademo.rb
@@ -2,7 +2,7 @@ server 'indonesiademo.trase.earth', user: 'ubuntu', roles: %w{web app db}, prima
 set :ssh_options, forward_agent: true
 
 set :nvm_type, :user
-set :nvm_node, 'v12.12.0'
+set :nvm_node, '12'
 set :nvm_map_bins, %w{node npm yarn}
 
 set :branch, 'develop'

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -2,7 +2,7 @@ server 'sandbox.trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: tr
 set :ssh_options, forward_agent: true
 
 set :nvm_type, :user
-set :nvm_node, 'v12.12.0'
+set :nvm_node, '12'
 set :nvm_map_bins, %w{node npm yarn}
 
 set :branch, 'develop'

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,4 +1,9 @@
 server 'sandbox.trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: true
 set :ssh_options, forward_agent: true
 
+set :nvm_type, :user
+set :nvm_node, 'v12.12.0'
+set :nvm_map_bins, %w{node npm yarn}
+
 set :branch, 'develop'
+

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -2,7 +2,7 @@ server 'staging.trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: tr
 set :ssh_options, forward_agent: true
 
 set :nvm_type, :user
-set :nvm_node, 'v12.12.0'
+set :nvm_node, '12'
 set :nvm_map_bins, %w{node npm yarn}
 
 set :branch, 'develop'


### PR DESCRIPTION
This PR updates sandbox, demo, indonesiademo capistrano config to use nvm. I also updated staging, so all of them use `12` instead of `v12.12.0`.

I also installed node in those 3 envs. Production setup is a bit different, didnt feel like touching it.

I'm not sure if we also need to update the system node, because of rails dependency.

Let me know if this is good to go and I'll deploy to sandbox.