### PR TITLE
Adds a way to configure shared geometries

### DIFF
--- a/app/admin/api/v3/context_node_type_property.rb
+++ b/app/admin/api/v3/context_node_type_property.rb
@@ -2,7 +2,8 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
   menu parent: 'General', priority: 3
 
   permit_params :context_node_type_id, :column_group, :is_default,
-                :is_geo_column, :is_choropleth_disabled, :role, :prefix
+                :is_geo_column, :is_choropleth_disabled,
+                :geometry_context_node_type_id, :role, :prefix
 
   after_action :clear_cache, only: [:create, :update, :destroy]
 
@@ -15,17 +16,32 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
   form do |f|
     f.semantic_errors
     inputs do
-      input :context_node_type, as: :select, required: true,
-                                collection: Api::V3::ContextNodeType.select_options
-      input :column_group, as: :select, required: true,
-                           collection: Api::V3::ContextNodeTypeProperty::COLUMN_GROUP,
-                           hint: object.class.column_comment('column_group')
-      input :is_default, as: :boolean, required: true,
-                         hint: object.class.column_comment('is_default')
-      input :is_geo_column, as: :boolean, required: true,
-                            hint: object.class.column_comment('is_geo_column')
-      input :is_choropleth_disabled, as: :boolean, required: true,
-                                     hint: object.class.column_comment('is_choropleth_disabled')
+      input :context_node_type,
+            as: :select,
+            required: true,
+            collection: Api::V3::ContextNodeType.select_options
+      input :column_group,
+            as: :select,
+            required: true,
+            collection: Api::V3::ContextNodeTypeProperty::COLUMN_GROUP,
+            hint: object.class.column_comment('column_group')
+      input :is_default,
+            as: :boolean,
+            required: true,
+            hint: object.class.column_comment('is_default')
+      input :is_geo_column,
+            as: :boolean,
+            required: true,
+            hint: object.class.column_comment('is_geo_column')
+      input :is_choropleth_disabled,
+            as: :boolean,
+            required: true,
+            hint: object.class.column_comment('is_choropleth_disabled')
+      input :geometry_context_node_type_id,
+            as: :select,
+            required: true,
+            collection: Api::V3::ContextNodeType.select_options,
+            hint: object.class.column_comment('geometry_context_node_type_id')
       input :role,
             as: :select,
             collection: Api::V3::ContextNodeTypeProperty.roles,
@@ -47,6 +63,7 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
     column :is_default
     column :is_geo_column
     column :is_choropleth_disabled
+    column('Geo Node Type', sortable: true) { |property| property.geometry_context_node_type&.node_type&.name }
     column :role
     column :prefix
     actions
@@ -57,11 +74,11 @@ ActiveAdmin.register Api::V3::ContextNodeTypeProperty, as: 'ContextNodeTypePrope
       row('Country') { |property| property.context_node_type&.context&.country&.name }
       row('Commodity') { |property| property.context_node_type&.context&.commodity&.name }
       row('Node Type') { |property| property.context_node_type&.node_type&.name }
-
       row :column_group
       row :is_default
       row :is_geo_column
       row :is_choropleth_disabled
+      row('Geo Node Type') { |property| property.geometry_context_node_type&.node_type&.name }
       row :role
       row :prefix
       row :created_at

--- a/app/models/api/v3/context_node_type.rb
+++ b/app/models/api/v3/context_node_type.rb
@@ -37,7 +37,7 @@ module Api
 
       def self.select_options
         Api::V3::ContextNodeType.includes(
-          context: [:country, :commodity]
+          {context: [:country, :commodity]}, :node_type
         ).order(
           'countries.name', 'commodities.name', :column_position
         ).map do |ctx_nt|

--- a/app/serializers/api/v3/node_types/node_type_serializer.rb
+++ b/app/serializers/api/v3/node_types/node_type_serializer.rb
@@ -10,6 +10,7 @@ module Api
                    :is_default,
                    :is_geo,
                    :is_choropleth_disabled,
+                   :geometry_node_type_id,
                    :profile_type,
                    :filter_to
 

--- a/app/services/api/v3/node_types/filter.rb
+++ b/app/services/api/v3/node_types/filter.rb
@@ -9,7 +9,14 @@ module Api
         def call
           Api::V3::NodeType.
             joins(context_node_types: :context_node_type_property).
-            joins("LEFT JOIN #{Api::V3::Profile.table_name} ON profiles.context_node_type_id = context_node_types.id").
+            joins(
+              'LEFT JOIN profiles
+              ON profiles.context_node_type_id = context_node_types.id'
+            ).
+            joins(
+              'LEFT JOIN context_node_types geo_cnt
+              ON geo_cnt.id = context_node_type_properties.geometry_context_node_type_id'
+            ).
             select([
               'node_types.id',
               'context_node_types.context_id',
@@ -20,6 +27,7 @@ module Api
               'context_node_type_properties.is_default',
               'context_node_type_properties.is_geo_column AS is_geo',
               'context_node_type_properties.is_choropleth_disabled',
+              'geo_cnt.node_type_id AS geometry_node_type_id',
               'profiles.name AS profile_type'
             ]).
             where('context_node_types.context_id = :context_id', context_id: @context.id).

--- a/db/migrate/20191212151744_add_geometry_node_type_id_to_context_node_type_properties.rb
+++ b/db/migrate/20191212151744_add_geometry_node_type_id_to_context_node_type_properties.rb
@@ -1,0 +1,10 @@
+class AddGeometryNodeTypeIdToContextNodeTypeProperties < ActiveRecord::Migration[5.2]
+  def change
+    add_column :context_node_type_properties,
+      :geometry_context_node_type_id,
+      :integer
+    add_foreign_key :context_node_type_properties,
+      :context_node_types,
+      column: :geometry_context_node_type_id
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -220,6 +220,12 @@ tables:
         comment: When set, show nodes on map
       - name: is_choropleth_disabled
         comment: When set, do not display the map choropleth
+      - name: geometry_context_node_type_id
+        comment: Use for geo columns, when geometry is to be taken from another node type (e.g. logistics hub -> municipality)
+      - name: role
+        comment: A grouping which defines in which filtering panel to display nodes
+      - name: prefix
+        comment: Used to construct the summary sentence of selection criteria
   - name: contexts
     comment: Country-commodity combinations.
     columns:

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1912,6 +1912,7 @@ CREATE TABLE public.context_node_type_properties (
     is_choropleth_disabled boolean DEFAULT false NOT NULL,
     role character varying NOT NULL,
     prefix text NOT NULL,
+    geometry_context_node_type_id integer,
     CONSTRAINT context_node_type_properties_role_check CHECK (((role)::text = ANY (ARRAY[('source'::character varying)::text, ('exporter'::character varying)::text, ('importer'::character varying)::text, ('destination'::character varying)::text])))
 );
 
@@ -1942,6 +1943,27 @@ COMMENT ON COLUMN public.context_node_type_properties.is_geo_column IS 'When set
 --
 
 COMMENT ON COLUMN public.context_node_type_properties.is_choropleth_disabled IS 'When set, do not display the map choropleth';
+
+
+--
+-- Name: COLUMN context_node_type_properties.role; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_node_type_properties.role IS 'A grouping which defines in which filtering panel to display nodes';
+
+
+--
+-- Name: COLUMN context_node_type_properties.prefix; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_node_type_properties.prefix IS 'Used to construct the summary sentence of selection criteria';
+
+
+--
+-- Name: COLUMN context_node_type_properties.geometry_context_node_type_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.context_node_type_properties.geometry_context_node_type_id IS 'Use for geo columns, when geometry is to be taken from another node type (e.g. logistics hub -> municipality)';
 
 
 --
@@ -9567,6 +9589,14 @@ ALTER TABLE ONLY public.download_versions
 
 
 --
+-- Name: context_node_type_properties fk_rails_40673dee59; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.context_node_type_properties
+    ADD CONSTRAINT fk_rails_40673dee59 FOREIGN KEY (geometry_context_node_type_id) REFERENCES public.context_node_types(id);
+
+
+--
 -- Name: chart_quals fk_rails_48ef39e784; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -10215,6 +10245,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20191209224805'),
 ('20191209230015'),
 ('20191211221707'),
-('20191211222503');
+('20191211222503'),
+('20191212151744');
 
 

--- a/frontend/scripts/react-components/profile-node/profile-node.reducer.js
+++ b/frontend/scripts/react-components/profile-node/profile-node.reducer.js
@@ -16,13 +16,6 @@ const profileNodeReducer = {
     return immer(state, draft => {
       const { columns } = action.payload;
 
-      // TODO the API should have the info on which file to load (if any) per column
-      const municipalitiesColumn = columns.find(column => column.name === 'MUNICIPALITY');
-      const logisticsHubColumn = columns.find(column => column.name === 'LOGISTICS HUB');
-      if (logisticsHubColumn && municipalitiesColumn) {
-        logisticsHubColumn.useGeometryFromColumnId = municipalitiesColumn.id;
-      }
-
       draft.columns = {};
       columns.forEach(column => {
         draft.columns[column.id] = column;

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -120,13 +120,6 @@ const toolLinksReducer = {
     return immer(state, draft => {
       const { columns } = action.payload;
 
-      // TODO the API should have the info on which file to load (if any) per column
-      const municipalitiesColumn = columns.find(column => column.name === 'MUNICIPALITY');
-      const logisticsHubColumn = columns.find(column => column.name === 'LOGISTICS HUB');
-      if (logisticsHubColumn && municipalitiesColumn) {
-        logisticsHubColumn.useGeometryFromColumnId = municipalitiesColumn.id;
-      }
-
       draft.data.columns = {};
       columns.forEach(column => {
         draft.data.columns[column.id] = column;

--- a/frontend/scripts/react-components/tool/map/map.component.js
+++ b/frontend/scripts/react-components/tool/map/map.component.js
@@ -167,16 +167,16 @@ export default class MapComponent {
 
     // create geometry layers for all polygonTypes that have their own geometry
     mapVectorData.forEach(polygonType => {
-      if (polygonType.useGeometryFromColumnId === undefined) {
+      if (polygonType.geometryNodeTypeId === null) {
         this.polygonTypesLayers[polygonType.id] = this._createPolygonTypeLayer(polygonType);
       }
     });
 
     // for polygonTypes that don't have their geometry, link to actual geometry layers
     mapVectorData.forEach(polygonType => {
-      if (polygonType.useGeometryFromColumnId !== undefined) {
+      if (polygonType.geometryNodeTypeId !== null) {
         this.polygonTypesLayers[polygonType.id] = this.polygonTypesLayers[
-          polygonType.useGeometryFromColumnId
+          polygonType.geometryNodeTypeId
         ];
       }
     });

--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -43,9 +43,9 @@ export function loadMapVectorData() {
       const vectorData = {
         id: geoColumn.id,
         name: geoColumn.name,
-        useGeometryFromColumnId: geoColumn.useGeometryFromColumnId
+        geometryNodeTypeId: geoColumn.geometryNodeTypeId
       };
-      if (geoColumn.useGeometryFromColumnId === undefined) {
+      if (geoColumn.geometryNodeTypeId === null) {
         const selectedContext = getSelectedContext(getState());
         const countryName = selectedContext.countryName;
         const vectorLayerURL = `vector_layers/${countryName}_${geoColumn.name.replace(

--- a/spec/models/api/v3/context_node_type_property_spec.rb
+++ b/spec/models/api/v3/context_node_type_property_spec.rb
@@ -20,6 +20,30 @@ RSpec.describe Api::V3::ContextNodeTypeProperty, type: :model do
         :api_v3_context_node_type_property, role: :exporter, prefix: nil
       )
     }
+    let(:context_node_type_from_another_context) {
+      cnt = FactoryBot.create(:api_v3_context_node_type)
+      FactoryBot.create(
+        :api_v3_context_node_type_property,
+        context_node_type: cnt,
+        is_geo_column: true
+      )
+      cnt
+    }
+
+    let(:property_with_invalid_geometry_context_node_type_1) {
+      FactoryBot.build(
+        :api_v3_context_node_type_property,
+        context_node_type: api_v3_logistics_hub_context_node,
+        geometry_context_node_type: context_node_type_from_another_context
+      )
+    }
+    let(:property_with_invalid_geometry_context_node_type_2) {
+      FactoryBot.build(
+        :api_v3_context_node_type_property,
+        context_node_type: api_v3_biome_context_node,
+        geometry_context_node_type: api_v3_exporter1_context_node
+      )
+    }
     it 'fails when context node type missing' do
       expect(property_without_context_node_type).to have(2).
         errors_on(:context_node_type)
@@ -30,6 +54,14 @@ RSpec.describe Api::V3::ContextNodeTypeProperty, type: :model do
     it 'fails when prefix missing' do
       expect(property_without_prefix).to have(1).
         errors_on(:prefix)
+    end
+    it 'fails when geometry_context_node_type from different context' do
+      expect(property_with_invalid_geometry_context_node_type_1).to have(1).
+        errors_on(:geometry_context_node_type_id)
+    end
+    it 'fails when geometry_context_node_type not geo column' do
+      expect(property_with_invalid_geometry_context_node_type_2).to have(1).
+        errors_on(:geometry_context_node_type_id)
     end
   end
 

--- a/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
+++ b/spec/support/contexts/api/v3/brazil/brazil_context_node_types.rb
@@ -16,6 +16,7 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
+        is_geo_column: true,
         column_group: 0,
         role: 'source'
       )
@@ -36,6 +37,7 @@ shared_context 'api v3 brazil context node types' do
       FactoryBot.create(
         :api_v3_context_node_type_property,
         context_node_type: cnt,
+        is_geo_column: true,
         column_group: 0,
         role: 'source'
       )
@@ -57,6 +59,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 0,
+        is_geo_column: true,
         role: 'source',
         is_default: true
       )
@@ -78,6 +81,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 0,
+        is_geo_column: true,
         role: 'source'
       )
     end
@@ -98,6 +102,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 1,
+        is_geo_column: false,
         role: 'exporter'
       )
     end
@@ -118,6 +123,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 1,
+        is_geo_column: false,
         role: 'exporter'
       )
     end
@@ -138,6 +144,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 2,
+        is_geo_column: false,
         role: 'importer'
       )
     end
@@ -158,6 +165,7 @@ shared_context 'api v3 brazil context node types' do
         :api_v3_context_node_type_property,
         context_node_type: cnt,
         column_group: 3,
+        is_geo_column: false,
         role: 'destination'
       )
     end

--- a/spec/support/schemas/v3_columns.json
+++ b/spec/support/schemas/v3_columns.json
@@ -11,6 +11,10 @@
         "additionalProperties": false,
         "id": "/properties/data/items",
         "properties": {
+          "geometryNodeTypeId": {
+            "id": "/properties/data/items/properties/geometryNodeTypeId",
+            "type": ["integer", "null"]
+          },
           "group": {
             "id": "/properties/data/items/properties/group",
             "type": "integer"
@@ -65,7 +69,8 @@
           "isChoroplethDisabled",
           "isDefault",
           "role",
-          "filterTo"
+          "filterTo",
+          "geometryNodeTypeId"
         ],
         "type": "object"
       },


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170277633

## Description

Added a new column in context_node_type_properties, which allows to link to a different context node type in same context.

## Testing instructions

<img width="1185" alt="Screenshot 2019-12-13 at 10 32 10" src="https://user-images.githubusercontent.com/134055/70789844-1ef59e00-1d94-11ea-9794-8a6c1d0670a6.png">

columns endpoint:
<img width="404" alt="Screenshot 2019-12-13 at 10 33 10" src="https://user-images.githubusercontent.com/134055/70789868-29b03300-1d94-11ea-96d4-0f036ee9354e.png">
