### PR TITLE
Added second production instance

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,7 @@
-server 'trase.earth', user: 'ubuntu', roles: %w{web app db}, primary: true
+server 'ec2-54-68-137-160.us-west-2.compute.amazonaws.com', user: 'ubuntu', roles: %w{web app db}, primary: true
+server 'ec2-54-244-16-87.us-west-2.compute.amazonaws.com', user: 'ubuntu', roles: %w{web app}, primary: false
+
 set :ssh_options, forward_agent: true
 
+set :sitemap_roles, :db
 after 'deploy:finishing', 'sitemap:refresh'


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170357672

## Description

There is now a load balancer in front of two production machines, like in sandbox.

## Testing instructions

`cap production deploy` deploys to two instances, runs migrations & generates sitemap only on one (the `data` one, which is a better machine)
