### PR TITLE
Updated host address; also now associated with an elastic IP

### DIFF
--- a/config/deploy/sandbox.rb
+++ b/config/deploy/sandbox.rb
@@ -1,5 +1,5 @@
 server 'ec2-34-216-27-79.us-west-2.compute.amazonaws.com', user: 'ubuntu', roles: %w{web app db}, primary: true
-server 'ec2-34-223-6-56.us-west-2.compute.amazonaws.com', user: 'ubuntu', roles: %w{web app}, primary: false
+server 'ec2-44-225-147-82.us-west-2.compute.amazonaws.com', user: 'ubuntu', roles: %w{web app}, primary: false
 
 set :ssh_options, forward_agent: true
 


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169724680 (fix because IP changed...)

## Description

I didn't realise one of the hosts did not have a stable IP. Thus I stopped and started it and the IP changed. I have now associated that host with an elastic IP, which should prevent that from happening in the future.

## Testing instructions

`cap sandbox deploy` works for both hosts
