### PR TITLE
We weren't adding default columns to flows fetch

### DIFF
--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.fetch.saga.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.fetch.saga.js
@@ -170,7 +170,6 @@ export function* getMoreData(name, reducer) {
   if (params.node_types_ids === null) {
     return;
   }
-  console.log(params);
   yield put(setLoadingItems(true, name));
   const url = getURLFromParams(GET_DASHBOARD_OPTIONS_URL, params);
   const { source, fetchPromise } = fetchWithCancel(url);

--- a/frontend/scripts/react-components/tool/tool.selectors.js
+++ b/frontend/scripts/react-components/tool/tool.selectors.js
@@ -14,7 +14,7 @@ export const getSelectedColumnsIds = createSelector(
     if (
       selectedColumnsIds &&
       selectedContext &&
-      selectedColumnsIds.length === selectedContext.defaultColumns.length &&
+      selectedColumnsIds.filter(Boolean).length === selectedContext.defaultColumns.length &&
       !extraColumn
     ) {
       return selectedColumnsIds;


### PR DESCRIPTION
## Pivotal Tracker

No link

## Description

We were using the shortcut in getSelectedColumnsIds to find the selectedColumnIds but some default columns were not added to the array resulting in null values.

I understand this early return helps performance but sometimes it causes some bugs we might want to remove it at some point

## Testing instructions

Go to Brazil - Soy and change last column (sandbox data)

![image](https://user-images.githubusercontent.com/9701591/69804150-37838700-11de-11ea-90ce-fde3c9e6e953.png)

