### PR TITLE
Raise 404 instead of 500 when profile configuration incomplete

### DIFF
--- a/app/admin/api/v3/chart_node_type.rb
+++ b/app/admin/api/v3/chart_node_type.rb
@@ -1,7 +1,10 @@
 ActiveAdmin.register Api::V3::ChartNodeType, as: 'ChartNodeType' do
   menu parent: 'Profiles', priority: 6
 
-  includes [chart: {profile: {context_node_type: [:context, :node_type]}}]
+  includes [
+    {chart: {profile: {context_node_type: [{context: [:country, :commodity]}, :node_type]}}},
+    :node_type
+  ]
 
   permit_params :chart_id, :node_type_id, :identifier, :position
 

--- a/app/models/api/v3/chart.rb
+++ b/app/models/api/v3/chart.rb
@@ -65,7 +65,11 @@ module Api
       end
 
       def self.select_options
-        Api::V3::Chart.includes(:profile).all.map do |chart|
+        Api::V3::Chart.includes(
+          profile: {context_node_type: [{context: [:country, :commodity]}, :node_type]}
+        ).order(
+          'countries.name, commodities.name, node_types.name'
+        ).all.map do |chart|
           profile = chart.profile
           context_node_type = profile&.context_node_type
           context = context_node_type&.context

--- a/app/models/api/v3/context.rb
+++ b/app/models/api/v3/context.rb
@@ -57,7 +57,9 @@ module Api
       validates :commodity, presence: true, uniqueness: {scope: :country}
 
       def self.select_options
-        Api::V3::Context.includes(:country, :commodity).all.map do |ctx|
+        Api::V3::Context.includes(:country, :commodity).order(
+          'countries.name, commodities.name'
+        ).all.map do |ctx|
           [[ctx.country&.name, ctx.commodity&.name].join(' / '), ctx.id]
         end
       end

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -69,7 +69,13 @@ module Api
       def refresh_dependents
         Api::V3::Readonly::NodeWithFlows.refresh
         Api::V3::Readonly::NodeWithFlowsOrGeo.refresh
-        # TODO: dashboards nodes
+        Api::V3::Readonly::Dashboards::Source.refresh(skip_dependencies: true)
+        Api::V3::Readonly::Dashboards::Company.refresh(skip_dependencies: true)
+        Api::V3::Readonly::Dashboards::Exporter.refresh(skip_dependencies: true)
+        Api::V3::Readonly::Dashboards::Importer.refresh(skip_dependencies: true)
+        Api::V3::Readonly::Dashboards::Destination.refresh(skip_dependencies: true)
+        Api::V3::Readonly::Dashboards::Country.refresh(skip_dependencies: true)
+        Api::V3::Readonly::Dashboards::Commodity.refresh(skip_dependencies: true)
         Api::V3::Readonly::Context.refresh
       end
     end

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -44,6 +44,8 @@ module Api
       def self.select_options
         Api::V3::Profile.includes(
           context_node_type: [{context: [:country, :commodity]}, :node_type]
+        ).order(
+          'countries.name, commodities.name, node_types.name'
         ).all.map do |profile|
           context_node_type = profile&.context_node_type
           [

--- a/app/services/api/v3/actors/basic_attributes.rb
+++ b/app/services/api/v3/actors/basic_attributes.rb
@@ -19,17 +19,25 @@ module Api
           @node_type_name = @node&.node_type&.name
           # Assumption: Volume is a special quant which always exists
           @volume_attribute = Dictionary::Quant.instance.get('Volume')
-          raise 'Quant Volume not found' unless @volume_attribute.present?
+          unless @volume_attribute.present?
+            raise ActiveRecord::RecordNotFound.new 'Quant Volume not found'
+          end
 
           @values = Api::V3::NodeAttributeValuesPreloader.new(@node, @year)
           initialize_chart_config(:actor, nil, :actor_basic_attributes)
           @source_node_type = @chart_config.named_node_type('source')
-          raise 'Chart node type "source" not found' unless @source_node_type
+          unless @source_node_type
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "source" not found'
+            )
+          end
 
           @destination_node_type = @chart_config.named_node_type('destination')
           # rubocop:disable Style/GuardClause
           unless @destination_node_type
-            raise 'Chart node type "destination" not found'
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "destination" not found'
+            )
           end
           # rubocop:enable Style/GuardClause
         end

--- a/app/services/api/v3/actors/exporting_companies_plot.rb
+++ b/app/services/api/v3/actors/exporting_companies_plot.rb
@@ -13,10 +13,14 @@ module Api
           @year = year
           # Assumption: Volume is a special quant which always exists
           @volume_attribute = Dictionary::Quant.instance.get('Volume')
-          raise 'Quant Volume not found' unless @volume_attribute.present?
+          unless @volume_attribute.present?
+            raise ActiveRecord::RecordNotFound.new 'Quant Volume not found'
+          end
 
           initialize_chart_config(:actor, nil, :actor_exporting_companies)
-          raise 'No attributes found' unless @chart_config.attributes.any?
+          unless @chart_config.attributes.any?
+            raise ActiveRecord::RecordNotFound.new 'No attributes found'
+          end
         end
 
         def call

--- a/app/services/api/v3/actors/sustainability_table.rb
+++ b/app/services/api/v3/actors/sustainability_table.rb
@@ -19,14 +19,20 @@ module Api
 
           # Assumption: Volume is a special quant which always exists
           @volume_attribute = Dictionary::Quant.instance.get('Volume')
-          raise 'Quant Volume not found' unless @volume_attribute.present?
+          unless @volume_attribute.present?
+            raise ActiveRecord::RecordNotFound.new 'Quant Volume not found'
+          end
 
           initialize_chart_config(:actor, nil, :actor_sustainability_table)
-          raise 'No attributes found' unless @chart_config.attributes.any?
+          unless @chart_config.attributes.any?
+            raise ActiveRecord::RecordNotFound.new 'No attributes found'
+          end
 
           @source_node_types = @chart_config.named_node_types('source')
           unless @source_node_types.any?
-            raise 'Chart node type "source" not found'
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "source" not found'
+            )
           end
 
           initialize_flow_stats_for_node

--- a/app/services/api/v3/actors/top_countries.rb
+++ b/app/services/api/v3/actors/top_countries.rb
@@ -14,15 +14,20 @@ module Api
             context, node, year
           )
           initialize_chart_config(:actor, nil, :actor_top_countries)
-          @destination_node_type = @chart_config.
-            named_node_type('destination')
+          @destination_node_type = @chart_config.named_node_type('destination')
           unless @destination_node_type
-            raise 'Chart node type "destination" not found'
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "destination" not found'
+            )
           end
 
           attribute_name = 'commodity_production'
           attribute = @chart_config.named_attribute(attribute_name)
-          raise "#{attribute_name} attribute not found" unless attribute
+          unless attribute
+            raise ActiveRecord::RecordNotFound.new(
+              "#{attribute_name} attribute not found"
+            )
+          end
 
           instance_variable_set("@#{attribute_name}_attribute", attribute)
           instance_variable_set(

--- a/app/services/api/v3/actors/top_nodes_summary.rb
+++ b/app/services/api/v3/actors/top_nodes_summary.rb
@@ -12,7 +12,9 @@ module Api
           quant_dictionary = Dictionary::Quant.instance
           # Assumption: Volume is a special quant which always exists
           @volume_attribute = quant_dictionary.get('Volume')
-          raise 'Quant Volume not found' unless @volume_attribute.present?
+          unless @volume_attribute.present?
+            raise ActiveRecord::RecordNotFound.new 'Quant Volume not found'
+          end
 
           initialize_flow_stats_for_node
         end

--- a/app/services/api/v3/actors/top_sources.rb
+++ b/app/services/api/v3/actors/top_sources.rb
@@ -16,12 +16,18 @@ module Api
           initialize_chart_config(:actor, nil, :actor_top_sources)
           @source_node_types = @chart_config.named_node_types('source')
           unless @source_node_types.any?
-            raise 'Chart node type "source" not found'
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "source" not found'
+            )
           end
 
           attribute_name = 'commodity_production'
           attribute = @chart_config.named_attribute(attribute_name)
-          raise "#{attribute_name} attribute not found" unless attribute
+          unless attribute
+            raise ActiveRecord::RecordNotFound.new(
+              "#{attribute_name} attribute not found"
+            )
+          end
 
           instance_variable_set("@#{attribute_name}_attribute", attribute)
           instance_variable_set(

--- a/app/services/api/v3/places/basic_attributes.rb
+++ b/app/services/api/v3/places/basic_attributes.rb
@@ -20,7 +20,9 @@ module Api
           quant_dictionary = Dictionary::Quant.instance
           # Assumption: Volume is a special quant which always exists
           @volume_attribute = quant_dictionary.get('Volume')
-          raise 'Quant Volume not found' unless @volume_attribute.present?
+          unless @volume_attribute.present?
+            raise ActiveRecord::RecordNotFound.new 'Quant Volume not found'
+          end
 
           @values = Api::V3::NodeAttributeValuesPreloader.new(@node, @year)
           initialize_chart_configuration
@@ -73,7 +75,9 @@ module Api
           @destination_node_type = top_countries_chart_config.
             named_node_type('destination')
           unless @destination_node_type
-            raise 'Chart node type "destination" not found (top countries)'
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "destination" not found (top countries)'
+            )
           end
 
           top_traders_chart_config = Api::V3::Profiles::ChartConfiguration.new(
@@ -87,7 +91,9 @@ module Api
             named_node_type('trader')
           # rubocop:disable Style/GuardClause
           unless @trader_node_type
-            raise 'Chart node type "trader" not found (top traders)'
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "trader" not found (top traders)'
+            )
           end
           # rubocop:enable Style/GuardClause
         end

--- a/app/services/api/v3/places/indicators_table.rb
+++ b/app/services/api/v3/places/indicators_table.rb
@@ -28,7 +28,10 @@ module Api
             chart_config = initialize_chart_config(
               :place, :place_indicators_table, chart.identifier
             )
-            raise 'No attributes found' unless chart_config.attributes.any?
+            unless chart_config.attributes.any?
+              raise ActiveRecord::RecordNotFound.new 'No attributes found'
+            end
+
             indicators_group(chart_config)
           end
         end

--- a/app/services/api/v3/places/mini_sankey.rb
+++ b/app/services/api/v3/places/mini_sankey.rb
@@ -11,7 +11,9 @@ module Api
           @year = year
           # Assumption: Volume is a special quant which always exists
           @volume_attribute = Dictionary::Quant.instance.get('Volume')
-          raise 'Quant Volume not found' unless @volume_attribute.present?
+          unless @volume_attribute.present?
+            raise ActiveRecord::RecordNotFound.new 'Quant Volume not found'
+          end
         end
 
         def call(node_type, include_domestic_consumption)

--- a/app/services/api/v3/places/top_consumer_actors.rb
+++ b/app/services/api/v3/places/top_consumer_actors.rb
@@ -12,7 +12,11 @@ module Api
           @node = node
           initialize_chart_config(:place, nil, :place_top_consumer_actors)
           @trader_node_type = @chart_config.named_node_type('trader')
-          raise 'Chart node type "trader" not found' unless @trader_node_type
+          unless @trader_node_type
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "trader" not found'
+            )
+          end
 
           @mini_sankey = Api::V3::Places::MiniSankey.new(
             context, node, year

--- a/app/services/api/v3/places/top_consumer_countries.rb
+++ b/app/services/api/v3/places/top_consumer_countries.rb
@@ -15,7 +15,9 @@ module Api
           )
           @destination_node_type = @chart_config.named_node_type('destination')
           unless @destination_node_type
-            raise 'Chart node type "destination" not found'
+            raise ActiveRecord::RecordNotFound.new(
+              'Chart node type "destination" not found'
+            )
           end
 
           @mini_sankey = Api::V3::Places::MiniSankey.new(

--- a/app/services/api/v3/places/trajectory_deforestation_plot.rb
+++ b/app/services/api/v3/places/trajectory_deforestation_plot.rb
@@ -22,7 +22,9 @@ module Api
           @chart_config = initialize_chart_config(
             :place, nil, :place_trajectory_deforestation
           )
-          raise 'No attributes found' unless @chart_config.attributes.any?
+          unless @chart_config.attributes.any?
+            raise ActiveRecord::RecordNotFound.new 'No attributes found'
+          end
         end
 
         def call

--- a/spec/controllers/api/v3/actors_controller_spec.rb
+++ b/spec/controllers/api/v3/actors_controller_spec.rb
@@ -1,13 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::ActorsController, type: :controller do
-  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil exporter quant values'
+  include_context 'api v3 brazil exporter qual values'
+  include_context 'api v3 brazil exporter ind values'
+  include_context 'api v3 brazil municipality quant values'
+  include_context 'api v3 brazil municipality qual values'
+  include_context 'api v3 brazil municipality ind values'
+  include_context 'api v3 brazil flows quants'
   include_context 'api v3 brazil exporter actor profile'
 
   let(:node) { api_v3_exporter1_node }
   let(:year) { 2015 }
+  let(:valid_params) {
+    {context_id: api_v3_context.id, actor_id: node.id, year: year}
+  }
+  let(:quant_dict) { instance_double(Dictionary::Quant) }
+  let(:chart_config) {
+    instance_double(Api::V3::Profiles::ChartConfiguration)
+  }
 
   before(:each) do
+    Api::V3::Readonly::CommodityAttributeProperty.refresh
+    Api::V3::Readonly::CountryAttributeProperty.refresh
+    Api::V3::Readonly::ContextAttributeProperty.refresh
     Api::V3::Readonly::FlowNode.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlowsPerYear.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlows.refresh(sync: true, skip_dependencies: true)
@@ -26,9 +42,7 @@ RSpec.describe Api::V3::ActorsController, type: :controller do
       }
 
       it 'is not found' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, actor_id: node.id, year: year
-        }
+        get :basic_attributes, params: valid_params
         expect(response).to have_http_status(404)
       end
     end
@@ -37,27 +51,64 @@ RSpec.describe Api::V3::ActorsController, type: :controller do
       let(:node) { api_v3_municipality_node }
 
       it 'is not found' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, actor_id: node.id, year: year
-        }
+        get :basic_attributes, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when Volume quant missing' do
+      it 'is not found' do
+        allow(Dictionary::Quant).to receive(:instance).and_return(quant_dict)
+        allow(quant_dict).to receive(:get).and_return(nil)
+
+        get :basic_attributes, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when source node type configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_type).with('source').and_return(nil)
+        )
+
+        get :basic_attributes, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when destination node type configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_type).
+            with('source').
+            and_return(api_v3_municipality_node_type)
+        )
+        allow(chart_config).to(
+          receive(:named_node_type).with('destination').and_return(nil)
+        )
+
+        get :basic_attributes, params: valid_params
         expect(response).to have_http_status(404)
       end
     end
 
     context 'when year provided and valid for node' do
       it 'is successful' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, actor_id: node.id, year: year
-        }
+        get :basic_attributes, params: valid_params
         expect(response).to be_successful
       end
     end
 
     context 'when year provided but not valid for node' do
       it 'defaults to last available' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, actor_id: node.id, year: 2016
-        }
+        get :basic_attributes, params: valid_params.merge(year: 2016)
         expect(assigns(:year)).to eq(year)
         expect(response).to be_successful
       end
@@ -65,11 +116,172 @@ RSpec.describe Api::V3::ActorsController, type: :controller do
 
     context 'when year not provided' do
       it 'defaults to last available' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, actor_id: node.id
-        }
+        get :basic_attributes, params: valid_params.except(:year)
         expect(assigns(:year)).to eq(year)
         expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'GET exporting_companies' do
+    context 'when Volume quant missing' do
+      it 'is not found' do
+        allow(Dictionary::Quant).to receive(:instance).and_return(quant_dict)
+        allow(quant_dict).to receive(:get).and_return(nil)
+
+        get :exporting_companies, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when attributes configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:attributes).and_return([])
+        )
+
+        get :exporting_companies, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe 'GET sustainability' do
+    context 'when Volume quant missing' do
+      it 'is not found' do
+        allow(Dictionary::Quant).to receive(:instance).and_return(quant_dict)
+        allow(quant_dict).to receive(:get).and_return(nil)
+
+        get :sustainability, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when source node type configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:attributes)
+        ).and_return([api_v3_potential_soy_deforestation_v2])
+        allow(chart_config).to(
+          receive(:named_node_types).with('source').and_return([])
+        )
+
+        get :sustainability, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when attributes configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:attributes).and_return([])
+        )
+
+        get :sustainability, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe 'GET top_countries' do
+    context 'when Volume quant missing' do
+      it 'is not found' do
+        allow(Dictionary::Quant).to receive(:instance).and_return(quant_dict)
+        allow(quant_dict).to receive(:get).and_return(nil)
+
+        get :top_countries, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when destination node type configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_type).with('destination').and_return(nil)
+        )
+
+        get :top_countries, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when named attribute configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_type).
+            with('destination').
+            and_return(api_v3_country_node_type)
+        )
+        allow(chart_config).to(
+          receive(:named_attribute).
+            with('commodity_production').
+            and_return(nil)
+        )
+
+        get :top_countries, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe 'GET top_sources' do
+    context 'when Volume quant missing' do
+      it 'is not found' do
+        allow(Dictionary::Quant).to receive(:instance).and_return(quant_dict)
+        allow(quant_dict).to receive(:get).and_return(nil)
+
+        get :top_sources, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when source node type configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_types).with('source').and_return([])
+        )
+
+        get :top_sources, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when named attribute configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_types).
+            with('source').
+            and_return([api_v3_department_node_type])
+        )
+        allow(chart_config).to(
+          receive(:named_attribute).
+            with('commodity_production').
+            and_return(nil)
+        )
+
+        get :top_sources, params: valid_params
+        expect(response).to have_http_status(404)
       end
     end
   end

--- a/spec/controllers/api/v3/places_controller_spec.rb
+++ b/spec/controllers/api/v3/places_controller_spec.rb
@@ -1,13 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe Api::V3::PlacesController, type: :controller do
-  include_context 'api v3 brazil flows'
+  include_context 'api v3 brazil municipality ind values'
+  include_context 'api v3 brazil municipality qual values'
+  include_context 'api v3 brazil municipality quant values'
+  include_context 'api v3 brazil flows quants'
   include_context 'api v3 brazil municipality place profile'
 
   let(:node) { api_v3_municipality_node }
   let(:year) { 2015 }
+  let(:valid_params) {
+    {context_id: api_v3_context.id, place_id: node.id, year: year}
+  }
+  let(:quant_dict) { instance_double(Dictionary::Quant) }
+  let(:chart_config) {
+    instance_double(Api::V3::Profiles::ChartConfiguration)
+  }
 
   before(:each) do
+    Api::V3::Readonly::CommodityAttributeProperty.refresh
+    Api::V3::Readonly::CountryAttributeProperty.refresh
+    Api::V3::Readonly::ContextAttributeProperty.refresh
     Api::V3::Readonly::FlowNode.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlowsPerYear.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlows.refresh(sync: true, skip_dependencies: true)
@@ -26,9 +39,7 @@ RSpec.describe Api::V3::PlacesController, type: :controller do
       }
 
       it 'is not found' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, place_id: node.id, year: year
-        }
+        get :basic_attributes, params: valid_params
         expect(response).to have_http_status(404)
       end
     end
@@ -37,9 +48,17 @@ RSpec.describe Api::V3::PlacesController, type: :controller do
       let(:node) { api_v3_exporter1_node }
 
       it 'is not found' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, place_id: node.id, year: year
-        }
+        get :basic_attributes, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    context 'when Volume quant missing' do
+      it 'is not found' do
+        allow(Dictionary::Quant).to receive(:instance).and_return(quant_dict)
+        allow(quant_dict).to receive(:get).and_return(nil)
+
+        get :basic_attributes, params: valid_params
         expect(response).to have_http_status(404)
       end
     end
@@ -55,9 +74,7 @@ RSpec.describe Api::V3::PlacesController, type: :controller do
 
     context 'when year provided but not valid for node' do
       it 'defaults to last available' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, place_id: node.id, year: 2016
-        }
+        get :basic_attributes, params: valid_params.merge(year: 2016)
         expect(assigns(:year)).to eq(year)
         expect(response).to be_successful
       end
@@ -65,11 +82,77 @@ RSpec.describe Api::V3::PlacesController, type: :controller do
 
     context 'when year not provided' do
       it 'defaults to last available' do
-        get :basic_attributes, params: {
-          context_id: api_v3_context.id, place_id: node.id
-        }
+        get :basic_attributes, params: valid_params.except(:year)
         expect(assigns(:year)).to eq(year)
         expect(response).to be_successful
+      end
+    end
+  end
+
+  describe 'GET top_consumer_actors' do
+    context 'when trader node type configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_type).with('trader').and_return(nil)
+        )
+
+        get :top_consumer_actors, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe 'GET top_consumer_countries' do
+    context 'when destination node type configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:named_node_type).with('destination').and_return(nil)
+        )
+
+        get :top_consumer_countries, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe 'GET indicators' do
+    context 'when attributes configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        chart = instance_double(Api::V3::Chart)
+        allow(chart_config).to receive(:chart).and_return(chart)
+        allow(chart).to receive(:children).and_return([chart])
+        allow(chart).to receive(:identifier)
+        allow(chart_config).to(
+          receive(:attributes).and_return([])
+        )
+
+        get :indicators, params: valid_params
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe 'GET trajectory_deforestation' do
+    context 'when attributes configuration missing' do
+      it 'is not found' do
+        allow(Api::V3::Profiles::ChartConfiguration).to(
+          receive(:new).and_return(chart_config)
+        )
+        allow(chart_config).to(
+          receive(:attributes).and_return([])
+        )
+
+        get :trajectory_deforestation, params: valid_params
+        expect(response).to have_http_status(404)
       end
     end
   end

--- a/spec/responses/api/v3/exporter_profile_spec.rb
+++ b/spec/responses/api/v3/exporter_profile_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Exporter profile', type: :request do
   include_context 'api v3 brazil municipality quant values'
   include_context 'api v3 brazil municipality qual values'
   include_context 'api v3 brazil municipality ind values'
-  include_context 'api v3 brazil flows'
   include_context 'api v3 brazil flows quants'
   include_context 'api v3 brazil exporter actor profile'
 
@@ -22,30 +21,12 @@ RSpec.describe 'Exporter profile', type: :request do
     Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
   end
 
-  let(:summary_params) {
-    {
-      year: 2015
-    }
-  }
+  let(:summary_params) { {year: 2015} }
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/basic_attributes' do
-    it 'returns not found if exporter node not found' do
-      [
-        api_v3_biome_node,
-        api_v3_state_node,
-        api_v3_municipality_node,
-        api_v3_logistics_hub_node,
-        api_v3_port1_node,
-        api_v3_country_of_destination1_node
-      ].each do |non_exporter_node|
-        get "/api/v3/contexts/#{api_v3_context.id}/actors/#{non_exporter_node.id}/basic_attributes"
-        expect(@response).to have_http_status(:not_found)
-        expect(JSON.parse(@response.body)['error']).to match("Couldn't find Api::V3::Readonly::NodeWithFlows with")
-      end
-    end
-
     it 'has the correct response structure' do
-      get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_exporter1_node.id}/basic_attributes", params: summary_params
+      get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_exporter1_node.id}/basic_attributes",
+        params: summary_params
 
       expect(@response.status).to eq 200
       expect(@response).to match_response_schema('v3_actor_basic_attributes')

--- a/spec/responses/api/v3/importer_profile_spec.rb
+++ b/spec/responses/api/v3/importer_profile_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe 'Importer profile', type: :request do
   include_context 'api v3 brazil municipality quant values'
   include_context 'api v3 brazil municipality qual values'
   include_context 'api v3 brazil municipality ind values'
-  include_context 'api v3 brazil flows'
   include_context 'api v3 brazil flows quants'
   include_context 'api v3 brazil importer actor profile'
 
   before(:each) do
+    Api::V3::Readonly::CommodityAttributeProperty.refresh
+    Api::V3::Readonly::CountryAttributeProperty.refresh
+    Api::V3::Readonly::ContextAttributeProperty.refresh
     Api::V3::Readonly::FlowNode.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlowsPerYear.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlows.refresh(sync: true, skip_dependencies: true)
@@ -19,115 +21,14 @@ RSpec.describe 'Importer profile', type: :request do
     Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
   end
 
-  let(:summary_params) {
-    {
-      year: 2015
-    }
-  }
+  let(:summary_params) { {year: 2015} }
 
   describe 'GET /api/v3/contexts/:context_id/actors/:id/basic_attributes' do
-    it 'returns not found if importer node not found' do
-      [
-        api_v3_biome_node,
-        api_v3_state_node,
-        api_v3_municipality_node,
-        api_v3_logistics_hub_node,
-        api_v3_port1_node,
-        api_v3_country_of_destination1_node
-      ].each do |non_importer_node|
-        get "/api/v3/contexts/#{api_v3_context.id}/actors/#{non_importer_node.id}/basic_attributes"
-        expect(@response).to have_http_status(:not_found)
-        expect(JSON.parse(@response.body)['error']).to match("Couldn't find Api::V3::Readonly::NodeWithFlows with")
-      end
-    end
-
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/basic_attributes", params: summary_params
 
       expect(@response.status).to eq 200
       expect(@response).to match_response_schema('v3_actor_basic_attributes')
-    end
-  end
-
-  describe 'GET /api/v3/contexts/:context_id/actors/:id/top_countries' do
-    it 'has the correct response structure' do
-      get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/top_countries", params: summary_params
-
-      expect(@response.status).to eq 200
-      expect(@response).to match_response_schema('v3_actor_top_countries')
-    end
-  end
-
-  describe 'GET /api/v3/contexts/:context_id/actors/:id/top_sources' do
-    let(:unknown_municipality) {
-      FactoryBot.create(
-        :api_v3_node,
-        node_type: api_v3_municipality_node_type,
-        is_unknown: true
-      )
-    }
-    let!(:flow_2014) {
-      FactoryBot.create(
-        :api_v3_flow,
-        context: api_v3_context,
-        path: [
-          api_v3_biome_node,
-          api_v3_state_node,
-          unknown_municipality,
-          api_v3_logistics_hub_node,
-          api_v3_port1_node,
-          api_v3_exporter1_node,
-          api_v3_importer1_node,
-          api_v3_country_of_destination1_node
-        ].map(&:id),
-        year: 2014
-      )
-    }
-    let!(:flow_2014_volume) {
-      FactoryBot.create(
-        :api_v3_flow_quant,
-        flow: flow_2014,
-        quant: api_v3_volume,
-        value: 10
-      )
-    }
-    it 'has the correct response structure' do
-      get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/top_sources", params: summary_params
-
-      expect(@response.status).to eq 200
-      expect(@response).to match_response_schema('v3_actor_top_sources')
-    end
-  end
-
-  describe 'GET /api/v3/contexts/:context_id/actors/:id/sustainability' do
-    before(:each) do
-      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
-      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
-      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
-      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
-      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
-    end
-    it 'has the correct response structure' do
-      get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/sustainability", params: summary_params
-
-      expect(@response.status).to eq 200
-      expect(@response).to match_response_schema('v3_actor_sustainability')
-    end
-  end
-
-  describe 'GET /api/v3/contexts/:context_id/actors/:id/exporting_companies' do
-    before(:each) do
-      Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
-      Api::V3::Readonly::ChartAttribute.refresh(sync: true, skip_dependencies: true)
-      Api::V3::Readonly::ContextAttributeProperty.refresh(sync: true, skip_dependencies: true)
-      Api::V3::Readonly::CountryAttributeProperty.refresh(sync: true, skip_dependencies: true)
-      Api::V3::Readonly::CommodityAttributeProperty.refresh(sync: true, skip_dependencies: true)
-    end
-    it 'has the correct response structure' do
-      get "/api/v3/contexts/#{api_v3_context.id}/actors/#{api_v3_importer1_node.id}/exporting_companies", params: summary_params
-
-      expect(@response.status).to eq 200
-      expect(@response).to match_response_schema('v3_actor_exporting_companies')
     end
   end
 end

--- a/spec/responses/api/v3/place_profile_spec.rb
+++ b/spec/responses/api/v3/place_profile_spec.rb
@@ -25,19 +25,6 @@ RSpec.describe 'Place profile', type: :request do
   }
 
   describe 'GET /api/v3/contexts/:context_id/places/:id/basic_attributes' do
-    it 'returns not found if place node not found' do
-      [
-        api_v3_exporter1_node,
-        api_v3_importer1_node,
-        api_v3_port1_node,
-        api_v3_country_of_destination1_node
-      ].each do |non_place_node|
-        get "/api/v3/contexts/#{api_v3_context.id}/places/#{non_place_node.id}/basic_attributes"
-        expect(@response).to have_http_status(:not_found)
-        expect(JSON.parse(@response.body)['error']).to match("Couldn't find Api::V3::Readonly::NodeWithFlows with")
-      end
-    end
-
     it 'has the correct response structure' do
       get "/api/v3/contexts/#{api_v3_context.id}/places/#{api_v3_municipality_node.id}/basic_attributes", params: summary_params
 


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170710420

(and a number of other bugs of similar type, concerning profile pages)

## Description

All profile pages endpoints have checks for required configuration, which result in error 500 thrown when configuration is missing. It should be a 404 error, which combined with the descriptive message should help with debugging and reduce the error rate.

## Testing instructions
e.g.
https://sandbox.trase.earth/api/v3/contexts/6/actors/36641/top_sources
