### PR TITLE
Downgraded sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'twitter', '~> 6.1'
 
 gem 'appsignal'
 gem 'newrelic_rpm'
-gem 'sidekiq'
+gem 'sidekiq', '~> 5.2.7'
 gem 'sidekiq-unique-jobs'
 gem 'whenever', require: false
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,11 +387,11 @@ GEM
       railties (>= 4.0.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
-    sidekiq (6.0.3)
-      connection_pool (>= 2.2.2)
-      rack (>= 2.0.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     sidekiq-unique-jobs (6.0.15)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 7.0)
@@ -515,7 +515,7 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 6.0)
   scenic
-  sidekiq
+  sidekiq (~> 5.2.7)
   sidekiq-unique-jobs
   simplecov
   sitemap_generator


### PR DESCRIPTION
Unfortunately there seems to be some incompatibility, probably between sidekiq and sidekiq-unique-jobs, so not upgrading to 6 for now