### PR TITLE
Performance/sankey flows improvements

### DIFF
--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -361,6 +361,7 @@ module Api
         def basic_flows_query
           cont_attr_table = @cont_attribute.flow_values_class.table_name
           query = Api::V3::Flow.
+            from('partitioned_flows flows').
             joins(cont_attr_table.to_sym).
             where(context_id: @context.id).
             where('year >= ? AND year <= ?', @year_start, @year_end).

--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -362,7 +362,7 @@ module Api
           cont_attr_table = @cont_attribute.flow_values_class.table_name
           query = Api::V3::Flow.
             from('partitioned_flows flows').
-            joins(cont_attr_table.to_sym).
+            joins("JOIN partitioned_#{cont_attr_table} #{cont_attr_table} ON flow_quants.flow_id = flows.id").
             where(context_id: @context.id).
             where('year >= ? AND year <= ?', @year_start, @year_end).
             where(

--- a/app/services/api/v3/flows/result.rb
+++ b/app/services/api/v3/flows/result.rb
@@ -21,29 +21,17 @@ module Api
         def initialize_data
           result = {}
           @flows.each do |flow|
-            active_path = get_active_path(flow)
-            identifier = active_path.dup
-            flow_hash = initialize_flow_hash(active_path, flow, identifier)
-
-            if result[identifier]
-              result[identifier][:quant] += flow['quant_value']
-            else
-              result[identifier] = flow_hash
-            end
+            path = flow.path
+            identifier = flow.path.dup
+            result[identifier] = initialize_flow_hash(flow, identifier)
           end
 
           @data = process_data(result)
         end
 
-        def get_active_path(flow)
-          flow.path.map.with_index do |node_id, i|
-            @active_nodes.key?(node_id) ? node_id : @other_nodes_ids[i]
-          end
-        end
-
-        def initialize_flow_hash(active_path, flow, identifier)
+        def initialize_flow_hash(flow, identifier)
           flow_hash = {
-            path: active_path,
+            path: flow.path,
             quant: flow['quant_value']
           }
 

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -105,10 +105,11 @@ module Api
           [
             Api::V3::Readonly::Context,
             Api::V3::Readonly::Attribute,
-            Api::V3::Readonly::Flow,
+            Api::V3::Readonly::Flow, # TODO: try to get rid of this one
             Api::V3::Readonly::FlowNode,
             Api::V3::Readonly::NodeWithFlowsPerYear
           ].each { |mview| mview.refresh(sync: true, skip_dependents: true) }
+          Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
           Api::V3::Readonly::DownloadFlow.refresh(
             sync: true, skip_dependents: true, skip_precompute: true
           )

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -110,6 +110,7 @@ module Api
             Api::V3::Readonly::NodeWithFlowsPerYear
           ].each { |mview| mview.refresh(sync: true, skip_dependents: true) }
           Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
+          Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
           Api::V3::Readonly::DownloadFlow.refresh(
             sync: true, skip_dependents: true, skip_precompute: true
           )

--- a/app/services/api/v3/table_partitions/create_partitions_for_flow_quants.rb
+++ b/app/services/api/v3/table_partitions/create_partitions_for_flow_quants.rb
@@ -1,0 +1,35 @@
+# Creates partitions for flow_quants and populates them with data from
+# flow_quants_v
+module Api
+  module V3
+    module TablePartitions
+      class CreatePartitionsForFlowQuants < CreatePartitions
+        def initialize
+          @table_name = :partitioned_flow_quants
+          @partition_key = :quant_id
+          super(@table_name, @partition_key)
+        end
+
+        def partition_key_values
+          Api::V3::Quant.pluck(:id)
+        end
+
+        def indexes
+          [
+            {columns: [:quant_id, :flow_id], unique: true}
+          ]
+        end
+
+        def insert_data(partition_name, partition_key_value)
+          execute(
+            <<~SQL
+              INSERT INTO #{partition_name}
+              SELECT flow_id, quant_id, value FROM flow_quants
+              WHERE #{@partition_key} = #{partition_key_value};
+            SQL
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/table_partitions/create_partitions_for_flows.rb
+++ b/app/services/api/v3/table_partitions/create_partitions_for_flows.rb
@@ -25,7 +25,7 @@ module Api
           execute(
             <<~SQL
               INSERT INTO #{partition_name}
-              SELECT id, context_id, year, path, unknown_path_positions(path) FROM flows
+              SELECT id, context_id, year, path, known_path_positions(path) FROM flows
               WHERE #{@partition_key} = #{partition_key_value};
             SQL
           )

--- a/app/services/api/v3/table_partitions/create_partitions_for_flows.rb
+++ b/app/services/api/v3/table_partitions/create_partitions_for_flows.rb
@@ -1,0 +1,36 @@
+# Creates partitions for flows and populates them with data from
+# flows_v
+module Api
+  module V3
+    module TablePartitions
+      class CreatePartitionsForFlows < CreatePartitions
+        def initialize
+          @table_name = :partitioned_flows
+          @partition_key = :context_id
+          super(@table_name, @partition_key)
+        end
+
+        def partition_key_values
+          Api::V3::Context.pluck(:id)
+        end
+
+        def indexes
+          [
+            {columns: [:context_id, :id], unique: true},
+            {columns: :year}
+          ]
+        end
+
+        def insert_data(partition_name, partition_key_value)
+          execute(
+            <<~SQL
+              INSERT INTO #{partition_name}
+              SELECT id, context_id, year, path, unknown_path_positions(path) FROM flows
+              WHERE #{@partition_key} = #{partition_key_value};
+            SQL
+          )
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20191209224804_create_function_known_path_positions.rb
+++ b/db/migrate/20191209224804_create_function_known_path_positions.rb
@@ -1,0 +1,24 @@
+class CreateFunctionKnownPathPositions < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION known_path_positions(
+        path INTEGER[]
+      )
+      RETURNS BOOLEAN[]
+      LANGUAGE 'sql'
+      IMMUTABLE
+      AS $BODY$
+        SELECT ARRAY_AGG(NOT nodes.is_unknown)::BOOLEAN[]
+        FROM UNNEST(path) WITH ORDINALITY a (node_id, position), nodes
+        WHERE nodes.id = a.node_id
+      $BODY$;
+
+      COMMENT ON FUNCTION known_path_positions(integer[]) IS
+      'Returns array with indexes in path where nodes are known.';
+    SQL
+  end
+
+  def down
+    execute 'DROP FUNCTION known_path_positions(integer[])'
+  end
+end

--- a/db/migrate/20191209224805_create_partitioned_flows.rb
+++ b/db/migrate/20191209224805_create_partitioned_flows.rb
@@ -1,0 +1,19 @@
+class CreatePartitionedFlows < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE TABLE partitioned_flows (
+        id INT,
+        context_id INT,
+        year SMALLINT,
+        path INT[],
+        unknown_path_positions SMALLINT[]
+      ) PARTITION BY LIST (context_id);
+    SQL
+
+    Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
+  end
+
+  def down
+    drop_table :partitioned_flows
+  end
+end

--- a/db/migrate/20191209224805_create_partitioned_flows.rb
+++ b/db/migrate/20191209224805_create_partitioned_flows.rb
@@ -6,7 +6,7 @@ class CreatePartitionedFlows < ActiveRecord::Migration[5.2]
         context_id INT,
         year SMALLINT,
         path INT[],
-        unknown_path_positions SMALLINT[]
+        known_path_positions BOOLEAN[]
       ) PARTITION BY LIST (context_id);
     SQL
 

--- a/db/migrate/20191209230015_create_partitioned_flow_quants.rb
+++ b/db/migrate/20191209230015_create_partitioned_flow_quants.rb
@@ -1,0 +1,17 @@
+class CreatePartitionedFlowQuants < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE TABLE partitioned_flow_quants (
+        flow_id INT,
+        quant_id INT,
+        value DOUBLE PRECISION
+      ) PARTITION BY LIST (quant_id);
+    SQL
+
+    Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
+  end
+
+  def down
+    drop_table :partitioned_flow_quants
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -151,6 +151,26 @@ COMMENT ON FUNCTION public.bucket_index(buckets double precision[], value double
 
 
 --
+-- Name: known_path_positions(integer[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.known_path_positions(path integer[]) RETURNS boolean[]
+    LANGUAGE sql IMMUTABLE
+    AS $$
+  SELECT ARRAY_AGG(NOT nodes.is_unknown)::BOOLEAN[]
+  FROM UNNEST(path) WITH ORDINALITY a (node_id, position), nodes
+  WHERE nodes.id = a.node_id
+$$;
+
+
+--
+-- Name: FUNCTION known_path_positions(path integer[]); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.known_path_positions(path integer[]) IS 'Returns array with indexes in path where nodes are known.';
+
+
+--
 -- Name: upsert_attributes(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -10105,6 +10125,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191202080716'),
 ('20191202083829'),
 ('20191202090700'),
-('20191205213427');
+('20191205213427'),
+('20191209224804');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5510,6 +5510,20 @@ CREATE VIEW public.nodes_with_flows_v AS
 
 
 --
+-- Name: partitioned_flows; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.partitioned_flows (
+    id integer,
+    context_id integer,
+    year smallint,
+    path integer[],
+    known_path_positions boolean[]
+)
+PARTITION BY LIST (context_id);
+
+
+--
 -- Name: profiles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -9081,6 +9095,20 @@ CREATE INDEX nodes_with_flows_per_year_id_idx ON public.nodes_with_flows_per_yea
 
 
 --
+-- Name: partitioned_flows_context_id_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partitioned_flows_context_id_id_idx ON ONLY public.partitioned_flows USING btree (context_id, id);
+
+
+--
+-- Name: partitioned_flows_year_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX partitioned_flows_year_idx ON ONLY public.partitioned_flows USING btree (year);
+
+
+--
 -- Name: qual_commodity_properties_commodity_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10126,6 +10154,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191202083829'),
 ('20191202090700'),
 ('20191205213427'),
-('20191209224804');
+('20191209224804'),
+('20191209224805');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5510,6 +5510,18 @@ CREATE VIEW public.nodes_with_flows_v AS
 
 
 --
+-- Name: partitioned_flow_quants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.partitioned_flow_quants (
+    flow_id integer,
+    quant_id integer,
+    value double precision
+)
+PARTITION BY LIST (quant_id);
+
+
+--
 -- Name: partitioned_flows; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -9095,6 +9107,13 @@ CREATE INDEX nodes_with_flows_per_year_id_idx ON public.nodes_with_flows_per_yea
 
 
 --
+-- Name: partitioned_flow_quants_quant_id_flow_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partitioned_flow_quants_quant_id_flow_id_idx ON ONLY public.partitioned_flow_quants USING btree (quant_id, flow_id);
+
+
+--
 -- Name: partitioned_flows_context_id_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10155,6 +10174,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191202090700'),
 ('20191205213427'),
 ('20191209224804'),
-('20191209224805');
+('20191209224805'),
+('20191209230015');
 
 

--- a/spec/controllers/api/v3/flows_controller_spec.rb
+++ b/spec/controllers/api/v3/flows_controller_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Api::V3::FlowsController, type: :controller do
     Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
     Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
     Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
+    Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
   end
 
   let(:cont_attribute) { api_v3_volume.readonly_attribute }

--- a/spec/responses/api/v3/flows_spec.rb
+++ b/spec/responses/api/v3/flows_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe 'Flows', type: :request do
   before(:each) do
     Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
     Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
+    Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
   end
 
   let(:cont_attribute) { api_v3_volume.readonly_attribute }

--- a/spec/services/api/v3/flows/filter_spec.rb
+++ b/spec/services/api/v3/flows/filter_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe Api::V3::Flows::Filter do
   include_context 'api v3 brazil recolor by attributes'
   include_context 'api v3 brazil flows quants'
 
-  before(:each) do
-    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
-    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
-    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
-  end
-
   let!(:api_v3_diamantino_node) {
     node = Api::V3::Node.where(
       name: 'DIAMANTINO', node_type_id: api_v3_municipality_node_type.id
@@ -56,6 +50,14 @@ RSpec.describe Api::V3::Flows::Filter do
       value: 0.1
     )
   }
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::ResizeByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::Readonly::RecolorByAttribute.refresh(sync: true, skip_dependents: true)
+    Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
+    Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
+  end
 
   describe :active_nodes do
     let(:node_types) {


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169391952

## Description

Introduces the following measures to speed up the sankey flows endpoint:
- a partitioned flows table
- a partitioned flow_quants table
- a change in how values are calculated for the "OTHER" nodes.
  Before:
      - find top nodes for each column
      - fetch all flows (~ 1 million for Brazil beef)
      - for each flow, for each element of the path, if it's one of top nodes then leave it alone, if it's not replace with 'OTHER'
      - group nodes by path
      - end up with ~ 1400 flows
  Now:
      - find top nodes for each column
      - fetch flows with non-top node ids already substituted with 'OTHER' and grouped by path (~ 1400 flows)
      - done

## Testing instructions

Run migrations and compare the outputs. That's easiest done when comparing visually using the sankey, if you have the same database as one of the dev environments. Ideally the same as sandbox, so that you can observe the difference in performance for Brazil beef.
