### PR TITLE
Chore/increase sidekiq concurrency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'twitter', '~> 6.1'
 
 gem 'appsignal'
 gem 'newrelic_rpm'
-gem 'sidekiq', '~> 5.2.7'
+gem 'sidekiq', '~> 6.0.4'
 gem 'sidekiq-unique-jobs'
 gem 'whenever', require: false
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
     rack (2.1.1)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (2.0.7)
+    rack-protection (2.0.8.1)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -385,11 +385,11 @@ GEM
       railties (>= 4.0.0)
     select2-rails (4.0.3)
       thor (~> 0.14)
-    sidekiq (5.2.7)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (>= 1.5.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.0.4)
+      connection_pool (>= 2.2.2)
+      rack (>= 2.0.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     sidekiq-unique-jobs (6.0.18)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 4.0, < 7.0)
@@ -513,7 +513,7 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 6.0)
   scenic
-  sidekiq (~> 5.2.7)
+  sidekiq (~> 6.0.4)
   sidekiq-unique-jobs
   simplecov
   sitemap_generator

--- a/app/workers/database_export_worker.rb
+++ b/app/workers/database_export_worker.rb
@@ -2,7 +2,7 @@ class DatabaseExportWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true,
                   unique: :until_executed,
                   run_lock_expiration: 120, # 2 mins

--- a/app/workers/database_import_worker.rb
+++ b/app/workers/database_import_worker.rb
@@ -2,7 +2,7 @@ class DatabaseImportWorker
   include Sidekiq::Worker
 
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true,
                   unique: :until_executed,
                   run_lock_expiration: 120, # 2 mins

--- a/app/workers/flow_attribute_available_years_update_worker.rb
+++ b/app/workers/flow_attribute_available_years_update_worker.rb
@@ -1,7 +1,7 @@
 class FlowAttributeAvailableYearsUpdateWorker
   include Sidekiq::Worker
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true
 
   def perform(object_class_name, object_id, context_id)

--- a/app/workers/materialized_view_refresh_worker.rb
+++ b/app/workers/materialized_view_refresh_worker.rb
@@ -1,7 +1,7 @@
 class MaterializedViewRefreshWorker
   include Sidekiq::Worker
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true,
                   unique: :until_and_while_executing,
                   run_lock_expiration: 150, # 2.5 mins

--- a/app/workers/mirror_database_update_worker.rb
+++ b/app/workers/mirror_database_update_worker.rb
@@ -1,7 +1,7 @@
 class MirrorDatabaseUpdateWorker
   include Sidekiq::Worker
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true,
                   unique: :until_executed,
                   run_lock_expiration: 60 * 60 * 2, # 2 hrs

--- a/app/workers/remote_database_update_worker.rb
+++ b/app/workers/remote_database_update_worker.rb
@@ -1,7 +1,7 @@
 class RemoteDatabaseUpdateWorker
   include Sidekiq::Worker
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true,
                   unique: :until_executed,
                   run_lock_expiration: 60 * 60 * 2, # 2 hrs

--- a/app/workers/upsert_attributes_worker.rb
+++ b/app/workers/upsert_attributes_worker.rb
@@ -1,7 +1,7 @@
 class UpsertAttributesWorker
   include Sidekiq::Worker
   sidekiq_options queue: :database,
-                  retry: 0,
+                  retry: false,
                   backtrace: true,
                   unique: :until_and_while_executing,
                   log_duplicate_payload: true

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,6 +6,7 @@ default: &default
   port: <%= ENV.fetch("POSTGRES_PORT") { "5432" } %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD") {} %>
   database: <%= ENV.fetch("POSTGRES_DATABASE") { "trase_dev" } %>
+  pool: <%= ENV['RAILS_MAX_THREADS'] || 5 %>
 
 development:
   <<: *default

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,9 +12,12 @@ Sidekiq.configure_server do |config|
     SidekiqUniqueJobs::Digests.del(digest: job['unique_digest']) if job['unique_digest']
   end
 
-  config.redis = {size: 4}
+  config.redis = {size: (config.options[:concurrency] + 5)}
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = {size: 2}
+  config.redis = {size: config.options[:concurrency]}
 end
+
+# about the size setting:
+# https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@ Sidekiq.configure_server do |config|
   # this is an error handler for sidekiq; it is used to ensure the job that failed
   # is marked as FAILED in the database_updates tables
   config.error_handlers << Proc.new do |e, ctx_hash|
-    return unless ctx_hash[:job] && ctx_hash[:job]['class'] == 'DatabaseUpdateWorker'
+    return unless ctx_hash[:job] && ctx_hash[:job]['class'] =~ /.+DatabaseUpdateWorker/
     jid = ctx_hash[:job]['jid']
     du = Api::V3::DatabaseUpdate.where(jid: jid).first
     du&.update_attribute(:status, Api::V3::DatabaseUpdate::FAILED)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -21,3 +21,8 @@ end
 
 # about the size setting:
 # https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
+# about logging:
+# sidekiq no longer supports a logfile
+# it will log to stdout in dev / test
+# in other envs we need to redirect the log output in systemd intializers
+# ExecStart=/bin/bash -lc 'bundle exec sidekiq -e staging -C config/sidekiq.yml 2>&1 >> /var/www/trase/current/log/sidekiq.log'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,3 @@
-logfile: ./log/sidekiq.log
 :verbose: true
 :concurrency: <%= ENV['RAILS_MAX_THREADS'] || 5 %>
 :queues:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,16 +1,5 @@
-verbose: true
 logfile: ./log/sidekiq.log
-development:
-  :concurrency: 2
-production:
-  :concurrency: 2
-staging:
-  :concurrency: 2
-sandbox:
-  :concurrency: 2
-demo:
-  :concurrency: 2
-indonesiademo:
-  :concurrency: 2
+:verbose: true
+:concurrency: <%= ENV['RAILS_MAX_THREADS'] || 5 %>
 :queues:
   - database

--- a/frontend/docs/index.mdx
+++ b/frontend/docs/index.mdx
@@ -24,7 +24,7 @@ While technically independent, the frontend application is heavily dependent on 
 - Ruby 2.6.3 and RubyGems (recommended installation via rvm)
 - [Bundler](http://bundler.io/)
 - PostgreSQL 11 with `intarray`, `tablefunc` and `postgres_fdw` extensions
-- redis >= 3
+- redis >= 4.1.0
 - wget
 - cron
 


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170177793

## Description

- Upgraded sidekiq to 6.0. This has consequences:
    - redis > 4.1.0
    - ruby > 2.5
    - logfile was removed from sidekiq - logging to a file needs to be configured in systemd initializers
    - there is a reported 10-15% performance improvement in the new version
- Simplified sidekiq configuration; concurrency defaults to 5 unless specified differently using `RAILS_MAX_THREADS` env var
- Rails db pool size uses the same env var & default

## Testing instructions

Ideally nothing changes in how background jobs are processed but it's faster
