### PR TITLE
Refresh nodes_stats_mv during import

### DIFF
--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -120,6 +120,7 @@ module Api
           [
             Api::V3::Readonly::NodeWithFlows,
             Api::V3::Readonly::NodeWithFlowsOrGeo,
+            Api::V3::Readonly::NodesStats,
             Api::V3::Readonly::ChartAttribute,
             Api::V3::Readonly::DashboardsAttribute,
             Api::V3::Readonly::DownloadAttribute,


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170278697

## Description

materialized view with aggregated values was not refreshed; now refreshed as part of the import process

## Testing instructions

<img width="995" alt="Screenshot 2019-12-13 at 11 28 17" src="https://user-images.githubusercontent.com/134055/70793511-bd393200-1d9b-11ea-86eb-b67157d96ac4.png">

