### PR TITLE
Added second sandbox instance

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -50,12 +50,12 @@ end
 
 namespace :sidekiq do
   task :quiet do
-    on roles(:app) do
+    on roles(:db) do
       puts capture("pgrep -f 'sidekiq' | xargs kill -TSTP")
     end
   end
   task :restart do
-    on roles(:app) do
+    on roles(:db) do
       execute :sudo, :systemctl, :restart, :sidekiq
     end
   end
@@ -84,7 +84,7 @@ end
 namespace :downloads do
   desc 'Clear pre-computed bulk downloads'
   task :clear do
-    on roles(:app) do
+    on roles(:db) do
       within release_path do
         with rails_env: fetch(:rails_env) do
           execute :rake, 'downloads:clear'
@@ -94,7 +94,7 @@ namespace :downloads do
   end
   desc 'Refresh pre-computed bulk downloads in a background job'
   task :refresh do
-    on roles(:app) do
+    on roles(:db) do
       within release_path do
         with rails_env: fetch(:rails_env) do
           execute :rake, 'downloads:refresh_later'

--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,5 +1,6 @@
-server 'sandbox.trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: true
+server 'ec2-34-216-27-79.us-west-2.compute.amazonaws.com', user: 'ubuntu', roles: %w{web app db}, primary: true
+server 'ec2-34-223-6-56.us-west-2.compute.amazonaws.com', user: 'ubuntu', roles: %w{web app}, primary: false
+
 set :ssh_options, forward_agent: true
 
 set :branch, 'develop'
-


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169724680

## Description

Adds deployment to a second sandbox instance. Only one of them is supposed to be running migrations, refreshing downloads and background jobs.

## Testing instructions

`cap sandbox deploy` will deploy to both servers
