### PR TITLE
Performance/partitioned flows tables

### DIFF
--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -112,6 +112,7 @@ module Api
           Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
           Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
           Api::V3::TablePartitions::CreatePartitionsForFlowInds.new.call
+          Api::V3::TablePartitions::CreatePartitionsForFlowQuals.new.call
           Api::V3::Readonly::DownloadFlow.refresh(
             sync: true, skip_dependents: true, skip_precompute: true
           )

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -105,10 +105,11 @@ module Api
           [
             Api::V3::Readonly::Context,
             Api::V3::Readonly::Attribute,
-            Api::V3::Readonly::Flow,
+            Api::V3::Readonly::Flow, # TODO: try to get rid of this one
             Api::V3::Readonly::FlowNode,
             Api::V3::Readonly::NodeWithFlowsPerYear
           ].each { |mview| mview.refresh(sync: true, skip_dependents: true) }
+          Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
           Api::V3::Readonly::DownloadFlow.refresh(
             sync: true, skip_dependents: true, skip_precompute: true
           )

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -110,6 +110,7 @@ module Api
             Api::V3::Readonly::NodeWithFlowsPerYear
           ].each { |mview| mview.refresh(sync: true, skip_dependents: true) }
           Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
+          Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
           Api::V3::Readonly::DownloadFlow.refresh(
             sync: true, skip_dependents: true, skip_precompute: true
           )

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -111,6 +111,7 @@ module Api
           ].each { |mview| mview.refresh(sync: true, skip_dependents: true) }
           Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
           Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
+          Api::V3::TablePartitions::CreatePartitionsForFlowInds.new.call
           Api::V3::Readonly::DownloadFlow.refresh(
             sync: true, skip_dependents: true, skip_precompute: true
           )

--- a/app/services/api/v3/table_partitions/create_partitions_for_flow_inds.rb
+++ b/app/services/api/v3/table_partitions/create_partitions_for_flow_inds.rb
@@ -1,0 +1,35 @@
+# Creates partitions for flow_inds and populates them with data from
+# flow_inds_v
+module Api
+  module V3
+    module TablePartitions
+      class CreatePartitionsForFlowInds < CreatePartitions
+        def initialize
+          @table_name = :partitioned_flow_inds
+          @partition_key = :ind_id
+          super(@table_name, @partition_key)
+        end
+
+        def partition_key_values
+          Api::V3::Ind.pluck(:id)
+        end
+
+        def indexes
+          [
+            {columns: [:ind_id, :flow_id], unique: true}
+          ]
+        end
+
+        def insert_data(partition_name, partition_key_value)
+          execute(
+            <<~SQL
+              INSERT INTO #{partition_name}
+              SELECT flow_id, ind_id, value FROM flow_inds
+              WHERE #{@partition_key} = #{partition_key_value};
+            SQL
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/table_partitions/create_partitions_for_flow_quals.rb
+++ b/app/services/api/v3/table_partitions/create_partitions_for_flow_quals.rb
@@ -1,0 +1,35 @@
+# Creates partitions for flow_quals and populates them with data from
+# flow_quals_v
+module Api
+  module V3
+    module TablePartitions
+      class CreatePartitionsForFlowQuals < CreatePartitions
+        def initialize
+          @table_name = :partitioned_flow_quals
+          @partition_key = :qual_id
+          super(@table_name, @partition_key)
+        end
+
+        def partition_key_values
+          Api::V3::Qual.pluck(:id)
+        end
+
+        def indexes
+          [
+            {columns: [:qual_id, :flow_id], unique: true}
+          ]
+        end
+
+        def insert_data(partition_name, partition_key_value)
+          execute(
+            <<~SQL
+              INSERT INTO #{partition_name}
+              SELECT flow_id, qual_id, value FROM flow_quals
+              WHERE #{@partition_key} = #{partition_key_value};
+            SQL
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/table_partitions/create_partitions_for_flow_quants.rb
+++ b/app/services/api/v3/table_partitions/create_partitions_for_flow_quants.rb
@@ -1,0 +1,35 @@
+# Creates partitions for flow_quants and populates them with data from
+# flow_quants_v
+module Api
+  module V3
+    module TablePartitions
+      class CreatePartitionsForFlowQuants < CreatePartitions
+        def initialize
+          @table_name = :partitioned_flow_quants
+          @partition_key = :quant_id
+          super(@table_name, @partition_key)
+        end
+
+        def partition_key_values
+          Api::V3::Quant.pluck(:id)
+        end
+
+        def indexes
+          [
+            {columns: [:quant_id, :flow_id], unique: true}
+          ]
+        end
+
+        def insert_data(partition_name, partition_key_value)
+          execute(
+            <<~SQL
+              INSERT INTO #{partition_name}
+              SELECT flow_id, quant_id, value FROM flow_quants
+              WHERE #{@partition_key} = #{partition_key_value};
+            SQL
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/v3/table_partitions/create_partitions_for_flows.rb
+++ b/app/services/api/v3/table_partitions/create_partitions_for_flows.rb
@@ -1,0 +1,36 @@
+# Creates partitions for flows and populates them with data from
+# flows_v
+module Api
+  module V3
+    module TablePartitions
+      class CreatePartitionsForFlows < CreatePartitions
+        def initialize
+          @table_name = :partitioned_flows
+          @partition_key = :context_id
+          super(@table_name, @partition_key)
+        end
+
+        def partition_key_values
+          Api::V3::Context.pluck(:id)
+        end
+
+        def indexes
+          [
+            {columns: [:context_id, :id], unique: true},
+            {columns: :year}
+          ]
+        end
+
+        def insert_data(partition_name, partition_key_value)
+          execute(
+            <<~SQL
+              INSERT INTO #{partition_name}
+              SELECT id, context_id, year, path, known_path_positions(path) FROM flows
+              WHERE #{@partition_key} = #{partition_key_value};
+            SQL
+          )
+        end
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,10 @@ module TraseNewApi
 
     config.active_record.schema_format = :sql
     # do not dump partitions
-    ActiveRecord::SchemaDumper.ignore_tables = ['download_flows_*']
+    ActiveRecord::SchemaDumper.ignore_tables = [
+      'download_flows_*',
+      'partitioned_flows_*'
+    ]
 
     config.middleware.insert_before 0, Rack::Cors do
       allow do

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,8 @@ module TraseNewApi
     # do not dump partitions
     ActiveRecord::SchemaDumper.ignore_tables = [
       'download_flows_*',
-      'partitioned_flows_*'
+      'partitioned_flows_*',
+      'partitioned_flow_quants_*'
     ]
 
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,7 +31,8 @@ module TraseNewApi
     ActiveRecord::SchemaDumper.ignore_tables = [
       'download_flows_*',
       'partitioned_flows_*',
-      'partitioned_flow_quants_*'
+      'partitioned_flow_quants_*',
+      'partitioned_flow_inds_*'
     ]
 
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,8 @@ module TraseNewApi
       'download_flows_*',
       'partitioned_flows_*',
       'partitioned_flow_quants_*',
-      'partitioned_flow_inds_*'
+      'partitioned_flow_inds_*',
+      'partitioned_flow_quals_*'
     ]
 
     config.middleware.insert_before 0, Rack::Cors do

--- a/db/migrate/20191209224804_create_function_known_path_positions.rb
+++ b/db/migrate/20191209224804_create_function_known_path_positions.rb
@@ -1,0 +1,24 @@
+class CreateFunctionKnownPathPositions < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION known_path_positions(
+        path INTEGER[]
+      )
+      RETURNS BOOLEAN[]
+      LANGUAGE 'sql'
+      IMMUTABLE
+      AS $BODY$
+        SELECT ARRAY_AGG(NOT nodes.is_unknown)::BOOLEAN[]
+        FROM UNNEST(path) WITH ORDINALITY a (node_id, position), nodes
+        WHERE nodes.id = a.node_id
+      $BODY$;
+
+      COMMENT ON FUNCTION known_path_positions(integer[]) IS
+      'Returns array with indexes in path where nodes are known.';
+    SQL
+  end
+
+  def down
+    execute 'DROP FUNCTION known_path_positions(integer[])'
+  end
+end

--- a/db/migrate/20191209224805_create_partitioned_flows.rb
+++ b/db/migrate/20191209224805_create_partitioned_flows.rb
@@ -1,0 +1,19 @@
+class CreatePartitionedFlows < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE TABLE partitioned_flows (
+        id INT,
+        context_id INT,
+        year SMALLINT,
+        path INT[],
+        known_path_positions SMALLINT[]
+      ) PARTITION BY LIST (context_id);
+    SQL
+
+    Api::V3::TablePartitions::CreatePartitionsForFlows.new.call
+  end
+
+  def down
+    drop_table :partitioned_flows
+  end
+end

--- a/db/migrate/20191209230015_create_partitioned_flow_quants.rb
+++ b/db/migrate/20191209230015_create_partitioned_flow_quants.rb
@@ -1,0 +1,17 @@
+class CreatePartitionedFlowQuants < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE TABLE partitioned_flow_quants (
+        flow_id INT,
+        quant_id INT,
+        value DOUBLE PRECISION
+      ) PARTITION BY LIST (quant_id);
+    SQL
+
+    Api::V3::TablePartitions::CreatePartitionsForFlowQuants.new.call
+  end
+
+  def down
+    drop_table :partitioned_flow_quants
+  end
+end

--- a/db/migrate/20191211221707_create_partitioned_flow_inds.rb
+++ b/db/migrate/20191211221707_create_partitioned_flow_inds.rb
@@ -1,0 +1,17 @@
+class CreatePartitionedFlowInds < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE TABLE partitioned_flow_inds (
+        flow_id INT,
+        ind_id INT,
+        value DOUBLE PRECISION
+      ) PARTITION BY LIST (ind_id);
+    SQL
+
+    Api::V3::TablePartitions::CreatePartitionsForFlowInds.new.call
+  end
+
+  def down
+    drop_table :partitioned_flow_inds
+  end
+end

--- a/db/migrate/20191211222503_create_partitioned_flow_quals.rb
+++ b/db/migrate/20191211222503_create_partitioned_flow_quals.rb
@@ -1,0 +1,17 @@
+class CreatePartitionedFlowQuals < ActiveRecord::Migration[5.2]
+  def up
+    execute <<~SQL
+      CREATE TABLE partitioned_flow_quals (
+        flow_id INT,
+        qual_id INT,
+        value TEXT
+      ) PARTITION BY LIST (qual_id);
+    SQL
+
+    Api::V3::TablePartitions::CreatePartitionsForFlowQuals.new.call
+  end
+
+  def down
+    drop_table :partitioned_flow_quals
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5510,6 +5510,18 @@ CREATE VIEW public.nodes_with_flows_v AS
 
 
 --
+-- Name: partitioned_flow_inds; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.partitioned_flow_inds (
+    flow_id integer,
+    ind_id integer,
+    value double precision
+)
+PARTITION BY LIST (ind_id);
+
+
+--
 -- Name: partitioned_flow_quants; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -9107,6 +9119,13 @@ CREATE INDEX nodes_with_flows_per_year_id_idx ON public.nodes_with_flows_per_yea
 
 
 --
+-- Name: partitioned_flow_inds_ind_id_flow_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partitioned_flow_inds_ind_id_flow_id_idx ON ONLY public.partitioned_flow_inds USING btree (ind_id, flow_id);
+
+
+--
 -- Name: partitioned_flow_quants_quant_id_flow_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10175,6 +10194,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191205213427'),
 ('20191209224804'),
 ('20191209224805'),
-('20191209230015');
+('20191209230015'),
+('20191211221707');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -151,6 +151,26 @@ COMMENT ON FUNCTION public.bucket_index(buckets double precision[], value double
 
 
 --
+-- Name: known_path_positions(integer[]); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.known_path_positions(path integer[]) RETURNS boolean[]
+    LANGUAGE sql IMMUTABLE
+    AS $$
+  SELECT ARRAY_AGG(NOT nodes.is_unknown)::BOOLEAN[]
+  FROM UNNEST(path) WITH ORDINALITY a (node_id, position), nodes
+  WHERE nodes.id = a.node_id
+$$;
+
+
+--
+-- Name: FUNCTION known_path_positions(path integer[]); Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON FUNCTION public.known_path_positions(path integer[]) IS 'Returns array with indexes in path where nodes are known.';
+
+
+--
 -- Name: upsert_attributes(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -10105,6 +10125,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191202080716'),
 ('20191202083829'),
 ('20191202090700'),
-('20191205213427');
+('20191205213427'),
+('20191209224804');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5510,6 +5510,20 @@ CREATE VIEW public.nodes_with_flows_v AS
 
 
 --
+-- Name: partitioned_flows; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.partitioned_flows (
+    id integer,
+    context_id integer,
+    year smallint,
+    path integer[],
+    known_path_positions boolean[]
+)
+PARTITION BY LIST (context_id);
+
+
+--
 -- Name: profiles_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -9081,6 +9095,20 @@ CREATE INDEX nodes_with_flows_per_year_id_idx ON public.nodes_with_flows_per_yea
 
 
 --
+-- Name: partitioned_flows_context_id_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partitioned_flows_context_id_id_idx ON ONLY public.partitioned_flows USING btree (context_id, id);
+
+
+--
+-- Name: partitioned_flows_year_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX partitioned_flows_year_idx ON ONLY public.partitioned_flows USING btree (year);
+
+
+--
 -- Name: qual_commodity_properties_commodity_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10126,6 +10154,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191202083829'),
 ('20191202090700'),
 ('20191205213427'),
-('20191209224804');
+('20191209224804'),
+('20191209224805');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5510,6 +5510,18 @@ CREATE VIEW public.nodes_with_flows_v AS
 
 
 --
+-- Name: partitioned_flow_quants; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.partitioned_flow_quants (
+    flow_id integer,
+    quant_id integer,
+    value double precision
+)
+PARTITION BY LIST (quant_id);
+
+
+--
 -- Name: partitioned_flows; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -9095,6 +9107,13 @@ CREATE INDEX nodes_with_flows_per_year_id_idx ON public.nodes_with_flows_per_yea
 
 
 --
+-- Name: partitioned_flow_quants_quant_id_flow_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partitioned_flow_quants_quant_id_flow_id_idx ON ONLY public.partitioned_flow_quants USING btree (quant_id, flow_id);
+
+
+--
 -- Name: partitioned_flows_context_id_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10155,6 +10174,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191202090700'),
 ('20191205213427'),
 ('20191209224804'),
-('20191209224805');
+('20191209224805'),
+('20191209230015');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5522,6 +5522,18 @@ PARTITION BY LIST (ind_id);
 
 
 --
+-- Name: partitioned_flow_quals; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.partitioned_flow_quals (
+    flow_id integer,
+    qual_id integer,
+    value text
+)
+PARTITION BY LIST (qual_id);
+
+
+--
 -- Name: partitioned_flow_quants; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -9126,6 +9138,13 @@ CREATE UNIQUE INDEX partitioned_flow_inds_ind_id_flow_id_idx ON ONLY public.part
 
 
 --
+-- Name: partitioned_flow_quals_qual_id_flow_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX partitioned_flow_quals_qual_id_flow_id_idx ON ONLY public.partitioned_flow_quals USING btree (qual_id, flow_id);
+
+
+--
 -- Name: partitioned_flow_quants_quant_id_flow_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -10195,6 +10214,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191209224804'),
 ('20191209224805'),
 ('20191209230015'),
-('20191211221707');
+('20191211221707'),
+('20191211222503');
 
 


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169391952
https://www.pivotaltracker.com/story/show/170177808
https://www.pivotaltracker.com/story/show/169391999

## Description

These database changes will be used in query optimisations for sankey, downloads and dashboards. This PR introduces no changes to functionality, just the new tables and services, so can be merged without side effects, other than an increase in the size of the db. Hopefully it will allow to get rid of the flows_mv materialised view and the download_flows partitioned table, so that afterwards the size is reduced.

## Testing instructions

Run migrations, observe new partitioned tables in the database.
