### PR TITLE
Fix: Germany not Sorriso destination in 2017

### DIFF
--- a/app/services/api/v3/dashboards/base_filter.rb
+++ b/app/services/api/v3/dashboards/base_filter.rb
@@ -61,6 +61,7 @@ module Api
           filter_by_node_types
           filter_by_profile_only
           filter_by_self
+          filter_by_year
         end
 
         def adjust_node_filters
@@ -110,6 +111,11 @@ module Api
           return unless @self_ids.any?
 
           @query = @query.where(id: @self_ids)
+        end
+
+        def filter_by_year
+          @query = @query.where('year >= ?', @start_year) if @start_year
+          @query = @query.where('year <= ?', @end_year) if @end_year
         end
       end
     end


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169866403

## Description

Endpoint was not filtering destinations by year. With the changes in underlying materialised views we introduced recently that is now possible.

## Testing instructions

Use urls from the PT, or go through dashboards selecting Brazil soy from Sorriso, Germany should not be coming up in destinations panel.


Please include examples where relevant
