### PR TITLE
Group flows through "OTHER" in the database rather than in ruby

### DIFF
--- a/app/services/api/v3/flows/result.rb
+++ b/app/services/api/v3/flows/result.rb
@@ -21,29 +21,17 @@ module Api
         def initialize_data
           result = {}
           @flows.each do |flow|
-            active_path = get_active_path(flow)
-            identifier = active_path.dup
-            flow_hash = initialize_flow_hash(active_path, flow, identifier)
-
-            if result[identifier]
-              result[identifier][:quant] += flow['quant_value']
-            else
-              result[identifier] = flow_hash
-            end
+            path = flow.path
+            identifier = flow.path.dup
+            result[identifier] = initialize_flow_hash(flow, identifier)
           end
 
           @data = process_data(result)
         end
 
-        def get_active_path(flow)
-          flow.path.map.with_index do |node_id, i|
-            @active_nodes.key?(node_id) ? node_id : @other_nodes_ids[i]
-          end
-        end
-
-        def initialize_flow_hash(active_path, flow, identifier)
+        def initialize_flow_hash(flow, identifier)
           flow_hash = {
-            path: active_path,
+            path: flow.path,
             quant: flow['quant_value']
           }
 

--- a/spec/services/api/v3/flows/filter_spec.rb
+++ b/spec/services/api/v3/flows/filter_spec.rb
@@ -67,13 +67,17 @@ RSpec.describe Api::V3::Flows::Filter do
       ]
     }
 
+    let(:node_types_positions) {
+      [2,5,6,7]
+    }
+
     let(:filter_params) {
       {
         year_start: 2015,
         year_end: 2015,
         node_types_ids: node_types.map(&:id),
         cont_attribute_id: api_v3_volume.readonly_attribute.id,
-        limit: 1
+        limit: 5
       }
     }
 
@@ -86,9 +90,10 @@ RSpec.describe Api::V3::Flows::Filter do
         it 'does not include low volume nodes in active nodes' do
           filter = Api::V3::Flows::Filter.new(
             api_v3_context,
-            filter_params
+            filter_params.merge(limit: 1)
           )
           filter.call
+
           expect(filter.active_nodes).not_to have_key(api_v3_diamantino_node.id)
         end
       end
@@ -111,7 +116,12 @@ RSpec.describe Api::V3::Flows::Filter do
             )
           )
           filter.call
-          expect(filter.flows).to include(api_v3_diamantino_flow)
+          paths = filter.flows.map(&:path)
+          diamantino_path =
+            api_v3_diamantino_flow.path.select.with_index do |id, position|
+              node_types_positions.include?(position)
+            end
+          expect(paths).to include(diamantino_path)
         end
       end
     end
@@ -125,7 +135,7 @@ RSpec.describe Api::V3::Flows::Filter do
         it 'does not include low volume nodes in active nodes' do
           filter = Api::V3::Flows::Filter.new(
             api_v3_context,
-            filter_params.merge(expanded_nodes)
+            filter_params.merge(expanded_nodes).merge(limit: 1)
           )
           filter.call
           expect(filter.active_nodes).not_to have_key(api_v3_diamantino_node.id)


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/169391952

## Description

A change in how values are calculated for the "OTHER" nodes.
  Before:
      - find top nodes for each column
      - fetch all flows (~ 1 million for Brazil beef)
      - for each flow, for each element of the path, if it's one of top nodes then leave it alone, if it's not replace with 'OTHER'
      - group nodes by path
      - end up with ~ 1400 flows
  Now:
      - find top nodes for each column
      - fetch flows with non-top node ids already substituted with 'OTHER' and grouped by path (~ 1400 flows)
      - done

## Testing instructions

Compare the outputs. That's easiest done when comparing visually using the sankey, if you have the same database as one of the dev environments. Ideally the same as sandbox, so that you can observe the difference in performance for Brazil beef.