### PR TITLE
Feature/order nodes by volume

### DIFF
--- a/app/controllers/concerns/api/v3/dashboards/filter_params.rb
+++ b/app/controllers/concerns/api/v3/dashboards/filter_params.rb
@@ -19,7 +19,10 @@ module Api
             destinations_ids: cs_string_to_int_array(params[:destinations_ids]),
             node_types_ids: cs_string_to_int_array(params[:node_types_ids]),
             profile_only: ActiveModel::Type::Boolean.new.cast(params[:profile_only]),
-            include: params[:include]
+            include: params[:include],
+            order_by: params[:order_by],
+            start_year: string_to_int(params[:start_year]),
+            end_year: string_to_int(params[:end_year])
           }
         end
       end

--- a/app/models/api/v3/node_property.rb
+++ b/app/models/api/v3/node_property.rb
@@ -34,6 +34,7 @@ module Api
       def refresh_dependents
         Api::V3::Readonly::Node.refresh
         Api::V3::Readonly::SankeyNode.refresh
+        # TODO dashboards nodes
       end
 
       def self.insert_missing_node_properties

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -66,6 +66,7 @@ module Api
 
       def refresh_dependents
         Api::V3::Readonly::Node.refresh
+        # TODO: sankey nodes and dashboards nodes
         Api::V3::Readonly::Context.refresh
       end
     end

--- a/app/models/api/v3/readonly/dashboards/destination.rb
+++ b/app/models/api/v3/readonly/dashboards/destination.rb
@@ -29,6 +29,14 @@ module Api
         class Destination < Api::Readonly::BaseModel
           self.table_name = 'dashboards_destinations_mv'
           belongs_to :node
+
+          class << self
+            def refresh_dependencies(options = {})
+              Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+                options.merge(skip_dependents: true)
+              )
+            end
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/exporter.rb
+++ b/app/models/api/v3/readonly/dashboards/exporter.rb
@@ -29,6 +29,14 @@ module Api
         class Exporter < Api::Readonly::BaseModel
           self.table_name = 'dashboards_exporters_mv'
           belongs_to :node
+
+          class << self
+            def refresh_dependencies(options = {})
+              Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+                options.merge(skip_dependents: true)
+              )
+            end
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/importer.rb
+++ b/app/models/api/v3/readonly/dashboards/importer.rb
@@ -29,6 +29,14 @@ module Api
         class Importer < Api::Readonly::BaseModel
           self.table_name = 'dashboards_importers_mv'
           belongs_to :node
+
+          class << self
+            def refresh_dependencies(options = {})
+              Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+                options.merge(skip_dependents: true)
+              )
+            end
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/source.rb
+++ b/app/models/api/v3/readonly/dashboards/source.rb
@@ -29,6 +29,14 @@ module Api
         class Source < Api::Readonly::BaseModel
           self.table_name = 'dashboards_sources_mv'
           belongs_to :node
+
+          class << self
+            def refresh_dependencies(options = {})
+              Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+                options.merge(skip_dependents: true)
+              )
+            end
+          end
         end
       end
     end

--- a/app/models/api/v3/readonly/nodes_per_context_ranked_by_volume_per_year.rb
+++ b/app/models/api/v3/readonly/nodes_per_context_ranked_by_volume_per_year.rb
@@ -1,0 +1,10 @@
+# Only needs to be refreshed once after data upload. Used in dashboards mviews.
+module Api
+  module V3
+    module Readonly
+      class NodesPerContextRankedByVolumePerYear < Api::Readonly::BaseModel
+        self.table_name = 'nodes_per_context_ranked_by_volume_per_year_mv'
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/filter_companies.rb
+++ b/app/services/api/v3/dashboards/filter_companies.rb
@@ -20,6 +20,10 @@ module Api
 
         private
 
+        def apply_order_by
+          @query = @query.order(:name)
+        end
+
         def filtered_class
           Api::V3::Readonly::Dashboards::Company
         end

--- a/app/services/api/v3/dashboards/filter_destinations.rb
+++ b/app/services/api/v3/dashboards/filter_destinations.rb
@@ -1,35 +1,15 @@
 module Api
   module V3
     module Dashboards
-      class FilterDestinations < BaseFilter
-        include CallWithQueryTerm
-
-        def initialize(params)
-          @self_ids = params.delete(:destinations_ids)
-          super(params)
-        end
-
-        def call_with_query_term(query_term)
-          super(query_term, {include_country_id: true})
-        end
-
+      class FilterDestinations < FilterNodes
         private
 
-        def initialize_query
-          @query = Api::V3::Readonly::Dashboards::Destination.
-            select(
-              :id,
-              :name,
-              :node_type,
-              :node_type_id
-            ).
-            group(
-              :id,
-              :name,
-              :node_type,
-              :node_type_id
-            ).
-            order(:name)
+        def param_name
+          :destinations_ids
+        end
+
+        def filtered_class
+          Api::V3::Readonly::Dashboards::Destination
         end
       end
     end

--- a/app/services/api/v3/dashboards/filter_exporters.rb
+++ b/app/services/api/v3/dashboards/filter_exporters.rb
@@ -1,21 +1,20 @@
 module Api
   module V3
     module Dashboards
-      class FilterExporters < BaseFilter
+      class FilterExporters < FilterNodes
         include Query
-        include CallWithQueryTerm
 
         def initialize(params)
-          @self_ids = params.delete(:exporters_ids)
+          @self_ids = params.delete(:param_name)
           @nodes_to_filter_by = Api::V3::Dashboards::NodesToFilterBy.new(params)
           super(params)
         end
 
-        def call_with_query_term(query_term)
-          super(query_term, {include_country_id: true})
-        end
-
         private
+
+        def param_name
+          :exporters_ids
+        end
 
         def filtered_class
           Api::V3::Readonly::Dashboards::Exporter

--- a/app/services/api/v3/dashboards/filter_importers.rb
+++ b/app/services/api/v3/dashboards/filter_importers.rb
@@ -1,21 +1,20 @@
 module Api
   module V3
     module Dashboards
-      class FilterImporters < BaseFilter
+      class FilterImporters < FilterNodes
         include Query
-        include CallWithQueryTerm
 
         def initialize(params)
-          @self_ids = params.delete(:importers_ids)
+          @self_ids = params.delete(:param_name)
           @nodes_to_filter_by = Api::V3::Dashboards::NodesToFilterBy.new(params)
           super(params)
         end
 
-        def call_with_query_term(query_term)
-          super(query_term, {include_country_id: true})
-        end
-
         private
+
+        def param_name
+          :importers_ids
+        end
 
         def filtered_class
           Api::V3::Readonly::Dashboards::Importer

--- a/app/services/api/v3/dashboards/filter_nodes.rb
+++ b/app/services/api/v3/dashboards/filter_nodes.rb
@@ -1,0 +1,105 @@
+module Api
+  module V3
+    module Dashboards
+      class FilterNodes < BaseFilter
+        include CallWithQueryTerm
+
+        ORDER_BY_VOLUME = 'volume'.freeze
+        ORDER_BY_NAME = 'name'.freeze
+
+          # @see Api::V3::Dashboards::FilterNodes::BaseFilter
+          # @option params [String] order_by
+          # @option params [Integer] start_year
+          # @option params [Integer] end_year
+        def initialize(params)
+          @self_ids = params.delete(param_name)
+          @order_by = params.delete(:order_by)&.downcase
+          @start_year = params.delete(:start_year)
+          @end_year = params.delete(:end_year)
+          super(params)
+        end
+
+        def call_with_query_term(query_term)
+          super(query_term, {include_country_id: true})
+        end
+
+        private
+
+        # @abstract
+        # @return [Symbol]
+        # @raise [NotImplementedError] when not defined in subclass
+        def param_name
+          raise NotImplementedError
+        end
+
+        # @abstract
+        # @return [Class]
+        # @raise [NotImplementedError] when not defined in subclass
+        def filtered_class
+          raise NotImplementedError
+        end
+
+        def initialize_query
+          @query = filtered_class.
+            select(
+              :id,
+              :name,
+              :node_type,
+              :node_type_id
+            ).
+            group(
+              :id,
+              :name,
+              :node_type,
+              :node_type_id
+            )
+          apply_order_by
+        end
+
+        def year_selected?
+          @start_year.present?
+        end
+
+        def context_selected?
+          @countries_ids.length == 1 && @commodities_ids.length == 1
+        end
+
+        def apply_order_by
+          # if ordering by name specifically requested
+          # or year param missing, which is required for ordering by volume
+          # or context not known
+
+          if @order_by == ORDER_BY_NAME ||
+              !year_selected? ||
+              !context_selected?
+            apply_order_by_name
+          else
+            apply_order_by_volume
+          end
+        end
+
+        def apply_order_by_name
+          @query = @query.order(:name)
+        end
+
+        def apply_order_by_volume
+          @query = @query.group(:rank_by_year)
+          if @start_year && @end_year && @end_year > @start_year
+            apply_order_by_average_volume
+          else
+            rank = "rank_by_year->'#{@start_year}'"
+            @query = @query.order(Arel.sql(rank))
+          end
+        end
+
+        def apply_order_by_average_volume
+          years = (@start_year..@end_year).to_a
+          no_of_years = years.length
+          rank_sum = years.map { |y| "(rank_by_year->'#{y}')::INT" }.join(' + ')
+          avg_rank = "(#{rank_sum}) / #{no_of_years}"
+          @query = @query.order(Arel.sql(avg_rank))
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/dashboards/filter_sources.rb
+++ b/app/services/api/v3/dashboards/filter_sources.rb
@@ -1,35 +1,15 @@
 module Api
   module V3
     module Dashboards
-      class FilterSources < BaseFilter
-        include CallWithQueryTerm
-
-        def initialize(params)
-          @self_ids = params.delete(:sources_ids)
-          super(params)
-        end
-
-        def call_with_query_term(query_term)
-          super(query_term, {include_country_id: true})
-        end
-
+      class FilterSources < FilterNodes
         private
 
-        def initialize_query
-          @query = Api::V3::Readonly::Dashboards::Source.
-            select(
-              :id,
-              :name,
-              :node_type,
-              :node_type_id
-            ).
-            group(
-              :id,
-              :name,
-              :node_type,
-              :node_type_id
-            ).
-            order(:name)
+        def param_name
+          :sources_ids
+        end
+
+        def filtered_class
+          Api::V3::Readonly::Dashboards::Source
         end
       end
     end

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -123,6 +123,7 @@ module Api
             Api::V3::Readonly::ResizeByAttribute,
             Api::V3::Readonly::Dashboards::Commodity,
             Api::V3::Readonly::Dashboards::Country,
+            Api::V3::Readonly::NodesPerContextRankedByVolumePerYear,
             Api::V3::Readonly::Dashboards::Source,
             # TODO: remove once dashboards_companies_mv retired
             Api::V3::Readonly::Dashboards::Company,

--- a/app/services/concerns/api/v3/dashboards/query.rb
+++ b/app/services/concerns/api/v3/dashboards/query.rb
@@ -51,8 +51,8 @@ module Api
               :node_type,
               :node_type_id,
               :country_id
-            ).
-            order(:name)
+            )
+          apply_order_by
         end
       end
     end

--- a/db/migrate/20191028134448_create_nodes_per_context_ranked_by_volume_per_year_mv.rb
+++ b/db/migrate/20191028134448_create_nodes_per_context_ranked_by_volume_per_year_mv.rb
@@ -1,0 +1,11 @@
+class CreateNodesPerContextRankedByVolumePerYearMv < ActiveRecord::Migration[5.2]
+  def change
+    create_view :nodes_per_context_ranked_by_volume_per_year_mv,
+      materialized: true
+
+    add_index :nodes_per_context_ranked_by_volume_per_year_mv,
+      [:context_id, :node_id],
+      unique: true,
+      name: 'nodes_per_context_ranked_by_volume_per_year_mv_unique_idx'
+  end
+end

--- a/db/migrate/20191028134449_add_rank_per_year_to_dashboards_mviews.rb
+++ b/db/migrate/20191028134449_add_rank_per_year_to_dashboards_mviews.rb
@@ -1,0 +1,23 @@
+class AddRankPerYearToDashboardsMviews < ActiveRecord::Migration[5.2]
+  def change
+    update_view :dashboards_sources_mv,
+      version: 9,
+      revert_to_version: 8,
+      materialized: true
+
+    update_view :dashboards_exporters_mv,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+
+    update_view :dashboards_importers_mv,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+
+    update_view :dashboards_destinations_mv,
+      version: 8,
+      revert_to_version: 7,
+      materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3420,50 +3420,98 @@ COMMENT ON COLUMN public.dashboards_countries_mv.node_id IS 'id of node, through
 
 
 --
+-- Name: flow_quants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.flow_quants (
+    id integer NOT NULL,
+    flow_id integer NOT NULL,
+    quant_id integer NOT NULL,
+    value double precision NOT NULL,
+    created_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: TABLE flow_quants; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.flow_quants IS 'Values of quants for flow';
+
+
+--
+-- Name: COLUMN flow_quants.value; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.flow_quants.value IS 'Numeric value';
+
+
+--
+-- Name: nodes_per_context_ranked_by_volume_per_year_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.nodes_per_context_ranked_by_volume_per_year_mv AS
+ SELECT node_volume_per_context_and_year_ranked.context_id,
+    node_volume_per_context_and_year_ranked.node_id,
+    jsonb_object_agg(node_volume_per_context_and_year_ranked.year, node_volume_per_context_and_year_ranked.rank) AS rank_by_year
+   FROM ( SELECT node_volume_per_context_and_year.node_id,
+            node_volume_per_context_and_year."position",
+            node_volume_per_context_and_year.context_id,
+            node_volume_per_context_and_year.year,
+            rank() OVER (PARTITION BY node_volume_per_context_and_year."position", node_volume_per_context_and_year.context_id, node_volume_per_context_and_year.year ORDER BY node_volume_per_context_and_year.value DESC) AS rank
+           FROM ( SELECT a.node_id,
+                    a."position",
+                    flows.context_id,
+                    flows.year,
+                    sum(flow_quants.value) AS value
+                   FROM public.flow_quants,
+                    public.flows,
+                    LATERAL unnest(flows.path) WITH ORDINALITY a(node_id, "position")
+                  WHERE ((flow_quants.flow_id = flows.id) AND (flow_quants.quant_id IN ( SELECT quants.id
+                           FROM public.quants
+                          WHERE (quants.name = 'Volume'::text))))
+                  GROUP BY a.node_id, a."position", flows.context_id, flows.year) node_volume_per_context_and_year) node_volume_per_context_and_year_ranked
+  GROUP BY node_volume_per_context_and_year_ranked.context_id, node_volume_per_context_and_year_ranked.node_id
+  WITH NO DATA;
+
+
+--
 -- Name: dashboards_destinations_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
 --
 
 CREATE MATERIALIZED VIEW public.dashboards_destinations_mv AS
- WITH active_cnt AS (
-         SELECT cnt.context_id,
-            cnt.column_position,
+ WITH all_flow_nodes AS (
+         SELECT flow_nodes.flow_id,
+            flow_nodes.node_id,
+            flow_nodes.context_id,
+            nodes.node_type_id,
+            btrim(nodes.name) AS name,
             cnt_props.role,
             profiles.name AS profile
-           FROM ((public.context_node_types cnt
+           FROM (((((public.flow_nodes_mv flow_nodes
+             JOIN public.nodes ON ((flow_nodes.node_id = nodes.id)))
+             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
+             JOIN public.context_node_types cnt ON (((flow_nodes.context_id = cnt.context_id) AND (flow_nodes."position" = (cnt.column_position + 1)) AND (nodes.node_type_id = cnt.node_type_id))))
              JOIN public.context_node_type_properties cnt_props ON ((cnt.id = cnt_props.context_node_type_id)))
              LEFT JOIN public.profiles ON ((cnt.id = profiles.context_node_type_id)))
-          WHERE (cnt_props.role IS NOT NULL)
-        ), flow_nodes AS (
-         SELECT flow_nodes.context_id,
-            flow_nodes.flow_id,
-            flow_nodes.node_id,
-            flow_nodes."position"
-           FROM (( SELECT flow_nodes_mv.context_id,
-                    flow_nodes_mv.flow_id,
-                    flow_nodes_mv.node_id,
-                    flow_nodes_mv."position"
-                   FROM public.flow_nodes_mv) flow_nodes
-             JOIN active_cnt ON (((flow_nodes.context_id = active_cnt.context_id) AND (flow_nodes."position" = (active_cnt.column_position + 1)))))
+          WHERE ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text))
         ), filtered_flow_nodes AS (
          SELECT flow_nodes.flow_id,
             flow_nodes.node_id,
-            nodes.node_type_id,
+            flow_nodes.context_id,
+            flow_nodes.node_type_id,
             contexts.country_id,
             contexts.commodity_id,
-            btrim(nodes.name) AS name,
-            to_tsvector('simple'::regconfig, COALESCE(btrim(nodes.name), ''::text)) AS name_tsvector,
+            flow_nodes.name,
+            to_tsvector('simple'::regconfig, COALESCE(flow_nodes.name, ''::text)) AS name_tsvector,
             node_types.name AS node_type,
-                CASE
-                    WHEN ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text)) THEN cnt.profile
-                    ELSE NULL::text
-                END AS profile
-           FROM (((((flow_nodes
-             JOIN public.nodes ON ((nodes.id = flow_nodes.node_id)))
-             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
-             JOIN public.node_types ON ((node_types.id = nodes.node_type_id)))
-             JOIN active_cnt cnt ON (((cnt.context_id = flow_nodes.context_id) AND ((cnt.column_position + 1) = flow_nodes."position"))))
-             JOIN public.contexts ON (((contexts.id = flow_nodes.context_id) AND (contexts.id = cnt.context_id))))
-          WHERE ((cnt.role)::text = 'destination'::text)
+            flow_nodes.profile,
+            ranked_nodes.rank_by_year
+           FROM (((all_flow_nodes flow_nodes
+             JOIN public.node_types ON ((node_types.id = flow_nodes.node_type_id)))
+             JOIN public.contexts ON ((contexts.id = flow_nodes.context_id)))
+             JOIN public.nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes ON (((flow_nodes.context_id = ranked_nodes.context_id) AND (flow_nodes.node_id = ranked_nodes.node_id))))
+          WHERE ((flow_nodes.role)::text = 'destination'::text)
         )
  SELECT ffn.node_id AS id,
     ffn.node_type_id,
@@ -3473,11 +3521,12 @@ CREATE MATERIALIZED VIEW public.dashboards_destinations_mv AS
     ffn.name,
     ffn.name_tsvector,
     ffn.node_type,
-    ffn.profile
+    ffn.profile,
+    ffn.rank_by_year
    FROM (filtered_flow_nodes ffn
-     JOIN flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
+     JOIN all_flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
   WHERE (ffn.node_id <> fn.node_id)
-  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile
+  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile, ffn.rank_by_year
   WITH NO DATA;
 
 
@@ -3521,46 +3570,38 @@ COMMENT ON COLUMN public.dashboards_destinations_mv.node_id IS 'id of another no
 --
 
 CREATE MATERIALIZED VIEW public.dashboards_exporters_mv AS
- WITH active_cnt AS (
-         SELECT cnt.context_id,
-            cnt.column_position,
+ WITH all_flow_nodes AS (
+         SELECT flow_nodes.flow_id,
+            flow_nodes.node_id,
+            flow_nodes.context_id,
+            nodes.node_type_id,
+            btrim(nodes.name) AS name,
             cnt_props.role,
             profiles.name AS profile
-           FROM ((public.context_node_types cnt
+           FROM (((((public.flow_nodes_mv flow_nodes
+             JOIN public.nodes ON ((flow_nodes.node_id = nodes.id)))
+             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
+             JOIN public.context_node_types cnt ON (((flow_nodes.context_id = cnt.context_id) AND (flow_nodes."position" = (cnt.column_position + 1)) AND (nodes.node_type_id = cnt.node_type_id))))
              JOIN public.context_node_type_properties cnt_props ON ((cnt.id = cnt_props.context_node_type_id)))
              LEFT JOIN public.profiles ON ((cnt.id = profiles.context_node_type_id)))
-          WHERE (cnt_props.role IS NOT NULL)
-        ), flow_nodes AS (
-         SELECT flow_nodes.context_id,
-            flow_nodes.flow_id,
-            flow_nodes.node_id,
-            flow_nodes."position"
-           FROM (( SELECT flow_nodes_mv.context_id,
-                    flow_nodes_mv.flow_id,
-                    flow_nodes_mv.node_id,
-                    flow_nodes_mv."position"
-                   FROM public.flow_nodes_mv) flow_nodes
-             JOIN active_cnt ON (((flow_nodes.context_id = active_cnt.context_id) AND (flow_nodes."position" = (active_cnt.column_position + 1)))))
+          WHERE ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text))
         ), filtered_flow_nodes AS (
          SELECT flow_nodes.flow_id,
             flow_nodes.node_id,
-            nodes.node_type_id,
+            flow_nodes.context_id,
+            flow_nodes.node_type_id,
             contexts.country_id,
             contexts.commodity_id,
-            btrim(nodes.name) AS name,
-            to_tsvector('simple'::regconfig, COALESCE(btrim(nodes.name), ''::text)) AS name_tsvector,
+            flow_nodes.name,
+            to_tsvector('simple'::regconfig, COALESCE(flow_nodes.name, ''::text)) AS name_tsvector,
             node_types.name AS node_type,
-                CASE
-                    WHEN ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text)) THEN cnt.profile
-                    ELSE NULL::text
-                END AS profile
-           FROM (((((flow_nodes
-             JOIN public.nodes ON ((nodes.id = flow_nodes.node_id)))
-             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
-             JOIN public.node_types ON ((node_types.id = nodes.node_type_id)))
-             JOIN active_cnt cnt ON (((cnt.context_id = flow_nodes.context_id) AND ((cnt.column_position + 1) = flow_nodes."position"))))
-             JOIN public.contexts ON (((contexts.id = flow_nodes.context_id) AND (contexts.id = cnt.context_id))))
-          WHERE ((cnt.role)::text = 'exporter'::text)
+            flow_nodes.profile,
+            ranked_nodes.rank_by_year
+           FROM (((all_flow_nodes flow_nodes
+             JOIN public.node_types ON ((node_types.id = flow_nodes.node_type_id)))
+             JOIN public.contexts ON ((contexts.id = flow_nodes.context_id)))
+             JOIN public.nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes ON (((flow_nodes.context_id = ranked_nodes.context_id) AND (flow_nodes.node_id = ranked_nodes.node_id))))
+          WHERE ((flow_nodes.role)::text = 'exporter'::text)
         )
  SELECT ffn.node_id AS id,
     ffn.node_type_id,
@@ -3570,11 +3611,12 @@ CREATE MATERIALIZED VIEW public.dashboards_exporters_mv AS
     ffn.name,
     ffn.name_tsvector,
     ffn.node_type,
-    ffn.profile
+    ffn.profile,
+    ffn.rank_by_year
    FROM (filtered_flow_nodes ffn
-     JOIN flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
+     JOIN all_flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
   WHERE (ffn.node_id <> fn.node_id)
-  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile
+  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile, ffn.rank_by_year
   WITH NO DATA;
 
 
@@ -3583,46 +3625,38 @@ CREATE MATERIALIZED VIEW public.dashboards_exporters_mv AS
 --
 
 CREATE MATERIALIZED VIEW public.dashboards_importers_mv AS
- WITH active_cnt AS (
-         SELECT cnt.context_id,
-            cnt.column_position,
+ WITH all_flow_nodes AS (
+         SELECT flow_nodes.flow_id,
+            flow_nodes.node_id,
+            flow_nodes.context_id,
+            nodes.node_type_id,
+            btrim(nodes.name) AS name,
             cnt_props.role,
             profiles.name AS profile
-           FROM ((public.context_node_types cnt
+           FROM (((((public.flow_nodes_mv flow_nodes
+             JOIN public.nodes ON ((flow_nodes.node_id = nodes.id)))
+             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
+             JOIN public.context_node_types cnt ON (((flow_nodes.context_id = cnt.context_id) AND (flow_nodes."position" = (cnt.column_position + 1)) AND (nodes.node_type_id = cnt.node_type_id))))
              JOIN public.context_node_type_properties cnt_props ON ((cnt.id = cnt_props.context_node_type_id)))
              LEFT JOIN public.profiles ON ((cnt.id = profiles.context_node_type_id)))
-          WHERE (cnt_props.role IS NOT NULL)
-        ), flow_nodes AS (
-         SELECT flow_nodes.context_id,
-            flow_nodes.flow_id,
-            flow_nodes.node_id,
-            flow_nodes."position"
-           FROM (( SELECT flow_nodes_mv.context_id,
-                    flow_nodes_mv.flow_id,
-                    flow_nodes_mv.node_id,
-                    flow_nodes_mv."position"
-                   FROM public.flow_nodes_mv) flow_nodes
-             JOIN active_cnt ON (((flow_nodes.context_id = active_cnt.context_id) AND (flow_nodes."position" = (active_cnt.column_position + 1)))))
+          WHERE ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text))
         ), filtered_flow_nodes AS (
          SELECT flow_nodes.flow_id,
             flow_nodes.node_id,
-            nodes.node_type_id,
+            flow_nodes.context_id,
+            flow_nodes.node_type_id,
             contexts.country_id,
             contexts.commodity_id,
-            btrim(nodes.name) AS name,
-            to_tsvector('simple'::regconfig, COALESCE(btrim(nodes.name), ''::text)) AS name_tsvector,
+            flow_nodes.name,
+            to_tsvector('simple'::regconfig, COALESCE(flow_nodes.name, ''::text)) AS name_tsvector,
             node_types.name AS node_type,
-                CASE
-                    WHEN ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text)) THEN cnt.profile
-                    ELSE NULL::text
-                END AS profile
-           FROM (((((flow_nodes
-             JOIN public.nodes ON ((nodes.id = flow_nodes.node_id)))
-             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
-             JOIN public.node_types ON ((node_types.id = nodes.node_type_id)))
-             JOIN active_cnt cnt ON (((cnt.context_id = flow_nodes.context_id) AND ((cnt.column_position + 1) = flow_nodes."position"))))
-             JOIN public.contexts ON (((contexts.id = flow_nodes.context_id) AND (contexts.id = cnt.context_id))))
-          WHERE ((cnt.role)::text = 'importer'::text)
+            flow_nodes.profile,
+            ranked_nodes.rank_by_year
+           FROM (((all_flow_nodes flow_nodes
+             JOIN public.node_types ON ((node_types.id = flow_nodes.node_type_id)))
+             JOIN public.contexts ON ((contexts.id = flow_nodes.context_id)))
+             JOIN public.nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes ON (((flow_nodes.context_id = ranked_nodes.context_id) AND (flow_nodes.node_id = ranked_nodes.node_id))))
+          WHERE ((flow_nodes.role)::text = 'importer'::text)
         )
  SELECT ffn.node_id AS id,
     ffn.node_type_id,
@@ -3632,11 +3666,12 @@ CREATE MATERIALIZED VIEW public.dashboards_importers_mv AS
     ffn.name,
     ffn.name_tsvector,
     ffn.node_type,
-    ffn.profile
+    ffn.profile,
+    ffn.rank_by_year
    FROM (filtered_flow_nodes ffn
-     JOIN flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
+     JOIN all_flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
   WHERE (ffn.node_id <> fn.node_id)
-  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile
+  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile, ffn.rank_by_year
   WITH NO DATA;
 
 
@@ -3702,46 +3737,38 @@ ALTER SEQUENCE public.dashboards_quants_id_seq OWNED BY public.dashboards_quants
 --
 
 CREATE MATERIALIZED VIEW public.dashboards_sources_mv AS
- WITH active_cnt AS (
-         SELECT cnt.context_id,
-            cnt.column_position,
+ WITH all_flow_nodes AS (
+         SELECT flow_nodes.flow_id,
+            flow_nodes.node_id,
+            flow_nodes.context_id,
+            nodes.node_type_id,
+            btrim(nodes.name) AS name,
             cnt_props.role,
             profiles.name AS profile
-           FROM ((public.context_node_types cnt
+           FROM (((((public.flow_nodes_mv flow_nodes
+             JOIN public.nodes ON ((flow_nodes.node_id = nodes.id)))
+             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
+             JOIN public.context_node_types cnt ON (((flow_nodes.context_id = cnt.context_id) AND (flow_nodes."position" = (cnt.column_position + 1)) AND (nodes.node_type_id = cnt.node_type_id))))
              JOIN public.context_node_type_properties cnt_props ON ((cnt.id = cnt_props.context_node_type_id)))
              LEFT JOIN public.profiles ON ((cnt.id = profiles.context_node_type_id)))
-          WHERE (cnt_props.role IS NOT NULL)
-        ), flow_nodes AS (
-         SELECT flow_nodes.context_id,
-            flow_nodes.flow_id,
-            flow_nodes.node_id,
-            flow_nodes."position"
-           FROM (( SELECT flow_nodes_mv.context_id,
-                    flow_nodes_mv.flow_id,
-                    flow_nodes_mv.node_id,
-                    flow_nodes_mv."position"
-                   FROM public.flow_nodes_mv) flow_nodes
-             JOIN active_cnt ON (((flow_nodes.context_id = active_cnt.context_id) AND (flow_nodes."position" = (active_cnt.column_position + 1)))))
+          WHERE ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text))
         ), filtered_flow_nodes AS (
          SELECT flow_nodes.flow_id,
             flow_nodes.node_id,
-            nodes.node_type_id,
+            flow_nodes.context_id,
+            flow_nodes.node_type_id,
             contexts.country_id,
             contexts.commodity_id,
-            btrim(nodes.name) AS name,
-            to_tsvector('simple'::regconfig, COALESCE(btrim(nodes.name), ''::text)) AS name_tsvector,
+            flow_nodes.name,
+            to_tsvector('simple'::regconfig, COALESCE(flow_nodes.name, ''::text)) AS name_tsvector,
             node_types.name AS node_type,
-                CASE
-                    WHEN ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text)) THEN cnt.profile
-                    ELSE NULL::text
-                END AS profile
-           FROM (((((flow_nodes
-             JOIN public.nodes ON ((nodes.id = flow_nodes.node_id)))
-             JOIN public.node_properties ON ((nodes.id = node_properties.node_id)))
-             JOIN public.node_types ON ((node_types.id = nodes.node_type_id)))
-             JOIN active_cnt cnt ON (((cnt.context_id = flow_nodes.context_id) AND ((cnt.column_position + 1) = flow_nodes."position"))))
-             JOIN public.contexts ON (((contexts.id = flow_nodes.context_id) AND (contexts.id = cnt.context_id))))
-          WHERE ((cnt.role)::text = 'source'::text)
+            flow_nodes.profile,
+            ranked_nodes.rank_by_year
+           FROM (((all_flow_nodes flow_nodes
+             JOIN public.node_types ON ((node_types.id = flow_nodes.node_type_id)))
+             JOIN public.contexts ON ((contexts.id = flow_nodes.context_id)))
+             JOIN public.nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes ON (((flow_nodes.context_id = ranked_nodes.context_id) AND (flow_nodes.node_id = ranked_nodes.node_id))))
+          WHERE ((flow_nodes.role)::text = 'source'::text)
         )
  SELECT ffn.node_id AS id,
     ffn.node_type_id,
@@ -3751,11 +3778,12 @@ CREATE MATERIALIZED VIEW public.dashboards_sources_mv AS
     ffn.name,
     ffn.name_tsvector,
     ffn.node_type,
-    ffn.profile
+    ffn.profile,
+    ffn.rank_by_year
    FROM (filtered_flow_nodes ffn
-     JOIN flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
+     JOIN all_flow_nodes fn ON ((ffn.flow_id = fn.flow_id)))
   WHERE (ffn.node_id <> fn.node_id)
-  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile
+  GROUP BY ffn.node_id, ffn.node_type_id, ffn.country_id, ffn.commodity_id, fn.node_id, ffn.name, ffn.name_tsvector, ffn.node_type, ffn.profile, ffn.rank_by_year
   WITH NO DATA;
 
 
@@ -4160,33 +4188,6 @@ COMMENT ON TABLE public.flow_quals IS 'Values of quals for flow';
 --
 
 COMMENT ON COLUMN public.flow_quals.value IS 'Textual value';
-
-
---
--- Name: flow_quants; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.flow_quants (
-    id integer NOT NULL,
-    flow_id integer NOT NULL,
-    quant_id integer NOT NULL,
-    value double precision NOT NULL,
-    created_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: TABLE flow_quants; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON TABLE public.flow_quants IS 'Values of quants for flow';
-
-
---
--- Name: COLUMN flow_quants.value; Type: COMMENT; Schema: public; Owner: -
---
-
-COMMENT ON COLUMN public.flow_quants.value IS 'Numeric value';
 
 
 --
@@ -5276,35 +5277,6 @@ CREATE MATERIALIZED VIEW public.nodes_mv AS
      JOIN public.context_node_type_properties ON ((context_node_type_properties.context_node_type_id = context_node_types.id)))
      LEFT JOIN public.profiles ON ((profiles.context_node_type_id = context_node_types.id)))
   WHERE ((nodes.is_unknown = false) AND (node_properties.is_domestic_consumption = false) AND (nodes.name !~~* 'OTHER'::text))
-  WITH NO DATA;
-
-
---
--- Name: nodes_per_context_ranked_by_volume_per_year_mv; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW public.nodes_per_context_ranked_by_volume_per_year_mv AS
- SELECT node_volume_per_context_and_year_ranked.context_id,
-    node_volume_per_context_and_year_ranked.node_id,
-    jsonb_object_agg(node_volume_per_context_and_year_ranked.year, node_volume_per_context_and_year_ranked.rank) AS rank_by_year
-   FROM ( SELECT node_volume_per_context_and_year.node_id,
-            node_volume_per_context_and_year."position",
-            node_volume_per_context_and_year.context_id,
-            node_volume_per_context_and_year.year,
-            rank() OVER (PARTITION BY node_volume_per_context_and_year."position", node_volume_per_context_and_year.context_id, node_volume_per_context_and_year.year ORDER BY node_volume_per_context_and_year.value DESC) AS rank
-           FROM ( SELECT a.node_id,
-                    a."position",
-                    flows.context_id,
-                    flows.year,
-                    sum(flow_quants.value) AS value
-                   FROM public.flow_quants,
-                    public.flows,
-                    LATERAL unnest(flows.path) WITH ORDINALITY a(node_id, "position")
-                  WHERE ((flow_quants.flow_id = flows.id) AND (flow_quants.quant_id IN ( SELECT quants.id
-                           FROM public.quants
-                          WHERE (quants.name = 'Volume'::text))))
-                  GROUP BY a.node_id, a."position", flows.context_id, flows.year) node_volume_per_context_and_year) node_volume_per_context_and_year_ranked
-  GROUP BY node_volume_per_context_and_year_ranked.context_id, node_volume_per_context_and_year_ranked.node_id
   WITH NO DATA;
 
 
@@ -9999,6 +9971,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191014111756'),
 ('20191015095615'),
 ('20191021084412'),
-('20191028134448');
+('20191028134448'),
+('20191028134449');
 
 

--- a/db/views/dashboards_destinations_mv_v08.sql
+++ b/db/views/dashboards_destinations_mv_v08.sql
@@ -1,0 +1,72 @@
+WITH all_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    nodes.node_type_id,
+    TRIM(nodes.name) AS name,
+    cnt_props.role,
+    profiles.name AS profile
+  FROM flow_nodes_mv flow_nodes
+  JOIN nodes ON flow_nodes.node_id = nodes.id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN context_node_types cnt ON flow_nodes.context_id = cnt.context_id
+    AND flow_nodes.position = cnt.column_position + 1
+    AND nodes.node_type_id = cnt.node_type_id
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  -- exclude unknowns and other placeholders; this mview is for filtering only
+  WHERE nodes.is_unknown = FALSE
+    AND node_properties.is_domestic_consumption = FALSE
+    AND nodes.name NOT ILIKE 'OTHER'
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    flow_nodes.node_type_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    flow_nodes.name,
+    TO_TSVECTOR('simple', COALESCE(flow_nodes.name, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    profile,
+    ranked_nodes.rank_by_year
+  FROM all_flow_nodes flow_nodes
+  JOIN node_types ON node_types.id = flow_nodes.node_type_id
+  JOIN contexts ON contexts.id = flow_nodes.context_id
+  JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+    ON flow_nodes.context_id = ranked_nodes.context_id
+    AND flow_nodes.node_id = ranked_nodes.node_id
+  WHERE role = 'destination'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+FROM filtered_flow_nodes ffn
+JOIN all_flow_nodes fn
+  ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+);

--- a/db/views/dashboards_exporters_mv_v02.sql
+++ b/db/views/dashboards_exporters_mv_v02.sql
@@ -1,0 +1,72 @@
+WITH all_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    nodes.node_type_id,
+    TRIM(nodes.name) AS name,
+    cnt_props.role,
+    profiles.name AS profile
+  FROM flow_nodes_mv flow_nodes
+  JOIN nodes ON flow_nodes.node_id = nodes.id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN context_node_types cnt ON flow_nodes.context_id = cnt.context_id
+    AND flow_nodes.position = cnt.column_position + 1
+    AND nodes.node_type_id = cnt.node_type_id
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  -- exclude unknowns and other placeholders; this mview is for filtering only
+  WHERE nodes.is_unknown = FALSE
+    AND node_properties.is_domestic_consumption = FALSE
+    AND nodes.name NOT ILIKE 'OTHER'
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    flow_nodes.node_type_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    flow_nodes.name,
+    TO_TSVECTOR('simple', COALESCE(flow_nodes.name, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    profile,
+    ranked_nodes.rank_by_year
+  FROM all_flow_nodes flow_nodes
+  JOIN node_types ON node_types.id = flow_nodes.node_type_id
+  JOIN contexts ON contexts.id = flow_nodes.context_id
+  JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+    ON flow_nodes.context_id = ranked_nodes.context_id
+    AND flow_nodes.node_id = ranked_nodes.node_id
+  WHERE role = 'exporter'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+FROM filtered_flow_nodes ffn
+JOIN all_flow_nodes fn
+  ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+);

--- a/db/views/dashboards_importers_mv_v02.sql
+++ b/db/views/dashboards_importers_mv_v02.sql
@@ -1,0 +1,72 @@
+WITH all_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    nodes.node_type_id,
+    TRIM(nodes.name) AS name,
+    cnt_props.role,
+    profiles.name AS profile
+  FROM flow_nodes_mv flow_nodes
+  JOIN nodes ON flow_nodes.node_id = nodes.id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN context_node_types cnt ON flow_nodes.context_id = cnt.context_id
+    AND flow_nodes.position = cnt.column_position + 1
+    AND nodes.node_type_id = cnt.node_type_id
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  -- exclude unknowns and other placeholders; this mview is for filtering only
+  WHERE nodes.is_unknown = FALSE
+    AND node_properties.is_domestic_consumption = FALSE
+    AND nodes.name NOT ILIKE 'OTHER'
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    flow_nodes.node_type_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    flow_nodes.name,
+    TO_TSVECTOR('simple', COALESCE(flow_nodes.name, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    profile,
+    ranked_nodes.rank_by_year
+  FROM all_flow_nodes flow_nodes
+  JOIN node_types ON node_types.id = flow_nodes.node_type_id
+  JOIN contexts ON contexts.id = flow_nodes.context_id
+  JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+    ON flow_nodes.context_id = ranked_nodes.context_id
+    AND flow_nodes.node_id = ranked_nodes.node_id
+  WHERE role = 'importer'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+FROM filtered_flow_nodes ffn
+JOIN all_flow_nodes fn
+  ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+);

--- a/db/views/dashboards_sources_mv_v09.sql
+++ b/db/views/dashboards_sources_mv_v09.sql
@@ -1,0 +1,72 @@
+WITH all_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    nodes.node_type_id,
+    TRIM(nodes.name) AS name,
+    cnt_props.role,
+    profiles.name AS profile
+  FROM flow_nodes_mv flow_nodes
+  JOIN nodes ON flow_nodes.node_id = nodes.id
+  JOIN node_properties ON nodes.id = node_properties.node_id
+  JOIN context_node_types cnt ON flow_nodes.context_id = cnt.context_id
+    AND flow_nodes.position = cnt.column_position + 1
+    AND nodes.node_type_id = cnt.node_type_id
+  JOIN context_node_type_properties cnt_props ON cnt.id = cnt_props.context_node_type_id
+  LEFT JOIN profiles ON cnt.id = profiles.context_node_type_id
+  -- exclude unknowns and other placeholders; this mview is for filtering only
+  WHERE nodes.is_unknown = FALSE
+    AND node_properties.is_domestic_consumption = FALSE
+    AND nodes.name NOT ILIKE 'OTHER'
+), filtered_flow_nodes AS (
+  SELECT
+    -- fixed width first
+    flow_nodes.flow_id,
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    flow_nodes.node_type_id,
+    contexts.country_id,
+    contexts.commodity_id,
+    flow_nodes.name,
+    TO_TSVECTOR('simple', COALESCE(flow_nodes.name, '')) AS name_tsvector,
+    node_types.name AS node_type,
+    profile,
+    ranked_nodes.rank_by_year
+  FROM all_flow_nodes flow_nodes
+  JOIN node_types ON node_types.id = flow_nodes.node_type_id
+  JOIN contexts ON contexts.id = flow_nodes.context_id
+  JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+    ON flow_nodes.context_id = ranked_nodes.context_id
+    AND flow_nodes.node_id = ranked_nodes.node_id
+  WHERE role = 'source'
+)
+SELECT
+  -- fixed width first
+  ffn.node_id AS id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+FROM filtered_flow_nodes ffn
+JOIN all_flow_nodes fn
+  ON ffn.flow_id = fn.flow_id
+WHERE ffn.node_id <> fn.node_id
+GROUP BY (
+  ffn.node_id,
+  ffn.node_type_id,
+  ffn.country_id,
+  ffn.commodity_id,
+  fn.node_id,
+  ffn.name,
+  ffn.name_tsvector,
+  ffn.node_type,
+  ffn.profile,
+  ffn.rank_by_year
+);

--- a/db/views/nodes_mv_v09.sql
+++ b/db/views/nodes_mv_v09.sql
@@ -13,6 +13,7 @@ SELECT
   nodes_with_flows.years
 FROM nodes
 JOIN (
+  -- might be an idea to use flow_nodes_mv here
   SELECT (UNNEST(path)) AS node_id, context_id, ARRAY_AGG(DISTINCT year ORDER BY year) AS years
   FROM flows
   GROUP BY UNNEST(path), context_id

--- a/db/views/nodes_per_context_ranked_by_volume_per_year_mv_v01.sql
+++ b/db/views/nodes_per_context_ranked_by_volume_per_year_mv_v01.sql
@@ -1,0 +1,31 @@
+SELECT
+  context_id,
+  node_id,
+  JSONB_OBJECT_AGG(year, rank) AS rank_by_year
+FROM (
+  SELECT
+  node_id,
+  position,
+  context_id,
+  year,
+  RANK() OVER (PARTITION BY position, context_id, year ORDER BY value DESC) AS rank
+  FROM (
+    SELECT
+      a.node_id,
+      a.position,
+      context_id,
+      year,
+      SUM(value) AS value
+    FROM flow_quants,
+    flows,
+    LATERAL unnest(flows.path) WITH ORDINALITY a(node_id, "position")
+    WHERE flow_quants.flow_id = flows.id
+    AND flow_quants.quant_id IN (SELECT id FROM quants WHERE name = 'Volume')
+    GROUP BY
+      a.node_id,
+      a.position,
+      flows.context_id,
+      flows.year
+  ) node_volume_per_context_and_year
+) node_volume_per_context_and_year_ranked
+GROUP BY context_id, node_id;

--- a/frontend/docs/swagger.yaml
+++ b/frontend/docs/swagger.yaml
@@ -915,6 +915,9 @@ paths:
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/profile_only"
+        - $ref: "#/components/parameters/start_year_opt_query_param"
+        - $ref: "#/components/parameters/end_year_opt_query_param"
+        - $ref: "#/components/parameters/order_by_opt_query_param"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -1037,6 +1040,9 @@ paths:
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/profile_only"
+        - $ref: "#/components/parameters/start_year_opt_query_param"
+        - $ref: "#/components/parameters/end_year_opt_query_param"
+        - $ref: "#/components/parameters/order_by_opt_query_param"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -1097,6 +1103,9 @@ paths:
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
         - $ref: "#/components/parameters/profile_only"
+        - $ref: "#/components/parameters/start_year_opt_query_param"
+        - $ref: "#/components/parameters/end_year_opt_query_param"
+        - $ref: "#/components/parameters/order_by_opt_query_param"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -1156,6 +1165,9 @@ paths:
         - $ref: "#/components/parameters/dashboards_importers_ids"
         - $ref: "#/components/parameters/dashboards_destinations_ids"
         - $ref: "#/components/parameters/node_types_ids"
+        - $ref: "#/components/parameters/start_year_opt_query_param"
+        - $ref: "#/components/parameters/end_year_opt_query_param"
+        - $ref: "#/components/parameters/order_by_opt_query_param"
         - $ref: "#/components/parameters/page"
         - $ref: "#/components/parameters/per_page"
       responses:
@@ -1911,6 +1923,13 @@ components:
       required: false
       schema:
         type: integer
+    order_by_opt_query_param:
+      name: order_by
+      in: query
+      required: false
+      schema:
+        type: string
+        example: volume
     node_id_req_query_param:
       name: node_id
       in: query

--- a/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
       [
         api_v3_exporter1_node,
         api_v3_importer1_node,
-        api_v3_other_exporter_node,
-        api_v3_other_importer_node
+        api_v3_exporter2_node,
+        api_v3_importer2_node
       ]
     }
 
@@ -65,7 +65,7 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
           node_types_ids: [api_v3_exporter_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+          [api_v3_exporter1_node.id, api_v3_exporter2_node.id]
         )
       end
 
@@ -77,7 +77,7 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
           node_types_ids: [api_v3_exporter_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+          [api_v3_exporter1_node.id, api_v3_exporter2_node.id]
         )
       end
 
@@ -98,12 +98,12 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
         get :index, params: {
           destinations_ids: [
             api_v3_country_of_destination1_node.id,
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ].join(','),
           node_types_ids: [api_v3_exporter_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+          [api_v3_exporter1_node.id, api_v3_exporter2_node.id]
         )
       end
     end
@@ -119,7 +119,12 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
       it 'returns companies with profiles' do
         get :index, params: {profile_only: true}
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id, api_v3_importer1_node.id]
+          [
+            api_v3_exporter1_node.id,
+            api_v3_importer1_node.id,
+            api_v3_exporter2_node.id,
+            api_v3_importer2_node.id
+          ]
         )
       end
     end

--- a/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe Api::V3::Dashboards::DestinationsController, type: :controller do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Destination.refresh(sync: true, skip_dependencies: true)
   end
 
@@ -25,7 +28,7 @@ RSpec.describe Api::V3::Dashboards::DestinationsController, type: :controller do
   describe 'GET index' do
     let(:all_results_alphabetically) {
       [
-        api_v3_other_country_of_destination_node,
+        api_v3_country_of_destination2_node,
         api_v3_country_of_destination1_node
       ]
     }
@@ -59,9 +62,9 @@ RSpec.describe Api::V3::Dashboards::DestinationsController, type: :controller do
     it 'allows multiple destinations selection' do
       get :index, params: {
         countries_ids: [api_v3_brazil.id].join(','),
-        destinations_ids: [api_v3_country_of_destination1_node.id, api_v3_other_country_of_destination_node.id].join(',')
+        destinations_ids: [api_v3_country_of_destination1_node.id, api_v3_country_of_destination2_node.id].join(',')
       }
-      expect(assigns(:collection).map(&:id)).to eq([api_v3_other_country_of_destination_node.id, api_v3_country_of_destination1_node.id])
+      expect(assigns(:collection).map(&:id)).to eq([api_v3_country_of_destination2_node.id, api_v3_country_of_destination1_node.id])
     end
   end
 end

--- a/spec/controllers/api/v3/dashboards/exporters_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/exporters_controller_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Exporter.refresh(sync: true, skip_dependencies: true)
   end
 
@@ -28,7 +31,7 @@ RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
     let(:all_results_alphabetically) {
       [
         api_v3_exporter1_node,
-        api_v3_other_exporter_node
+        api_v3_exporter2_node
       ]
     }
 
@@ -62,7 +65,7 @@ RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
           node_types_ids: [api_v3_exporter_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+          [api_v3_exporter1_node.id, api_v3_exporter2_node.id]
         )
       end
 
@@ -74,7 +77,7 @@ RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
           node_types_ids: [api_v3_exporter_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+          [api_v3_exporter1_node.id, api_v3_exporter2_node.id]
         )
       end
 
@@ -95,12 +98,12 @@ RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
         get :index, params: {
           destinations_ids: [
             api_v3_country_of_destination1_node.id,
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ].join(','),
           node_types_ids: [api_v3_exporter_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id, api_v3_other_exporter_node.id]
+          [api_v3_exporter1_node.id, api_v3_exporter2_node.id]
         )
       end
     end
@@ -116,7 +119,7 @@ RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
       it 'returns companies with profiles' do
         get :index, params: {profile_only: true}
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_exporter1_node.id]
+          [api_v3_exporter1_node.id, api_v3_exporter2_node.id]
         )
       end
     end

--- a/spec/controllers/api/v3/dashboards/importers_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/importers_controller_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Importer.refresh(sync: true, skip_dependencies: true)
   end
 
@@ -28,7 +31,7 @@ RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
     let(:all_results_alphabetically) {
       [
         api_v3_importer1_node,
-        api_v3_other_importer_node
+        api_v3_importer2_node
       ]
     }
 
@@ -62,7 +65,7 @@ RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
           node_types_ids: [api_v3_importer_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_importer1_node.id, api_v3_other_importer_node.id]
+          [api_v3_importer1_node.id, api_v3_importer2_node.id]
         )
       end
 
@@ -74,7 +77,7 @@ RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
           node_types_ids: [api_v3_importer_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_importer1_node.id, api_v3_other_importer_node.id]
+          [api_v3_importer1_node.id, api_v3_importer2_node.id]
         )
       end
 
@@ -95,12 +98,12 @@ RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
         get :index, params: {
           destinations_ids: [
             api_v3_country_of_destination1_node.id,
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ].join(','),
           node_types_ids: [api_v3_importer_node_type.id].join(',')
         }
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_importer1_node.id, api_v3_other_importer_node.id]
+          [api_v3_importer1_node.id, api_v3_importer2_node.id]
         )
       end
     end
@@ -116,7 +119,7 @@ RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
       it 'returns companies with profiles' do
         get :index, params: {profile_only: true}
         expect(assigns(:collection).map(&:id)).to eq(
-          [api_v3_importer1_node.id]
+          [api_v3_importer1_node.id, api_v3_importer2_node.id]
         )
       end
     end

--- a/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Api::V3::Dashboards::SourcesController, type: :controller do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Source.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/responses/api/v3/dashboards/destinations_spec.rb
+++ b/spec/responses/api/v3/dashboards/destinations_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe 'destinations', type: :request do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Destination.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/responses/api/v3/dashboards/exporters_spec.rb
+++ b/spec/responses/api/v3/dashboards/exporters_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe 'Exporters', type: :request do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Exporter.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/responses/api/v3/dashboards/importers_spec.rb
+++ b/spec/responses/api/v3/dashboards/importers_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe 'Importers', type: :request do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Importer.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/responses/api/v3/dashboards/sources_spec.rb
+++ b/spec/responses/api/v3/dashboards/sources_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe 'sources', type: :request do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Source.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/responses/api/v3/dashboards/templates_spec.rb
+++ b/spec/responses/api/v3/dashboards/templates_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe 'Templates', type: :request do
       )
       Api::V3::Readonly::Dashboards::Commodity.refresh(sync: true, skip_dependencies: true)
       Api::V3::Readonly::Dashboards::Country.refresh(sync: true, skip_dependencies: true)
+      Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+        sync: true, skip_dependencies: true, skip_dependents: true
+      )
       Api::V3::Readonly::Dashboards::Source.refresh(sync: true, skip_dependencies: true)
       Api::V3::Readonly::Dashboards::Company.refresh(sync: true, skip_dependencies: true)
       Api::V3::Readonly::Dashboards::Destination.refresh(sync: true, skip_dependencies: true)

--- a/spec/responses/api/v3/nodes_stats_spec.rb
+++ b/spec/responses/api/v3/nodes_stats_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Nodes stats', type: :request do
           parsed_response['data'].first['top_nodes'].map { |a| a['id'] }
         expect(nodes_ids).to eql([
           api_v3_country_of_destination1_node.id,
-          api_v3_other_country_of_destination_node.id
+          api_v3_country_of_destination2_node.id
         ])
       end
     end
@@ -51,7 +51,7 @@ RSpec.describe 'Nodes stats', type: :request do
           parsed_response['data'].first['top_nodes'].map { |a| a['id'] }
         expect(nodes_ids).to eql([
           api_v3_country_of_destination1_node.id,
-          api_v3_other_country_of_destination_node.id
+          api_v3_country_of_destination2_node.id
         ])
       end
     end
@@ -74,7 +74,7 @@ RSpec.describe 'Nodes stats', type: :request do
           parsed_response['data'].first['top_nodes'].map { |a| a['id'] }
         expect(nodes_ids).to eql([
           api_v3_country_of_destination1_node.id,
-          api_v3_other_country_of_destination_node.id
+          api_v3_country_of_destination2_node.id
         ])
       end
     end

--- a/spec/services/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNcontOverview do
 
     context 'when filtered by 1 exporter' do
       let(:parameters_hash) {
-        shared_parameters_hash.merge(companies_ids: [api_v3_other_exporter_node.id])
+        shared_parameters_hash.merge(companies_ids: [api_v3_exporter2_node.id])
       }
       it 'summarized flows matching exporter per ncont' do
         expect(data.size).to eq(1)
@@ -65,7 +65,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
       }
@@ -80,7 +80,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+            api_v3_exporter2_node.id, api_v3_importer1_node.id
           ]
         )
       }
@@ -96,9 +96,9 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNcontOverview do
         shared_parameters_hash.merge(
           companies_ids: [
             api_v3_exporter1_node.id,
-            api_v3_other_exporter_node.id,
+            api_v3_exporter2_node.id,
             api_v3_importer1_node.id,
-            api_v3_other_importer_node.id
+            api_v3_importer2_node.id
           ]
         )
       }

--- a/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_node_type_view_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontNodeTypeView do
 
   let(:other_exporter_idx) {
     result[:meta].each do |meta_key, meta|
-      break meta_key if meta[:label] == api_v3_other_exporter_node.name
+      break meta_key if meta[:label] == api_v3_exporter2_node.name
     end
   }
 
@@ -120,7 +120,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontNodeTypeView do
         shared_parameters_hash.merge(
           companies_ids: [api_v3_exporter1_node.id],
           excluded_destinations_ids: [
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ]
         )
       }
@@ -136,7 +136,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontNodeTypeView do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
       }
@@ -152,7 +152,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontNodeTypeView do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+            api_v3_exporter2_node.id, api_v3_importer1_node.id
           ]
         )
       }
@@ -169,9 +169,9 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontNodeTypeView do
         shared_parameters_hash.merge(
           companies_ids: [
             api_v3_exporter1_node.id,
-            api_v3_other_exporter_node.id,
+            api_v3_exporter2_node.id,
             api_v3_importer1_node.id,
-            api_v3_other_importer_node.id
+            api_v3_importer2_node.id
           ]
         )
       }

--- a/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_no_ncont_overview_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontOverview do
         shared_parameters_hash.merge(
           companies_ids: [api_v3_exporter1_node.id],
           excluded_destinations_ids: [
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ]
         )
       }
@@ -74,7 +74,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
       }
@@ -89,7 +89,7 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+            api_v3_exporter2_node.id, api_v3_importer1_node.id
           ]
         )
       }
@@ -105,9 +105,9 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNoNcontOverview do
         shared_parameters_hash.merge(
           companies_ids: [
             api_v3_exporter1_node.id,
-            api_v3_other_exporter_node.id,
+            api_v3_exporter2_node.id,
             api_v3_importer1_node.id,
-            api_v3_other_importer_node.id
+            api_v3_importer2_node.id
           ]
         )
       }

--- a/spec/services/api/v3/dashboards/charts/single_year_ncont_node_type_view_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_ncont_node_type_view_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
         shared_parameters_hash.merge(
           companies_ids: [api_v3_exporter1_node.id],
           excluded_destinations_ids: [
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ]
         )
       }
@@ -80,7 +80,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
       }
@@ -94,7 +94,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+            api_v3_exporter2_node.id, api_v3_importer1_node.id
           ]
         )
       }
@@ -110,9 +110,9 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
         shared_parameters_hash.merge(
           companies_ids: [
             api_v3_exporter1_node.id,
-            api_v3_other_exporter_node.id,
+            api_v3_exporter2_node.id,
             api_v3_importer1_node.id,
-            api_v3_other_importer_node.id
+            api_v3_importer2_node.id
           ]
         )
       }

--- a/spec/services/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_ncont_overview_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontOverview do
         shared_parameters_hash.merge(
           companies_ids: [api_v3_exporter1_node.id],
           excluded_destinations_ids: [
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ]
         )
       }
@@ -79,7 +79,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
       }
@@ -93,7 +93,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+            api_v3_exporter2_node.id, api_v3_importer1_node.id
           ]
         )
       }
@@ -108,9 +108,9 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontOverview do
         shared_parameters_hash.merge(
           companies_ids: [
             api_v3_exporter1_node.id,
-            api_v3_other_exporter_node.id,
+            api_v3_exporter2_node.id,
             api_v3_importer1_node.id,
-            api_v3_other_importer_node.id
+            api_v3_importer2_node.id
           ]
         )
       }

--- a/spec/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_no_ncont_node_type_view_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontNodeTypeView do
         shared_parameters_hash.merge(
           companies_ids: [api_v3_exporter1_node.id],
           excluded_destinations_ids: [
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ]
         )
       }
@@ -119,7 +119,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontNodeTypeView do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
       }
@@ -132,7 +132,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontNodeTypeView do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+            api_v3_exporter2_node.id, api_v3_importer1_node.id
           ]
         )
       }
@@ -146,9 +146,9 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontNodeTypeView do
         shared_parameters_hash.merge(
           companies_ids: [
             api_v3_exporter1_node.id,
-            api_v3_other_exporter_node.id,
+            api_v3_exporter2_node.id,
             api_v3_importer1_node.id,
-            api_v3_other_importer_node.id
+            api_v3_importer2_node.id
           ]
         )
       }

--- a/spec/services/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_no_ncont_overview_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontOverview do
         shared_parameters_hash.merge(
           companies_ids: [api_v3_exporter1_node.id],
           excluded_destinations_ids: [
-            api_v3_other_country_of_destination_node.id
+            api_v3_country_of_destination2_node.id
           ]
         )
       }
@@ -67,7 +67,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
       }
@@ -80,7 +80,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontOverview do
       let(:parameters_hash) {
         shared_parameters_hash.merge(
           companies_ids: [
-            api_v3_other_exporter_node.id, api_v3_importer1_node.id
+            api_v3_exporter2_node.id, api_v3_importer1_node.id
           ]
         )
       }
@@ -94,9 +94,9 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNoNcontOverview do
         shared_parameters_hash.merge(
           companies_ids: [
             api_v3_exporter1_node.id,
-            api_v3_other_exporter_node.id,
+            api_v3_exporter2_node.id,
             api_v3_importer1_node.id,
-            api_v3_other_importer_node.id
+            api_v3_importer2_node.id
           ]
         )
       }

--- a/spec/services/api/v3/dashboards/filter_destinations_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_destinations_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::FilterDestinations do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil soy goias flows'
+  include_context 'api v3 paraguay flows'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 paraguay flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Destination.refresh(
+      sync: true, skip_dependencies: true
+    )
+  end
+
+  describe :call do
+    context 'when ordering by volume in single year' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterDestinations.new(
+          node_types_ids: [api_v3_country_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015
+        )
+      }
+      it 'orders top destination first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_country_of_destination1_node.name)
+      end
+    end
+    context 'when ordering by volume in year range' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterDestinations.new(
+          node_types_ids: [api_v3_country_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015,
+          end_year: 2016
+        )
+      }
+      it 'orders top destination first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_country_of_destination1_node.name)
+      end
+    end
+    context 'when ordering by name' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterDestinations.new(
+          node_types_ids: [api_v3_country_node_type.id],
+          order_by: 'name',
+          start_year: 2015
+        )
+      }
+      it 'orders alphabetically' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_paraguay_country_node.name)
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/filter_exporters_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_exporters_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::FilterExporters do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil soy goias flows'
+  include_context 'api v3 paraguay flows'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 paraguay flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Exporter.refresh(
+      sync: true, skip_dependencies: true
+    )
+  end
+
+  describe :call do
+    context 'when ordering by volume in single year' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterExporters.new(
+          node_types_ids: [api_v3_exporter_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015
+        )
+      }
+      it 'orders top exporter first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_exporter1_node.name)
+      end
+    end
+    context 'when ordering by volume in year range' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterExporters.new(
+          node_types_ids: [api_v3_exporter_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015,
+          end_year: 2016
+        )
+      }
+      it 'orders top exporter first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_exporter1_node.name)
+      end
+    end
+    context 'when ordering by name' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterExporters.new(
+          node_types_ids: [api_v3_exporter_node_type.id],
+          order_by: 'name',
+          start_year: 2015
+        )
+      }
+      it 'orders alphabetically' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_exporter1_node.name)
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/filter_importers_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_importers_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::Dashboards::FilterImporters do
+  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil soy goias flows'
+  include_context 'api v3 paraguay flows'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 paraguay flows quants'
+
+  before(:each) do
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Importer.refresh(
+      sync: true, skip_dependencies: true
+    )
+  end
+
+  describe :call do
+    context 'when ordering by volume in single year' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterImporters.new(
+          node_types_ids: [api_v3_importer_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015
+        )
+      }
+      it 'orders top exporter first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_importer1_node.name)
+      end
+    end
+    context 'when ordering by volume in year range' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterImporters.new(
+          node_types_ids: [api_v3_importer_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015,
+          end_year: 2016
+        )
+      }
+      it 'orders top exporter first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_importer1_node.name)
+      end
+    end
+    context 'when ordering by name' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterImporters.new(
+          node_types_ids: [api_v3_importer_node_type.id],
+          order_by: 'name',
+          start_year: 2015
+        )
+      }
+      it 'orders alphabetically' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_importer1_node.name)
+      end
+    end
+  end
+end

--- a/spec/services/api/v3/dashboards/filter_sources_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_sources_spec.rb
@@ -4,12 +4,19 @@ RSpec.describe Api::V3::Dashboards::FilterSources do
   include_context 'api v3 brazil flows'
   include_context 'api v3 brazil soy goias flows'
   include_context 'api v3 paraguay flows'
+  include_context 'api v3 brazil flows quants'
+  include_context 'api v3 paraguay flows quants'
 
   before(:each) do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
-    Api::V3::Readonly::Dashboards::Source.refresh(sync: true)
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::Dashboards::Source.refresh(
+      sync: true, skip_dependencies: true
+    )
   end
 
   describe :call do
@@ -33,6 +40,50 @@ RSpec.describe Api::V3::Dashboards::FilterSources do
         )
       }
       it 'filters by node id' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_municipality_abadia_de_goias.name)
+      end
+    end
+    context 'when ordering by volume in single year' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterSources.new(
+          node_types_ids: [api_v3_municipality_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015
+        )
+      }
+      it 'orders top source first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_municipality_node.name)
+      end
+    end
+    context 'when ordering by volume in year range' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterSources.new(
+          node_types_ids: [api_v3_municipality_node_type.id],
+          order_by: 'volume',
+          countries_ids: [api_v3_brazil.id],
+          commodities_ids: [api_v3_soy.id],
+          start_year: 2015,
+          end_year: 2016
+        )
+      }
+      it 'orders top source first' do
+        nodes = filter.call
+        expect(nodes.first.name).to eq(api_v3_municipality_node.name)
+      end
+    end
+    context 'when ordering by name' do
+      let(:filter) {
+        Api::V3::Dashboards::FilterSources.new(
+          node_types_ids: [api_v3_municipality_node_type.id],
+          order_by: 'name',
+          start_year: 2015
+        )
+      }
+      it 'orders alphabetically' do
         nodes = filter.call
         expect(nodes.first.name).to eq(api_v3_municipality_abadia_de_goias.name)
       end

--- a/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
+++ b/spec/services/api/v3/dashboards/parametrised_charts/flow_values_spec.rb
@@ -462,7 +462,7 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
         merge(no_flow_path_filters).
         merge(
           companies_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
     }
@@ -491,10 +491,10 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
           x: :year,
           break_by: :ncont_attribute,
           node_type_id: api_v3_exporter_node_type.id,
-          companies_ids: [api_v3_other_exporter_node.id],
+          companies_ids: [api_v3_exporter2_node.id],
           single_filter_key: :companies,
           grouping_key: :cont_attribute_id,
-          grouping_label: api_v3_other_exporter_node.name
+          grouping_label: api_v3_exporter2_node.name
         }
       ] + [
         api_v3_biome_node_type,
@@ -532,7 +532,7 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
         merge(no_flow_path_filters).
         merge(
           exporters_ids: [
-            api_v3_exporter1_node.id, api_v3_other_exporter_node.id
+            api_v3_exporter1_node.id, api_v3_exporter2_node.id
           ]
         )
     }
@@ -561,10 +561,10 @@ RSpec.describe Api::V3::Dashboards::ParametrisedCharts::FlowValuesCharts do
           x: :year,
           break_by: :ncont_attribute,
           node_type_id: api_v3_exporter_node_type.id,
-          exporters_ids: [api_v3_other_exporter_node.id],
+          exporters_ids: [api_v3_exporter2_node.id],
           single_filter_key: :exporters,
           grouping_key: :cont_attribute_id,
-          grouping_label: api_v3_other_exporter_node.name
+          grouping_label: api_v3_exporter2_node.name
         }
       ] + [
         api_v3_biome_node_type,

--- a/spec/support/contexts/api/v3/brazil/brazil_flows.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows.rb
@@ -49,7 +49,7 @@ shared_context 'api v3 brazil flows' do
         api_v3_port1_node,
         api_v3_exporter1_node,
         api_v3_importer1_node,
-        api_v3_other_country_of_destination_node
+        api_v3_country_of_destination2_node
       ].map(&:id),
       year: 2015
     )
@@ -66,7 +66,7 @@ shared_context 'api v3 brazil flows' do
         api_v3_municipality_node,
         api_v3_logistics_hub_node,
         api_v3_port1_node,
-        api_v3_other_exporter_node,
+        api_v3_exporter2_node,
         api_v3_importer1_node,
         api_v3_country_of_destination1_node
       ].map(&:id),
@@ -86,7 +86,7 @@ shared_context 'api v3 brazil flows' do
         api_v3_logistics_hub_node,
         api_v3_port1_node,
         api_v3_exporter1_node,
-        api_v3_other_importer_node,
+        api_v3_importer2_node,
         api_v3_country_of_destination1_node
       ].map(&:id),
       year: 2015

--- a/spec/support/contexts/api/v3/brazil/brazil_flows_quants.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_flows_quants.rb
@@ -42,6 +42,14 @@ shared_context 'api v3 brazil flows quants' do
       value: 30
     )
   end
+  let!(:flow6_volume) do
+    FactoryBot.create(
+      :api_v3_flow_quant,
+      flow: api_v3_flow6,
+      quant: api_v3_volume,
+      value: 0
+    )
+  end
   let!(:flow1_deforestation_v2) do
     FactoryBot.create(
       :api_v3_flow_quant,

--- a/spec/support/contexts/api/v3/brazil/brazil_soy_goias_flows.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_soy_goias_flows.rb
@@ -1,4 +1,6 @@
 shared_context 'api v3 brazil soy goias flows' do
+  include_context 'api v3 quants'
+
   let!(:api_v3_municipality_goias) {
     name = 'GOIAS'
     node = Api::V3::Node.find_by(
@@ -72,6 +74,24 @@ shared_context 'api v3 brazil soy goias flows' do
         api_v3_country_of_destination1_node
       ].map(&:id),
       year: 2015
+    )
+  end
+
+  let!(:api_v3_goias_flow_volume) do
+    FactoryBot.create(
+      :api_v3_flow_quant,
+      flow: api_v3_goias_flow,
+      quant: api_v3_volume,
+      value: 10
+    )
+  end
+
+  let!(:api_v3_abadia_de_goias_flow_volume) do
+    FactoryBot.create(
+      :api_v3_flow_quant,
+      flow: api_v3_abadia_de_goias_flow,
+      quant: api_v3_volume,
+      value: 10
     )
   end
 end

--- a/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_soy_nodes.rb
@@ -133,6 +133,24 @@ shared_context 'api v3 brazil soy nodes' do
     node
   end
 
+  let!(:api_v3_exporter2_node) do
+    node = Api::V3::Node.where(
+      name: 'BUNGE EX', node_type_id: api_v3_exporter_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node,
+        name: 'BUNGE EX',
+        node_type: api_v3_exporter_node_type
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
+  end
+
   let!(:api_v3_other_exporter_node) do
     node = Api::V3::Node.where(
       name: 'OTHER', node_type_id: api_v3_exporter_node_type.id
@@ -187,6 +205,24 @@ shared_context 'api v3 brazil soy nodes' do
     node
   end
 
+  let!(:api_v3_importer2_node) do
+    node = Api::V3::Node.where(
+      name: 'BUNGE IM', node_type_id: api_v3_importer_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node,
+        name: 'BUNGE IM',
+        node_type: api_v3_importer_node_type
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
+  end
+
   let!(:api_v3_other_importer_node) do
     node = Api::V3::Node.where(
       name: 'OTHER', node_type_id: api_v3_importer_node_type.id
@@ -215,6 +251,25 @@ shared_context 'api v3 brazil soy nodes' do
         name: 'RUSSIAN FEDERATION',
         node_type: api_v3_country_node_type,
         geo_id: 'RU'
+      )
+      FactoryBot.create(
+        :api_v3_node_property,
+        node: node
+      )
+    end
+    node
+  end
+
+  let!(:api_v3_country_of_destination2_node) do
+    node = Api::V3::Node.where(
+      name: 'GERMANY', node_type_id: api_v3_country_node_type.id
+    ).first
+    unless node
+      node = FactoryBot.create(
+        :api_v3_node,
+        name: 'GERMANY',
+        node_type: api_v3_country_node_type,
+        geo_id: 'DE'
       )
       FactoryBot.create(
         :api_v3_node_property,

--- a/spec/support/schemas/v3_actor_sustainability.json
+++ b/spec/support/schemas/v3_actor_sustainability.json
@@ -72,7 +72,7 @@
                   "type": "array",
                   "items": {
                     "$id": "#/properties/data/items/properties/rows/items/properties/values/items",
-                    "type": "object",
+                    "type": ["object", "null"],
                     "required": [
                       "value"
                     ],


### PR DESCRIPTION
Word of warning: the migration takes forever. On the plus side, ordering seems to be quite quick.

This is the approach I took:
- a new materialised view, which stores computed ranks for each node per context per year, e.g.
`SELECT rank_by_year->'2017' FROM nodes_per_context_ranked_by_volume_per_year_mv WHERE node_id = 23958` returns `2`, which is because this materialised view does not filter out DOMESTIC CONSUMPTION (that is in order to prevent it from being recalculated after `node_properties.is_domestic_consumption` is changed)
- the JSONB column `rank_by_year` has been added to `dashboards_[sources|exporters|importers|destinations]_mv` (please note: not to the old companies mview, as that will be retired anyway) - that's the migration that takes ages to run and a good candidate for optimisation when we move to that area of work
- the endpoints now support 3 new parameters: `order_by` (`volume` or `name`), `start_year` and `end_year`.
- to use order by volume, at least a start year needs to be provided. That will make sense with the new design, where the year selection happens first.
- If only start year is provided, ordering uses rank for that year; if both start and end year are provided, then average rank over range of years. Order by volume is the default now, unless year is missing - then it falls back to ordering by name.
- please note we need a country & commodity selection for this to work (available at this stage according to the design), we'd need much deeper changes otherwise

Example:
`http://localhost:3000/api/v3/dashboards/exporters?node_types_ids=6&countries_ids=27&commodities_ids=1&order_by=volume&start_year=2016`


