### PR TITLE
Add tabs to destination panel

### DIFF
--- a/frontend/scripts/react-components/nodes-panel/destinations-panel/destinations-panel.component.jsx
+++ b/frontend/scripts/react-components/nodes-panel/destinations-panel/destinations-panel.component.jsx
@@ -7,6 +7,7 @@ import GridListItem from 'react-components/shared/grid-list-item/grid-list-item.
 import ResizeListener from 'react-components/shared/resize-listener.component';
 import { BREAKPOINTS } from 'constants';
 import OrderBy from 'react-components/nodes-panel/order-by.component';
+import Tabs from 'react-components/shared/tabs/tabs.component';
 
 import './destinations-panel.scss';
 
@@ -27,7 +28,10 @@ function DestinationsPanel(props) {
     setSearchResult,
     getSearchResults,
     setSelectedItems,
-    selectedNodesIds
+    selectedNodesIds,
+    tabs,
+    activeTab,
+    setSelectedTab
   } = props;
 
   useEffect(() => {
@@ -55,32 +59,42 @@ function DestinationsPanel(props) {
                 onSelect={setSearchResult}
                 onSearchTermChange={getSearchResults}
               />
-              <OrderBy orderBy={orderBy} setOrderBy={setOrderBy} />
             </div>
-            <GridList
-              className="dashboard-panel-pill-list"
-              items={destinations}
-              height={200}
-              width={width}
-              rowHeight={50}
-              columnWidth={190}
-              columnCount={columnsCount}
-              page={page}
-              getMoreItems={setPage}
-              loading={loading}
-              itemToScrollTo={itemToScrollTo}
-              excludingMode={ENABLE_REDESIGN_PAGES ? excludingMode : undefined}
-              onSelectAllClick={ENABLE_REDESIGN_PAGES ? setExcludingMode : undefined}
+            <Tabs
+              tabs={tabs}
+              onSelectTab={setSelectedTab}
+              selectedTab={activeTab}
+              itemTabRenderer={i => i.name}
+              getTabId={item => item.id}
+              actionComponent={<OrderBy orderBy={orderBy} setOrderBy={setOrderBy} />}
             >
-              {itemProps => (
-                <GridListItem
-                  {...itemProps}
-                  isActive={selectedNodesIds.includes(itemProps.item?.id)}
-                  enableItem={setSelectedItems}
-                  disableItem={setSelectedItems}
-                />
+              {activeTab && (
+                <GridList
+                  className="dashboard-panel-pill-list"
+                  items={destinations}
+                  height={200}
+                  width={width}
+                  rowHeight={50}
+                  columnWidth={190}
+                  columnCount={columnsCount}
+                  page={page}
+                  getMoreItems={setPage}
+                  loading={loading}
+                  itemToScrollTo={itemToScrollTo}
+                  excludingMode={ENABLE_REDESIGN_PAGES ? excludingMode : undefined}
+                  onSelectAllClick={ENABLE_REDESIGN_PAGES ? setExcludingMode : undefined}
+                >
+                  {itemProps => (
+                    <GridListItem
+                      {...itemProps}
+                      isActive={selectedNodesIds.includes(itemProps.item?.id)}
+                      enableItem={setSelectedItems}
+                      disableItem={setSelectedItems}
+                    />
+                  )}
+                </GridList>
               )}
-            </GridList>
+            </Tabs>
           </div>
         );
       }}
@@ -104,7 +118,10 @@ DestinationsPanel.propTypes = {
   excludingMode: PropTypes.bool,
   setExcludingMode: PropTypes.func,
   setOrderBy: PropTypes.func,
-  orderBy: PropTypes.object
+  orderBy: PropTypes.object,
+  tabs: PropTypes.array,
+  activeTab: PropTypes.object,
+  setSelectedTab: PropTypes.func
 };
 
 DestinationsPanel.defaultProps = {

--- a/frontend/scripts/react-components/nodes-panel/destinations-panel/destinations-panel.js
+++ b/frontend/scripts/react-components/nodes-panel/destinations-panel/destinations-panel.js
@@ -6,6 +6,7 @@ import {
   getSearchResults,
   setLoadingItems,
   setSelectedItems,
+  setSelectedTab,
   setExcludingMode,
   setOrderBy
 } from 'react-components/nodes-panel/nodes-panel.actions';
@@ -18,6 +19,7 @@ const mapDispatchToProps = {
   fetchData: key => fetchData(key, NAME),
   setOrderBy: orderBy => setOrderBy(orderBy, NAME),
   setExcludingMode: mode => setExcludingMode(mode, NAME),
+  setSelectedTab: activeTab => setSelectedTab(activeTab, NAME),
   setLoadingItems: loadingItems => setLoadingItems(loadingItems, NAME),
   setSearchResult: activeItem => setSearchResult(activeItem, NAME),
   getSearchResults: query => getSearchResults(query, NAME),

--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.modules.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.modules.js
@@ -8,6 +8,7 @@ const modules = {
   },
   destinations: {
     hasSearch: true,
+    hasTabs: true,
     hasMultipleSelection: true
   },
   exporters: {

--- a/frontend/scripts/utils/pluralize.js
+++ b/frontend/scripts/utils/pluralize.js
@@ -5,6 +5,7 @@ export default name => {
   const plural = {
     logisticsHub: 'logistics hubs',
     portOfImport: 'ports of import',
+    economicBloc: 'economic blocs',
     portOfExport: 'ports of export',
     districtOfExport: 'districts of export',
     countryOfProduction: 'country of production'


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170123242

## Description

Add tabs to destination panel

## Testing instructions

Go to dashboards and destination panel. You should see two tabs in sandbox data

![image](https://user-images.githubusercontent.com/9701591/70262429-9d4eb080-1794-11ea-95d2-612e6f6983ec.png)

Note: There might be some changes in the Sankey. Mostly about the column switch
