### PR TITLE
Added process host display name

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -48,6 +48,7 @@ staging:
 sandbox:
   <<: *default_settings
   app_name: Trase (Sandbox)
+  process_host.display_name: "<%= ENV['NEW_RELIC_PROCESS_HOST_DISPLAY_NAME'] %>"
 
 demo:
   <<: *default_settings


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169861177

## Description

Trying to make NewRelic label hosts sensibly, so far the env var on its own didn't work.

## Testing instructions

When looking at sandbox overview in NewRelic, the hosts at the bottom of the page should have labels sandbox-data and sandbox-web
