### PR TITLE
Added unit_type to attributes response

### DIFF
--- a/app/serializers/api/public/attributes/flow_attribute_serializer.rb
+++ b/app/serializers/api/public/attributes/flow_attribute_serializer.rb
@@ -2,10 +2,11 @@ module Api
   module Public
     module Attributes
       class FlowAttributeSerializer < ActiveModel::Serializer
-        attributes :attribute_id,
+        attributes :id,
                    :name,
                    :display_name,
                    :unit,
+                   :unit_type,
                    :availability
       end
     end

--- a/app/services/api/public/attributes/response_builder.rb
+++ b/app/services/api/public/attributes/response_builder.rb
@@ -53,10 +53,11 @@ module Api
 
         def flow_attributes_select_clause
           [
-            'attribute_id',
+            'attribute_id AS id',
             'name',
             'display_name',
             'unit',
+            'unit_type',
             'json_agg(' \
               'json_build_object(' \
                 '\'country\', countries.iso2, ' \
@@ -68,7 +69,7 @@ module Api
         end
 
         def flow_attributes_group_clause
-          %w[attribute_id name display_name unit]
+          %w[attribute_id name display_name unit unit_type]
         end
 
         def initialize_data

--- a/db/migrate/20191111213756_add_unit_type_to_flow_attributes_mv.rb
+++ b/db/migrate/20191111213756_add_unit_type_to_flow_attributes_mv.rb
@@ -1,0 +1,8 @@
+class AddUnitTypeToFlowAttributesMv < ActiveRecord::Migration[5.2]
+  def change
+    update_view :flow_attributes_mv,
+      version: 3,
+      revert_to_version: 1,
+      materialized: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4384,34 +4384,37 @@ CREATE MATERIALIZED VIEW public.flow_attributes_mv AS
     attributes.name,
     attributes.display_name,
     attributes.unit,
+    attributes.unit_type,
     flows.context_id,
     array_agg(DISTINCT flows.year) AS years
    FROM ((public.flows
      JOIN public.flow_quants ON ((flow_quants.flow_id = flows.id)))
      JOIN public.attributes ON (((attributes.original_type = 'Quant'::text) AND (attributes.original_id = flow_quants.quant_id))))
-  GROUP BY attributes.id, attributes.name, attributes.display_name, attributes.unit, flows.context_id
+  GROUP BY attributes.id, attributes.name, attributes.display_name, attributes.unit, attributes.unit_type, flows.context_id
 UNION ALL
  SELECT attributes.id AS attribute_id,
     attributes.name,
     attributes.display_name,
     attributes.unit,
+    attributes.unit_type,
     flows.context_id,
     array_agg(DISTINCT flows.year) AS years
    FROM ((public.flows
      JOIN public.flow_quals ON ((flow_quals.flow_id = flows.id)))
      JOIN public.attributes ON (((attributes.original_type = 'Qual'::text) AND (attributes.original_id = flow_quals.qual_id))))
-  GROUP BY attributes.id, attributes.name, attributes.display_name, attributes.unit, flows.context_id
+  GROUP BY attributes.id, attributes.name, attributes.display_name, attributes.unit, attributes.unit_type, flows.context_id
 UNION ALL
  SELECT attributes.id AS attribute_id,
     attributes.name,
     attributes.display_name,
     attributes.unit,
+    attributes.unit_type,
     flows.context_id,
     array_agg(DISTINCT flows.year) AS years
    FROM ((public.flows
      JOIN public.flow_inds ON ((flow_inds.flow_id = flows.id)))
      JOIN public.attributes ON (((attributes.original_type = 'Ind'::text) AND (attributes.original_id = flow_inds.ind_id))))
-  GROUP BY attributes.id, attributes.name, attributes.display_name, attributes.unit, flows.context_id
+  GROUP BY attributes.id, attributes.name, attributes.display_name, attributes.unit, attributes.unit_type, flows.context_id
   WITH NO DATA;
 
 
@@ -9972,6 +9975,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191015095615'),
 ('20191021084412'),
 ('20191028134448'),
-('20191028134449');
+('20191028134449'),
+('20191111213756');
 
 

--- a/db/views/flow_attributes_mv_v03.sql
+++ b/db/views/flow_attributes_mv_v03.sql
@@ -1,0 +1,57 @@
+SELECT attributes.id AS attribute_id,
+       attributes.name,
+       attributes.display_name,
+       attributes.unit,
+       attributes.unit_type,
+       flows.context_id,
+       ARRAY_AGG(DISTINCT flows.year) AS years
+FROM flows
+INNER JOIN flow_quants ON flow_quants.flow_id = flows.id
+INNER JOIN attributes ON attributes.original_type = 'Quant' AND
+                         attributes.original_id = flow_quants.quant_id
+GROUP BY attributes.id,
+         attributes.name,
+         attributes.display_name,
+         attributes.unit,
+         attributes.unit_type,
+         flows.context_id
+
+UNION ALL
+
+SELECT attributes.id AS attribute_id,
+       attributes.name,
+       attributes.display_name,
+       attributes.unit,
+       attributes.unit_type,
+       flows.context_id,
+       ARRAY_AGG(DISTINCT flows.year) AS years
+FROM flows
+INNER JOIN flow_quals ON flow_quals.flow_id = flows.id
+INNER JOIN attributes ON attributes.original_type = 'Qual' AND
+                         attributes.original_id = flow_quals.qual_id
+GROUP BY attributes.id,
+         attributes.name,
+         attributes.display_name,
+         attributes.unit,
+         attributes.unit_type,
+         flows.context_id
+
+UNION ALL
+
+SELECT attributes.id AS attribute_id,
+       attributes.name,
+       attributes.display_name,
+       attributes.unit,
+       attributes.unit_type,
+       flows.context_id,
+       ARRAY_AGG(DISTINCT flows.year) AS years
+FROM flows
+INNER JOIN flow_inds ON flow_inds.flow_id = flows.id
+INNER JOIN attributes ON attributes.original_type = 'Ind' AND
+                         attributes.original_id = flow_inds.ind_id
+GROUP BY attributes.id,
+         attributes.name,
+         attributes.display_name,
+         attributes.unit,
+         attributes.unit_type,
+         flows.context_id


### PR DESCRIPTION
Added the unit_type property to the attributes endpoint, so that users can understand better what kind of values they get. Also changed the name of the key from `attribute_id` to `id`, to keep it consistent with other endpoints.