### PR TITLE
Performance/replace flow nodes mv with table

### DIFF
--- a/app/models/api/v3/readonly/dashboards/commodity.rb
+++ b/app/models/api/v3/readonly/dashboards/commodity.rb
@@ -24,8 +24,16 @@ module Api
     module Readonly
       module Dashboards
         class Commodity < Api::Readonly::BaseModel
-          self.table_name = 'dashboards_commodities_mv'
+          include Api::V3::Readonly::MaterialisedTable
+
+          self.table_name = 'dashboards_commodities'
           belongs_to :commodity
+
+          INDEXES = [
+            {columns: :country_id},
+            {columns: :node_id},
+            {columns: :name_tsvector, using: :gin}
+          ].freeze
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/company.rb
+++ b/app/models/api/v3/readonly/dashboards/company.rb
@@ -30,8 +30,25 @@ module Api
     module Readonly
       module Dashboards
         class Company < Api::Readonly::BaseModel
-          self.table_name = 'dashboards_companies_mv'
+          include Api::V3::Readonly::MaterialisedTable
+
+          self.table_name = 'dashboards_companies'
           belongs_to :node
+
+          class << self
+            def refresh_dependencies(options = {})
+              Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+                options.merge(skip_dependents: true)
+              )
+            end
+          end
+
+          INDEXES = [
+            {columns: :commodity_id},
+            {columns: :country_id},
+            {columns: :name_tsvector, using: :gin},
+            {columns: :node_type_id}
+          ].freeze
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/country.rb
+++ b/app/models/api/v3/readonly/dashboards/country.rb
@@ -25,8 +25,16 @@ module Api
     module Readonly
       module Dashboards
         class Country < Api::Readonly::BaseModel
-          self.table_name = 'dashboards_countries_mv'
+          include Api::V3::Readonly::MaterialisedTable
+
+          self.table_name = 'dashboards_countries'
           belongs_to :country
+
+          INDEXES = [
+            {columns: :commodity_id},
+            {columns: :node_id},
+            {columns: :name_tsvector, using: :gin}
+          ].freeze
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/destination.rb
+++ b/app/models/api/v3/readonly/dashboards/destination.rb
@@ -27,7 +27,9 @@ module Api
     module Readonly
       module Dashboards
         class Destination < Api::Readonly::BaseModel
-          self.table_name = 'dashboards_destinations_mv'
+          include Api::V3::Readonly::MaterialisedTable
+
+          self.table_name = 'dashboards_destinations'
           belongs_to :node
 
           class << self
@@ -37,6 +39,13 @@ module Api
               )
             end
           end
+
+          INDEXES = [
+            {columns: :commodity_id},
+            {columns: :country_id},
+            {columns: :name_tsvector, using: :gin},
+            {columns: :node_type_id}
+          ].freeze
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/exporter.rb
+++ b/app/models/api/v3/readonly/dashboards/exporter.rb
@@ -27,7 +27,9 @@ module Api
     module Readonly
       module Dashboards
         class Exporter < Api::Readonly::BaseModel
-          self.table_name = 'dashboards_exporters_mv'
+          include Api::V3::Readonly::MaterialisedTable
+
+          self.table_name = 'dashboards_exporters'
           belongs_to :node
 
           class << self
@@ -37,6 +39,13 @@ module Api
               )
             end
           end
+
+          INDEXES = [
+            {columns: :commodity_id},
+            {columns: :country_id},
+            {columns: :name_tsvector, using: :gin},
+            {columns: :node_type_id}
+          ].freeze
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/importer.rb
+++ b/app/models/api/v3/readonly/dashboards/importer.rb
@@ -27,7 +27,9 @@ module Api
     module Readonly
       module Dashboards
         class Importer < Api::Readonly::BaseModel
-          self.table_name = 'dashboards_importers_mv'
+          include Api::V3::Readonly::MaterialisedTable
+
+          self.table_name = 'dashboards_importers'
           belongs_to :node
 
           class << self
@@ -37,6 +39,13 @@ module Api
               )
             end
           end
+
+          INDEXES = [
+            {columns: :commodity_id},
+            {columns: :country_id},
+            {columns: :name_tsvector, using: :gin},
+            {columns: :node_type_id}
+          ].freeze
         end
       end
     end

--- a/app/models/api/v3/readonly/dashboards/source.rb
+++ b/app/models/api/v3/readonly/dashboards/source.rb
@@ -27,7 +27,9 @@ module Api
     module Readonly
       module Dashboards
         class Source < Api::Readonly::BaseModel
-          self.table_name = 'dashboards_sources_mv'
+          include Api::V3::Readonly::MaterialisedTable
+
+          self.table_name = 'dashboards_sources'
           belongs_to :node
 
           class << self
@@ -37,6 +39,13 @@ module Api
               )
             end
           end
+
+          INDEXES = [
+            {columns: :commodity_id},
+            {columns: :country_id},
+            {columns: :name_tsvector, using: :gin},
+            {columns: :node_type_id}
+          ].freeze
         end
       end
     end

--- a/app/models/api/v3/readonly/flow_node.rb
+++ b/app/models/api/v3/readonly/flow_node.rb
@@ -13,13 +13,22 @@
 #  flow_nodes_mv_flow_id_node_id_idx  (flow_id,node_id) UNIQUE
 #
 
-# This materialised view does not depend on any yellow tables.
+# This class is not backed by a materialized view, but a table.
+# The table is refreshed using a SQL function.
 # It should only be refreshed once per data import.
 module Api
   module V3
     module Readonly
       class FlowNode < Api::Readonly::BaseModel
-        self.table_name = 'flow_nodes_mv'
+        include Api::V3::Readonly::MaterialisedTable
+
+        self.table_name = 'flow_nodes'
+
+        INDEXES = [
+          {columns: :flow_id},
+          {columns: :node_id},
+          {columns: [:context_id, :position]}
+        ].freeze
       end
     end
   end

--- a/app/models/api/v3/readonly/node_with_flows_per_year.rb
+++ b/app/models/api/v3/readonly/node_with_flows_per_year.rb
@@ -1,0 +1,16 @@
+# Only needs to be refreshed once after data upload. Used in dashboards mviews.
+module Api
+  module V3
+    module Readonly
+      class NodeWithFlowsPerYear < Api::Readonly::BaseModel
+        include Api::V3::Readonly::MaterialisedTable
+
+        self.table_name = 'nodes_with_flows_per_year'
+
+        INDEXES = [
+          {columns: :node_id}
+        ].freeze
+      end
+    end
+  end
+end

--- a/app/models/concerns/api/v3/readonly/materialised_table.rb
+++ b/app/models/concerns/api/v3/readonly/materialised_table.rb
@@ -1,0 +1,58 @@
+require 'active_support/concern'
+
+module Api
+  module V3
+    module Readonly
+      module MaterialisedTable
+        extend ActiveSupport::Concern
+
+        class_methods do
+          def create_indexes
+            self::INDEXES.each do |index_properties|
+              columns = index_properties[:columns]
+              execute "CREATE INDEX IF NOT EXISTS #{index_name(columns)} \
+                ON #{table_name} (#{columns_to_string(columns, ',')})"
+            end
+          end
+
+          def drop_indexes
+            self::INDEXES.each do |index_properties|
+              columns = index_properties[:columns]
+              execute 'DROP INDEX IF EXISTS ' + index_name(columns)
+            end
+          end
+
+          protected
+
+          def refresh_by_name(table_name, _options)
+            drop_indexes
+            connection.execute(
+              "TRUNCATE #{table_name};
+              INSERT INTO #{table_name} SELECT * FROM #{table_name}_v"
+            )
+            create_indexes
+          end
+
+          def index_name(columns)
+            index_name = self.table_name + '_'
+            index_name << columns_to_string(columns, '_')
+            index_name << '_idx'
+            index_name
+          end
+
+          def columns_to_string(columns, separator)
+            if columns.is_a? Array
+              columns.join(separator)
+            else
+              columns.to_s
+            end
+          end
+
+          def execute(sql)
+            ActiveRecord::Base.connection.execute sql
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/public/node/filter.rb
+++ b/app/services/api/public/node/filter.rb
@@ -26,15 +26,15 @@ module Api
         def initialize_query
           @query = Api::V3::Readonly::FlowNode.
             select(*select_clause).
-            joins('INNER JOIN nodes_mv ON nodes_mv.id = flow_nodes_mv.node_id').
-            joins('INNER JOIN contexts_mv ON contexts_mv.id = flow_nodes_mv.context_id').
+            joins('INNER JOIN nodes_mv ON nodes_mv.id = flow_nodes.node_id').
+            joins('INNER JOIN contexts_mv ON contexts_mv.id = flow_nodes.context_id').
             group(*group_clause).
-            order('flow_nodes_mv.node_id')
+            order('flow_nodes.node_id')
         end
 
         def select_clause
           [
-            'flow_nodes_mv.node_id',
+            'flow_nodes.node_id',
             'nodes_mv.name',
             'nodes_mv.node_type',
             'nodes_mv.geo_id',
@@ -56,7 +56,7 @@ module Api
               'DISTINCT JSONB_BUILD_OBJECT(' \
                 '\'country\', contexts_mv.iso2, ' \
                 '\'commodity\', contexts_mv.commodity_name, ' \
-                '\'flow_id\', flow_nodes_mv.flow_id, ' \
+                '\'flow_id\', flow_nodes.flow_id, ' \
                 "'values', #{select_flow_attributes_clause}" \
               ')' \
             ') AS flow_attributes'
@@ -76,8 +76,8 @@ module Api
               '\'year\', year, ' \
               '\'value\', value) ' \
             "FROM node_#{node_type} " \
-            "WHERE node_#{node_type}.node_id = flow_nodes_mv.node_id AND " \
-              "node_#{node_type}.year = flow_nodes_mv.year" \
+            "WHERE node_#{node_type}.node_id = flow_nodes.node_id AND " \
+              "node_#{node_type}.year = flow_nodes.year" \
           ')'
         end
 
@@ -94,13 +94,13 @@ module Api
               '\'year\', year, ' \
               '\'value\', value) ' \
             "FROM flow_#{flow_type} " \
-            "WHERE flow_#{flow_type}.flow_id = flow_nodes_mv.flow_id" \
+            "WHERE flow_#{flow_type}.flow_id = flow_nodes.flow_id" \
           ')'
         end
 
         def group_clause
           [
-            'flow_nodes_mv.node_id',
+            'flow_nodes.node_id',
             'nodes_mv.name',
             'nodes_mv.node_type',
             'nodes_mv.geo_id',
@@ -117,14 +117,14 @@ module Api
         def apply_node_id_filter
           return unless @node_id
 
-          @query = @query.where('flow_nodes_mv.node_id' => @node_id)
+          @query = @query.where('flow_nodes.node_id' => @node_id)
         end
 
         def apply_year_filter
           return unless @node_id
 
           @query = @query.where(
-            'flow_nodes_mv.year IS NULL OR flow_nodes_mv.year = ?', @year
+            'flow_nodes.year IS NULL OR flow_nodes.year = ?', @year
           )
         end
       end

--- a/app/services/api/v3/dashboards/base_filter.rb
+++ b/app/services/api/v3/dashboards/base_filter.rb
@@ -21,8 +21,11 @@ module Api
             (params[:importers_ids] || []) +
             (params[:destinations_ids] || [])
           @node_types_ids = params[:node_types_ids] || []
+          @start_year = params.delete(:start_year)
+          @end_year = params.delete(:end_year)
           @profile_only = params.delete(:profile_only) || false
           @self_ids ||= []
+          initialize_contexts
           initialize_query
           apply_filters
         end
@@ -32,6 +35,16 @@ module Api
         end
 
         private
+
+        def initialize_contexts
+          @contexts = Api::V3::Context.all
+          if @commodities_ids.any?
+            @contexts = @contexts.where(commodity_id: @commodities_ids)
+          end
+          return unless @countries_ids.any?
+
+          @contexts = @contexts.where(country_id: @countries_ids)
+        end
 
         # @abstract
         # @return [ActiveRecord::Relation]

--- a/app/services/api/v3/dashboards/filter_companies.rb
+++ b/app/services/api/v3/dashboards/filter_companies.rb
@@ -4,24 +4,19 @@
 module Api
   module V3
     module Dashboards
-      class FilterCompanies < BaseFilter
+      class FilterCompanies < FilterNodes
         include Query
-        include CallWithQueryTerm
 
         def initialize(params)
-          @self_ids = params.delete(:companies_ids)
+          @self_ids = params.delete(:param_name)
           @nodes_to_filter_by = Api::V3::Dashboards::NodesToFilterBy.new(params)
           super(params)
         end
 
-        def call_with_query_term(query_term)
-          super(query_term, {include_country_id: true})
-        end
-
         private
 
-        def apply_order_by
-          @query = @query.order(:name)
+        def param_name
+          :companies_ids
         end
 
         def filtered_class

--- a/app/services/api/v3/dashboards/filter_nodes.rb
+++ b/app/services/api/v3/dashboards/filter_nodes.rb
@@ -14,9 +14,8 @@ module Api
         def initialize(params)
           @self_ids = params.delete(param_name)
           @order_by = params.delete(:order_by)&.downcase
-          @start_year = params.delete(:start_year)
-          @end_year = params.delete(:end_year)
           super(params)
+          initialize_contexts
         end
 
         def call_with_query_term(query_term)
@@ -67,7 +66,7 @@ module Api
         end
 
         def context_selected?
-          @countries_ids.length == 1 && @commodities_ids.length == 1
+          @contexts.length == 1
         end
 
         def apply_order_by

--- a/app/services/api/v3/dashboards/filter_nodes.rb
+++ b/app/services/api/v3/dashboards/filter_nodes.rb
@@ -56,6 +56,12 @@ module Api
           apply_order_by
         end
 
+        def filter_by_nodes
+          return unless @node_ids.any?
+
+          @query = @query.where("nodes_ids && ARRAY[#{@node_ids.join(',')}]")
+        end
+
         def year_selected?
           @start_year.present?
         end

--- a/db/migrate/20191118213141_create_flow_nodes.rb
+++ b/db/migrate/20191118213141_create_flow_nodes.rb
@@ -1,5 +1,5 @@
 class CreateFlowNodes < ActiveRecord::Migration[5.2]
-  def change
+  def up
     create_table :flow_nodes, primary_key: %i[flow_id node_id] do |t|
       t.integer :flow_id, null: false
       t.integer :node_id, null: false
@@ -13,5 +13,10 @@ class CreateFlowNodes < ActiveRecord::Migration[5.2]
     Api::V3::Readonly::FlowNode.refresh(
       sync: (Rails.env.development? || Rails.env.test?)
     )
+  end
+
+  def down
+    drop_table :flow_nodes
+    drop_view 'flow_nodes_v'
   end
 end

--- a/db/migrate/20191118213141_create_flow_nodes.rb
+++ b/db/migrate/20191118213141_create_flow_nodes.rb
@@ -1,0 +1,17 @@
+class CreateFlowNodes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :flow_nodes, primary_key: %i[flow_id node_id] do |t|
+      t.integer :flow_id, null: false
+      t.integer :node_id, null: false
+      t.integer :context_id, null: false
+      t.column :position, 'smallint', null: false
+      t.column :year, 'smallint', null: false
+    end
+
+    create_view 'flow_nodes_v', materialized: false
+
+    Api::V3::Readonly::FlowNode.refresh(
+      sync: (Rails.env.development? || Rails.env.test?)
+    )
+  end
+end

--- a/db/migrate/20191119115004_create_nodes_with_flows_per_year.rb
+++ b/db/migrate/20191119115004_create_nodes_with_flows_per_year.rb
@@ -1,0 +1,30 @@
+class CreateNodesWithFlowsPerYear < ActiveRecord::Migration[5.2]
+  def up
+    create_table :nodes_with_flows_per_year, primary_key: %i[node_id context_id year] do |t|
+      t.integer :node_id
+      t.integer :context_id
+      t.integer :country_id
+      t.integer :commodity_id
+      t.integer :node_type_id
+      t.integer :context_node_type_id
+      t.column :year, 'smallint'
+      t.column :nodes_ids, 'int[]'
+      t.text :name
+      t.column :name_tsvector, 'tsvector'
+      t.text :node_type
+      t.text :geo_id
+      t.boolean :is_unknown
+    end
+
+    create_view 'nodes_with_flows_per_year_v', materialized: false
+
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: (Rails.env.development? || Rails.env.test?)
+    )
+  end
+
+  def down
+    drop_table :nodes_with_flows_per_year
+    drop_view 'nodes_with_flows_per_year_v', materialized: false
+  end
+end

--- a/db/migrate/20191119115005_create_dashboards_nodes.rb
+++ b/db/migrate/20191119115005_create_dashboards_nodes.rb
@@ -1,0 +1,176 @@
+class CreateDashboardsNodes < ActiveRecord::Migration[5.2]
+  def up
+    [
+      Api::V3::Readonly::Dashboards::Source,
+      Api::V3::Readonly::Dashboards::Exporter,
+      Api::V3::Readonly::Dashboards::Importer,
+      Api::V3::Readonly::Dashboards::Company,
+      Api::V3::Readonly::Dashboards::Destination
+    ].each do |klass|
+      table_name = klass.table_name
+
+      create_table table_name, primary_key: %i[id country_id commodity_id year] do |t|
+        t.integer :id
+        t.integer :node_type_id
+        t.integer :context_id
+        t.integer :country_id
+        t.integer :commodity_id
+        t.column :nodes_ids, 'int[]'
+        t.column :year, 'smallint'
+        t.text :name
+        t.column :name_tsvector, 'tsvector'
+        t.text :node_type
+        t.text :profile
+        t.column :rank_by_year, 'jsonb'
+      end
+
+      create_view "#{table_name}_v", materialized: false
+
+      klass.refresh(
+        sync: (Rails.env.development? || Rails.env.test?)
+      )
+
+      drop_view "#{table_name}_mv", materialized: true
+    end
+  end
+
+  def down
+    create_view 'dashboards_sources_mv', version: 9, materialized: true
+    create_view 'dashboards_exporters_mv', version: 2, materialized: true
+    create_view 'dashboards_importers_mv', version: 2, materialized: true
+    create_view 'dashboards_companies_mv', version: 7, materialized: true
+    create_view 'dashboards_destinations_mv', version: 8, materialized: true
+
+    redo_dashboards_sources_indexes
+    redo_dashboards_exporters_indexes
+    redo_dashboards_importers_indexes
+    redo_dashboards_companies_indexes
+    redo_dashboards_destinations_indexes
+    [
+      Api::V3::Readonly::Dashboards::Source,
+      Api::V3::Readonly::Dashboards::Exporter,
+      Api::V3::Readonly::Dashboards::Importer,
+      Api::V3::Readonly::Dashboards::Company,
+      Api::V3::Readonly::Dashboards::Destination
+    ].each do |klass|
+      table_name = klass.table_name
+      drop_table table_name
+      drop_view "#{table_name}_v", materialized: false
+    end
+  end
+
+  def redo_dashboards_sources_indexes
+    add_index :dashboards_sources_mv,
+      :commodity_id,
+      name: 'dashboards_sources_mv_commodity_id_idx'
+    add_index :dashboards_sources_mv,
+      :country_id,
+      name: 'dashboards_sources_mv_country_id_idx'
+    add_index :dashboards_sources_mv,
+      :name_tsvector,
+      name: 'dashboards_sources_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_sources_mv,
+      :node_id,
+      name: 'dashboards_sources_mv_node_id_idx'
+    add_index :dashboards_sources_mv,
+      :node_type_id,
+      name: 'dashboards_sources_mv_node_type_id_idx'
+    add_index :dashboards_sources_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_sources_unique_idx'
+  end
+
+  def redo_dashboards_exporters_indexes
+    add_index :dashboards_exporters_mv,
+      :commodity_id,
+      name: 'dashboards_exporters_mv_commodity_id_idx'
+    add_index :dashboards_exporters_mv,
+      :country_id,
+      name: 'dashboards_exporters_mv_country_id_idx'
+    add_index :dashboards_exporters_mv,
+      :name_tsvector,
+      name: 'dashboards_exporters_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_exporters_mv,
+      :node_id,
+      name: 'dashboards_exporters_mv_node_id_idx'
+    add_index :dashboards_exporters_mv,
+      :node_type_id,
+      name: 'dashboards_exporters_mv_node_type_id_idx'
+    add_index :dashboards_exporters_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_exporters_mv_unique_idx'
+  end
+
+  def redo_dashboards_importers_indexes
+    add_index :dashboards_importers_mv,
+      :commodity_id,
+      name: 'dashboards_importers_mv_commodity_id_idx'
+    add_index :dashboards_importers_mv,
+      :country_id,
+      name: 'dashboards_importers_mv_country_id_idx'
+    add_index :dashboards_importers_mv,
+      :name_tsvector,
+      name: 'dashboards_importers_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_importers_mv,
+      :node_id,
+      name: 'dashboards_importers_mv_node_id_idx'
+    add_index :dashboards_importers_mv,
+      :node_type_id,
+      name: 'dashboards_importers_mv_node_type_id_idx'
+    add_index :dashboards_importers_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_importers_mv_unique_idx'
+  end
+
+  def redo_dashboards_companies_indexes
+    add_index :dashboards_companies_mv,
+      :commodity_id,
+      name: 'dashboards_companies_mv_commodity_id_idx'
+    add_index :dashboards_companies_mv,
+      :country_id,
+      name: 'dashboards_companies_mv_country_id_idx'
+    add_index :dashboards_companies_mv,
+      :name_tsvector,
+      name: 'dashboards_companies_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_companies_mv,
+      :node_id,
+      name: 'dashboards_companies_mv_node_id_idx'
+    add_index :dashboards_companies_mv,
+      :node_type_id,
+      name: 'dashboards_companies_mv_node_type_id_idx'
+    add_index :dashboards_companies_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_companies_mv_unique_idx'
+  end
+
+  def redo_dashboards_destinations_indexes
+    add_index :dashboards_destinations_mv,
+      :country_id,
+      name: 'dashboards_destinations_mv_country_id_idx'
+    add_index :dashboards_destinations_mv,
+      :commodity_id,
+      name: 'dashboards_destinations_mv_commodity_id_idx'
+    add_index :dashboards_destinations_mv,
+      :name_tsvector,
+      name: 'dashboards_destinations_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_destinations_mv,
+      :node_id,
+      name: 'dashboards_destinations_mv_node_id_idx'
+    add_index :dashboards_destinations_mv,
+      :node_type_id,
+      name: 'dashboards_destinations_mv_node_type_id_idx'
+    add_index :dashboards_destinations_mv,
+      [:id, :node_id, :country_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_destinations_mv_unique_idx'
+  end
+end

--- a/db/migrate/20191122074338_create_dashboards_commodities_and_countries.rb
+++ b/db/migrate/20191122074338_create_dashboards_commodities_and_countries.rb
@@ -1,0 +1,95 @@
+class CreateDashboardsCommoditiesAndCountries < ActiveRecord::Migration[5.2]
+  def up
+    create_table :dashboards_commodities, primary_key: %i[id node_id country_id] do |t|
+      t.integer :id
+      t.integer :country_id
+      t.integer :node_id
+      t.text :name
+      t.column :name_tsvector, 'tsvector'
+      t.text :profile
+    end
+
+    create_table :dashboards_countries, primary_key: %i[id node_id commodity_id] do |t|
+      t.integer :id
+      t.integer :commodity_id
+      t.integer :node_id
+      t.text :iso2
+      t.text :name
+      t.column :name_tsvector, 'tsvector'
+      t.text :profile
+    end
+
+    create_view :dashboards_commodities_v, materialized: false
+    create_view :dashboards_countries_v, materialized: false
+
+    Api::V3::Readonly::Dashboards::Commodity.refresh(
+      sync: (Rails.env.development? || Rails.env.test?)
+    )
+    Api::V3::Readonly::Dashboards::Country.refresh(
+      sync: (Rails.env.development? || Rails.env.test?)
+    )
+
+    drop_view :dashboards_commodities_mv, materialized: true
+    drop_view :dashboards_countries_mv, materialized: true
+  end
+
+  def down
+    create_view :dashboards_commodities_mv, version: 5, materialized: true
+    create_view :dashboards_countries_mv, version: 5, materialized: true
+
+    redo_dashboards_commodities_indexes
+    redo_dashboards_countries_indexes
+
+    drop_table :dashboards_commodities
+    drop_table :dashboards_countries
+
+    drop_view :dashboards_commodities_v, materialized: false
+    drop_view :dashboards_countries_v, materialized: false
+  end
+
+  def redo_dashboards_countries_indexes
+    add_index :dashboards_countries_mv,
+      :commodity_id,
+      name: 'dashboards_countries_mv_commodity_id_idx'
+    add_index :dashboards_countries_mv,
+      [:id, :name],
+      name: 'dashboards_countries_mv_group_columns_idx'
+    add_index :dashboards_countries_mv,
+      :name_tsvector,
+      name: 'dashboards_countries_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_countries_mv,
+      :node_id,
+      name: 'dashboards_countries_mv_node_id_idx'
+    add_index :dashboards_countries_mv,
+      [:id, :node_id, :commodity_id],
+      unique: true,
+      name: 'dashboards_countries_mv_unique_idx'
+    add_index :dashboards_countries_mv,
+      :name,
+      name: 'dashboards_countries_mv_name_idx'
+  end
+
+  def redo_dashboards_commodities_indexes
+    add_index :dashboards_commodities_mv,
+      :country_id,
+      name: 'dashboards_commodities_mv_country_id_idx'
+    add_index :dashboards_commodities_mv,
+      [:id, :name],
+      name: 'dashboards_commodities_mv_group_columns_idx'
+    add_index :dashboards_commodities_mv,
+      :name_tsvector,
+      name: 'dashboards_commodities_mv_name_tsvector_idx',
+      using: :gin
+    add_index :dashboards_commodities_mv,
+      :node_id,
+      name: 'dashboards_commodities_mv_node_id_idx'
+    add_index :dashboards_commodities_mv,
+      [:id, :node_id, :country_id],
+      unique: true,
+      name: 'dashboards_commodities_mv_unique_idx'
+    add_index :dashboards_commodities_mv,
+      :name,
+      name: 'dashboards_commodities_mv_name_idx'
+  end
+end

--- a/db/migrate/20191122074453_drop_flow_nodes_mv.rb
+++ b/db/migrate/20191122074453_drop_flow_nodes_mv.rb
@@ -1,0 +1,9 @@
+class DropFlowNodesMv < ActiveRecord::Migration[5.2]
+  def up
+    drop_view :flow_nodes_mv, materialized: true
+  end
+
+  def down
+    create_view :flow_nodes_mv, version: 1, materialized: true
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -40,6 +40,68 @@ tables:
         comment: Reference to ind
       - name: tooltip_text
         comment: Context-specific tooltips are the most specific tooltips that can be defined; in absence of a context-specific tooltip, a country-specific tooltip will be used (if any).
+  - name: dashboards_commodities
+    comment: 'Materialized table used for listing commodities in tool search panels'
+    columns:
+      - name: id
+        comment: id of commodity (not unique)
+      - name: country_id
+        comment: id of country, from which this commodity is sourced
+      - name: node_id
+        comment: id of node, through which this commodity is sourced from this country
+  - name: dashboards_countries
+    comment: 'Materialized table used for listing countries in tool search panels'
+    columns:
+      - name: id
+        comment: id of sourcing country (not unique)
+      - name: commodity_id
+        comment: id of commodity sourced from this country
+      - name: node_id
+        comment: id of node, through which this commodity is sourced from this country
+  - name: dashboards_sources
+    comment: 'Materialized table used for listing sources in tool search panels'
+    columns:
+      - name: id
+        comment: id of source node (not unique)
+      - name: commodity_id
+        comment: id of commodity coming from this node
+      - name: country_id
+        comment: id of country sourcing commodity coming from this node
+      - name: nodes_ids
+        comment: array of ids of other nodes from the same supply chain
+  - name: dashboards_exporters
+    comment: 'Materialized table used for listing exporters in tool search panels'
+    columns:
+      - name: id
+        comment: id of exporter node (not unique)
+      - name: commodity_id
+        comment: id of commodity traded by this node
+      - name: country_id
+        comment: id of country sourcing commodity traded by this node
+      - name: nodes_ids
+        comment: array of ids of other nodes from the same supply chain
+  - name: dashboards_importers
+    comment: 'Materialized table used for listing importers in tool search panels'
+    columns:
+      - name: id
+        comment: id of importer node (not unique)
+      - name: commodity_id
+        comment: id of commodity traded by this node
+      - name: country_id
+        comment: id of country sourcing commodity traded by this node
+      - name: nodes_ids
+        comment: array of ids of other nodes from the same supply chain
+  - name: dashboards_destinations
+    comment: 'Materialized table used for listing destinations in tool search panels'
+    columns:
+      - name: id
+        comment: id of destination node (not unique)
+      - name: commodity_id
+        comment: id of commodity going to this node
+      - name: country_id
+        comment: id of country sourcing commodity going to this node
+      - name: nodes_ids
+        comment: array of ids of other nodes from the same supply chain
   - name: quant_context_properties
     comment: Context specific properties for quant (like tooltip text)
     columns:
@@ -263,6 +325,19 @@ tables:
     columns:
       - name: value
         comment: Numeric value
+  - name: flow_nodes
+    comment: Normalised flows, a readonly table populated during data upload.
+    columns:
+      - name: flow_id
+        comment: id from flows
+      - name: node_id
+        comment: id from path at position
+      - name: context_id
+        comment: from flows
+      - name: position
+        comment: 0-indexed
+      - name: year
+        comment: from flows
   - name: flow_quals
     comment: Values of quals for flow
     columns:
@@ -572,7 +647,7 @@ materialized_views:
       - name: quant_id
         comment: Reference to quant
       - name: qual_id
-        comment: Reference to qual 
+        comment: Reference to qual
       - name: context_id
         comment: Reference to context
       - name: tooltip_text
@@ -585,7 +660,7 @@ materialized_views:
       - name: quant_id
         comment: Reference to quant
       - name: qual_id
-        comment: Reference to qual 
+        comment: Reference to qual
       - name: commodity_id
         comment: Reference to commodity
       - name: tooltip_text
@@ -598,59 +673,8 @@ materialized_views:
       - name: quant_id
         comment: Reference to quant
       - name: qual_id
-        comment: Reference to qual 
+        comment: Reference to qual
       - name: country_id
         comment: Reference to country
       - name: tooltip_text
         comment: Tooltip text
-  - name: dashboards_commodities_mv
-    comment: 'Materialized view used for listing commodities in tool search panels'
-    columns:
-      - name: id
-        comment: id of commodity (not unique)
-      - name: country_id
-        comment: id of country, from which this commodity is sourced
-      - name: node_id
-        comment: id of node, through which this commodity is sourced from this country
-  - name: dashboards_countries_mv
-    comment: 'Materialized view used for listing countries in tool search panels'
-    columns:
-      - name: id
-        comment: id of sourcing country (not unique)
-      - name: commodity_id
-        comment: id of commodity sourced from this country
-      - name: node_id
-        comment: id of node, through which this commodity is sourced from this country
-  - name: dashboards_sources_mv
-    comment: 'Materialized view used for listing sources in tool search panels'
-    columns:
-      - name: id
-        comment: id of source node (not unique)
-      - name: commodity_id
-        comment: id of commodity coming from this node
-      - name: country_id
-        comment: id of country sourcing commodity coming from this node
-      - name: node_id
-        comment: id of another node from the same supply chain
-  - name: dashboards_companies_mv
-    comment: 'Materialized view used for listing companies in tool search panels'
-    columns:
-      - name: id
-        comment: id of company node (not unique)
-      - name: commodity_id
-        comment: id of commodity traded by this node
-      - name: country_id
-        comment: id of country sourcing commodity traded by this node
-      - name: node_id
-        comment: id of another node from the same supply chain
-  - name: dashboards_destinations_mv
-    comment: 'Materialized view used for listing destinations in tool search panels'
-    columns:
-      - name: id
-        comment: id of destination node (not unique)
-      - name: commodity_id
-        comment: id of commodity going to this node
-      - name: country_id
-        comment: id of country sourcing commodity going to this node
-      - name: node_id
-        comment: id of another node from the same supply chain

--- a/db/views/dashboards_commodities_v_v01.sql
+++ b/db/views/dashboards_commodities_v_v01.sql
@@ -1,0 +1,11 @@
+SELECT DISTINCT
+  commodity_id AS id,
+  country_id,
+  node_id,
+  TRIM(commodities.name) AS name,
+  TO_TSVECTOR('simple', COALESCE(TRIM(commodities.name)::TEXT, '')) AS name_tsvector,
+  profiles.name AS profile
+FROM nodes_with_flows_per_year nodes
+JOIN commodities ON commodities.id = commodity_id
+LEFT JOIN profiles ON nodes.context_node_type_id = profiles.context_node_type_id
+WHERE NOT is_unknown;

--- a/db/views/dashboards_companies_v_v01.sql
+++ b/db/views/dashboards_companies_v_v01.sql
@@ -1,0 +1,26 @@
+SELECT
+  -- fixed width first
+  nodes.node_id AS id,
+  nodes.node_type_id,
+  nodes.context_id,
+  nodes.country_id,
+  nodes.commodity_id,
+  nodes.nodes_ids,
+  nodes.year,
+  nodes.name,
+  nodes.name_tsvector,
+  nodes.node_type,
+  profiles.name AS profile,
+  ranked_nodes.rank_by_year
+FROM nodes_with_flows_per_year nodes
+JOIN node_properties node_props ON nodes.node_id = node_props.node_id
+JOIN context_node_type_properties cnt_props ON nodes.context_node_type_id = cnt_props.context_node_type_id
+LEFT JOIN profiles ON nodes.context_node_type_id = profiles.context_node_type_id
+JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+  ON nodes.context_id = ranked_nodes.context_id
+  AND nodes.node_id = ranked_nodes.node_id
+WHERE
+  cnt_props.role IN ('importer', 'exporter')
+  AND NOT nodes.is_unknown
+  AND NOT node_props.is_domestic_consumption
+  AND UPPER(nodes.name) <> 'OTHER';

--- a/db/views/dashboards_countries_v_v01.sql
+++ b/db/views/dashboards_countries_v_v01.sql
@@ -1,0 +1,12 @@
+SELECT DISTINCT
+  country_id AS id,
+  commodity_id,
+  node_id,
+  iso2,
+  TRIM(countries.name) AS name,
+  TO_TSVECTOR('simple', COALESCE(TRIM(countries.name)::TEXT, '')) AS name_tsvector,
+  profiles.name AS profile
+FROM nodes_with_flows_per_year nodes
+JOIN countries ON countries.id = country_id
+LEFT JOIN profiles ON nodes.context_node_type_id = profiles.context_node_type_id
+WHERE NOT is_unknown;

--- a/db/views/dashboards_destinations_v_v01.sql
+++ b/db/views/dashboards_destinations_v_v01.sql
@@ -1,0 +1,26 @@
+SELECT
+  -- fixed width first
+  nodes.node_id AS id,
+  nodes.node_type_id,
+  nodes.context_id,
+  nodes.country_id,
+  nodes.commodity_id,
+  nodes.nodes_ids,
+  nodes.year,
+  nodes.name,
+  nodes.name_tsvector,
+  nodes.node_type,
+  profiles.name AS profile,
+  ranked_nodes.rank_by_year
+FROM nodes_with_flows_per_year nodes
+JOIN node_properties node_props ON nodes.node_id = node_props.node_id
+JOIN context_node_type_properties cnt_props ON nodes.context_node_type_id = cnt_props.context_node_type_id
+LEFT JOIN profiles ON nodes.context_node_type_id = profiles.context_node_type_id
+JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+  ON nodes.context_id = ranked_nodes.context_id
+  AND nodes.node_id = ranked_nodes.node_id
+WHERE
+  cnt_props.role = 'destination'
+  AND NOT nodes.is_unknown
+  AND NOT node_props.is_domestic_consumption
+  AND UPPER(nodes.name) <> 'OTHER';

--- a/db/views/dashboards_exporters_v_v01.sql
+++ b/db/views/dashboards_exporters_v_v01.sql
@@ -1,0 +1,26 @@
+SELECT
+  -- fixed width first
+  nodes.node_id AS id,
+  nodes.node_type_id,
+  nodes.context_id,
+  nodes.country_id,
+  nodes.commodity_id,
+  nodes.nodes_ids,
+  nodes.year,
+  nodes.name,
+  nodes.name_tsvector,
+  nodes.node_type,
+  profiles.name AS profile,
+  ranked_nodes.rank_by_year
+FROM nodes_with_flows_per_year nodes
+JOIN node_properties node_props ON nodes.node_id = node_props.node_id
+JOIN context_node_type_properties cnt_props ON nodes.context_node_type_id = cnt_props.context_node_type_id
+LEFT JOIN profiles ON nodes.context_node_type_id = profiles.context_node_type_id
+JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+  ON nodes.context_id = ranked_nodes.context_id
+  AND nodes.node_id = ranked_nodes.node_id
+WHERE
+  cnt_props.role = 'exporter'
+  AND NOT nodes.is_unknown
+  AND NOT node_props.is_domestic_consumption
+  AND UPPER(nodes.name) <> 'OTHER';

--- a/db/views/dashboards_importers_v_v01.sql
+++ b/db/views/dashboards_importers_v_v01.sql
@@ -1,0 +1,26 @@
+SELECT
+  -- fixed width first
+  nodes.node_id AS id,
+  nodes.node_type_id,
+  nodes.context_id,
+  nodes.country_id,
+  nodes.commodity_id,
+  nodes.nodes_ids,
+  nodes.year,
+  nodes.name,
+  nodes.name_tsvector,
+  nodes.node_type,
+  profiles.name AS profile,
+  ranked_nodes.rank_by_year
+FROM nodes_with_flows_per_year nodes
+JOIN node_properties node_props ON nodes.node_id = node_props.node_id
+JOIN context_node_type_properties cnt_props ON nodes.context_node_type_id = cnt_props.context_node_type_id
+LEFT JOIN profiles ON nodes.context_node_type_id = profiles.context_node_type_id
+JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+  ON nodes.context_id = ranked_nodes.context_id
+  AND nodes.node_id = ranked_nodes.node_id
+WHERE
+  cnt_props.role = 'importer'
+  AND NOT nodes.is_unknown
+  AND NOT node_props.is_domestic_consumption
+  AND UPPER(nodes.name) <> 'OTHER';

--- a/db/views/dashboards_sources_v_v01.sql
+++ b/db/views/dashboards_sources_v_v01.sql
@@ -1,0 +1,26 @@
+SELECT
+  -- fixed width first
+  nodes.node_id AS id,
+  nodes.node_type_id,
+  nodes.context_id,
+  nodes.country_id,
+  nodes.commodity_id,
+  nodes.nodes_ids,
+  nodes.year,
+  nodes.name,
+  nodes.name_tsvector,
+  nodes.node_type,
+  profiles.name AS profile,
+  ranked_nodes.rank_by_year
+FROM nodes_with_flows_per_year nodes
+JOIN node_properties node_props ON nodes.node_id = node_props.node_id
+JOIN context_node_type_properties cnt_props ON nodes.context_node_type_id = cnt_props.context_node_type_id
+LEFT JOIN profiles ON nodes.context_node_type_id = profiles.context_node_type_id
+JOIN nodes_per_context_ranked_by_volume_per_year_mv ranked_nodes
+  ON nodes.context_id = ranked_nodes.context_id
+  AND nodes.node_id = ranked_nodes.node_id
+WHERE
+  cnt_props.role = 'source'
+  AND NOT nodes.is_unknown
+  AND NOT node_props.is_domestic_consumption
+  AND UPPER(nodes.name) <> 'OTHER';

--- a/db/views/flow_nodes_v_v01.sql
+++ b/db/views/flow_nodes_v_v01.sql
@@ -1,0 +1,8 @@
+SELECT
+  flows.id AS flow_id,
+  a.node_id,
+  flows.context_id,
+  a."position",
+  flows.year
+FROM public.flows,
+  LATERAL unnest(flows.path) WITH ORDINALITY a(node_id, "position");

--- a/db/views/nodes_per_context_ranked_by_volume_per_year_mv_v01.sql
+++ b/db/views/nodes_per_context_ranked_by_volume_per_year_mv_v01.sql
@@ -10,6 +10,7 @@ FROM (
   year,
   RANK() OVER (PARTITION BY position, context_id, year ORDER BY value DESC) AS rank
   FROM (
+    -- TODO: use flow_nodes here?
     SELECT
       a.node_id,
       a.position,

--- a/db/views/nodes_with_flows_per_year_v_v01.sql
+++ b/db/views/nodes_with_flows_per_year_v_v01.sql
@@ -1,0 +1,39 @@
+SELECT
+  nodes_with_co_nodes.node_id,
+  nodes_with_co_nodes.context_id,
+  contexts.country_id,
+  contexts.commodity_id,
+  nodes.node_type_id,
+  cnt.id AS context_node_type_id,
+  nodes_with_co_nodes.year,
+  nodes_with_co_nodes.nodes_ids,
+  TRIM(nodes.name) AS name,
+  TO_TSVECTOR('simple', COALESCE(nodes.name, '')) AS name_tsvector,
+  node_types.name AS node_type,
+  nodes.geo_id,
+  nodes.is_unknown
+FROM (
+  SELECT
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    flow_nodes.position,
+    flow_nodes.year,
+    ARRAY_AGG(DISTINCT co_flow_nodes.node_id) AS nodes_ids
+  FROM flow_nodes
+  JOIN flow_nodes co_flow_nodes ON flow_nodes.flow_id = co_flow_nodes.flow_id
+  WHERE flow_nodes.node_id <> co_flow_nodes.node_id
+  GROUP BY
+    flow_nodes.node_id,
+    flow_nodes.context_id,
+    flow_nodes.position,
+    flow_nodes.year
+) nodes_with_co_nodes
+JOIN nodes ON nodes_with_co_nodes.node_id = nodes.id
+JOIN node_types ON nodes.node_type_id = node_types.id
+JOIN contexts ON nodes_with_co_nodes.context_id = contexts.id
+JOIN context_node_types cnt ON
+  nodes_with_co_nodes.context_id = cnt.context_id
+  AND nodes_with_co_nodes.position = cnt.column_position + 1
+  AND contexts.id = cnt.context_id
+  AND nodes.node_type_id = cnt.node_type_id
+  AND node_types.id = cnt.node_type_id;

--- a/spec/controllers/api/v3/dashboards/commodities_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/commodities_controller_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Api::V3::Dashboards::CommoditiesController, type: :controller do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Commodity.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/companies_controller_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Api::V3::Dashboards::CompaniesController, type: :controller do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Company.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/controllers/api/v3/dashboards/countries_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/countries_controller_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Api::V3::Dashboards::CountriesController, type: :controller do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Country.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/destinations_controller_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe Api::V3::Dashboards::DestinationsController, type: :controller do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Destination.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/controllers/api/v3/dashboards/exporters_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/exporters_controller_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Api::V3::Dashboards::ExportersController, type: :controller do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Exporter.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/controllers/api/v3/dashboards/importers_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/importers_controller_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Api::V3::Dashboards::ImportersController, type: :controller do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Importer.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
+++ b/spec/controllers/api/v3/dashboards/sources_controller_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Api::V3::Dashboards::SourcesController, type: :controller do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Source.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/responses/api/v3/dashboards/companies_spec.rb
+++ b/spec/responses/api/v3/dashboards/companies_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe 'Companies', type: :request do
     Api::V3::Readonly::FlowNode.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Company.refresh(sync: true, skip_dependencies: true)
   end
 

--- a/spec/services/api/v3/dashboards/filter_destinations_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_destinations_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Api::V3::Dashboards::FilterDestinations do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Destination.refresh(
       sync: true, skip_dependencies: true
     )

--- a/spec/services/api/v3/dashboards/filter_exporters_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_exporters_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Api::V3::Dashboards::FilterExporters do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Exporter.refresh(
       sync: true, skip_dependencies: true
     )

--- a/spec/services/api/v3/dashboards/filter_importers_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_importers_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Api::V3::Dashboards::FilterImporters do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Importer.refresh(
       sync: true, skip_dependencies: true
     )

--- a/spec/services/api/v3/dashboards/filter_sources_spec.rb
+++ b/spec/services/api/v3/dashboards/filter_sources_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe Api::V3::Dashboards::FilterSources do
     Api::V3::Readonly::NodesPerContextRankedByVolumePerYear.refresh(
       sync: true, skip_dependencies: true, skip_dependents: true
     )
+    Api::V3::Readonly::NodeWithFlowsPerYear.refresh(
+      sync: true, skip_dependencies: true, skip_dependents: true
+    )
     Api::V3::Readonly::Dashboards::Source.refresh(
       sync: true, skip_dependencies: true
     )


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169828789
https://www.pivotaltracker.com/story/show/169828841
https://www.pivotaltracker.com/story/show/169828825

## Description

In order to speed up the refresh process, as well as to enable fixing some weird bugs in dashboards filtering resulting from lack of support for year filtering, the dashboards mviews were changed into tables.

## Testing instructions

Run migrations - it's one of the long ones, but I think it's now faster than it used to be to refresh the dashboards tables. Then check if dashboards filtering works as before.
