### PR TITLE
Units should be shown in all rows

### DIFF
--- a/frontend/scripts/react-components/profiles/table/table.component.jsx
+++ b/frontend/scripts/react-components/profiles/table/table.component.jsx
@@ -38,7 +38,6 @@ class ProfilesTable extends Component {
   renderPlacesTable() {
     const { data, testId } = this.props;
     const columns = data.included_columns;
-
     return (
       <tbody>
         {data.rows[0].values.map((value, valueKey) => (
@@ -146,9 +145,7 @@ class ProfilesTable extends Component {
                         : formattedValue(value, valueIndex)}
                     </span>
                     {valueIndex > 0 && (
-                      <span className="unit">
-                        {rowIndex === 0 ? data.included_columns[valueIndex].unit : null}
-                      </span>
+                      <span className="unit">{data.included_columns[valueIndex].unit}</span>
                     )}
                   </>
                 )}


### PR DESCRIPTION
## Pivotal Tracker

No links

## Description

Add units to all the rows of the table, not only the first

## Testing instructions

http://localhost:8081/profile-actor?nodeId=23089&contextId=1
Check DEFORESTATION RISK table

![image](https://user-images.githubusercontent.com/9701591/69958893-0d93d280-1506-11ea-9d2b-a20249c16f0d.png)

