### PR TITLE
skip loading contexts directly in controller

### DIFF
--- a/app/controllers/api/public/nodes/destinations_controller.rb
+++ b/app/controllers/api/public/nodes/destinations_controller.rb
@@ -4,6 +4,8 @@ module Api
       class DestinationsController < ApiController
         include Nodes
 
+        skip_before_action :load_context
+
         private
 
         def filter_klass

--- a/app/controllers/api/public/nodes/exporters_controller.rb
+++ b/app/controllers/api/public/nodes/exporters_controller.rb
@@ -4,6 +4,8 @@ module Api
       class ExportersController < ApiController
         include Nodes
 
+        skip_before_action :load_context
+
         private
 
         def filter_klass

--- a/app/controllers/api/public/nodes/importers_controller.rb
+++ b/app/controllers/api/public/nodes/importers_controller.rb
@@ -4,6 +4,8 @@ module Api
       class ImportersController < ApiController
         include Nodes
 
+        skip_before_action :load_context
+
         private
 
         def filter_klass

--- a/app/controllers/api/public/nodes/sources_controller.rb
+++ b/app/controllers/api/public/nodes/sources_controller.rb
@@ -4,6 +4,8 @@ module Api
       class SourcesController < ApiController
         include Nodes
 
+        skip_before_action :load_context
+
         private
 
         def filter_klass

--- a/app/controllers/concerns/api/public/nodes.rb
+++ b/app/controllers/concerns/api/public/nodes.rb
@@ -6,10 +6,6 @@ module Api
       include PaginationHeaders
       include PaginatedCollection
 
-      included do
-        skip_before_action :load_context
-      end
-
       def index
         initialize_collection_for_index
         render json: @collection,


### PR DESCRIPTION
for some reason when in module doesn't work on staging

## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169912815

## Description

When skipping the context is included from a mixin, works on localhost but not on staging. 

## Testing instructions
This should work:

https://staging.trase.earth/api/public/nodes/exporters?commodity=SOY&country=BR
