### PR TITLE
Fix crash when missing carto layers

### DIFF
--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -124,7 +124,7 @@ export function setMapContextLayers(contextualLayers) {
       const cartoIds = contextLayersCarto[NAMED_MAPS_ENV][layer.identifier];
       // TODO: implement multi-year support
       const cartoData = layer.cartoLayers[0];
-      if (!cartoData.rasterUrl && cartoIds) {
+      if (cartoData && !cartoData.rasterUrl && cartoIds) {
         contextLayer.cartoURL = `${CARTO_NAMED_MAPS_BASE_URL}${cartoIds.uid}/jsonp?callback=cb`;
         contextLayer.layergroupid = cartoIds.layergroupid;
       }


### PR DESCRIPTION
## Pivotal Tracker

No links

## Description

We were having an error if there were no cartolayers. This layers should be added anyway for Brazil water scarcity:

![image](https://user-images.githubusercontent.com/9701591/69954179-061afc00-14fb-11ea-8cff-6e18d585a14d.png)


## Testing instructions

Brazil Pork sankey (There is no edit layers)