### PR TITLE
ed25519 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'annotate'
-  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
+  gem 'bcrypt_pbkdf', '~> 1.0'
   gem 'capistrano', '~> 3.11', require: false
   gem 'capistrano-bundler'
   gem 'capistrano-yarn'
@@ -88,11 +88,16 @@ group :development do
   gem 'capistrano-passenger'
   gem 'capistrano-rails', '~> 1.4', require: false
   gem 'capistrano-rvm'
-  gem 'rbnacl', '>= 3.2', '< 5.0'
-  gem 'rbnacl-libsodium'
+  gem 'ed25519', '~> 1.2'
   gem 'rubocop', '~> 0.79.0', require: false
   gem 'rubocop-performance', require: false
 end
+
+# a note about ed25519 support
+# from net-ssh readme https://github.com/net-ssh/net-ssh:
+#{ }"For ed25519 public key auth support your bundle file should contain ed25519, bcrypt_pbkdf dependencies."
+# those are development dependencies of net-ssh
+# versions required by net-ssh can be looked up here: https://github.com/net-ssh/net-ssh/blob/master/net-ssh.gemspec
 
 group :test do
   # Adds support for Capybara system testing and selenium driver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    ed25519 (1.2.4)
     enumerate_it (3.0.0)
       activesupport (>= 4.2.0)
     equalizer (0.0.11)
@@ -324,10 +325,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rbnacl (4.0.2)
-      ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     redis (4.1.3)
     require_all (1.5.0)
     responders (3.0.0)
@@ -466,7 +463,7 @@ DEPENDENCIES
   annotate
   appsignal
   aws-sdk-s3 (~> 1)
-  bcrypt_pbkdf (>= 1.0, < 2.0)
+  bcrypt_pbkdf (~> 1.0)
   best_in_place
   bootsnap (>= 1.1.0)
   byebug
@@ -482,6 +479,7 @@ DEPENDENCIES
   database_cleaner
   devise (~> 4.7)
   dotenv-rails (~> 2.7)
+  ed25519 (~> 1.2)
   enumerate_it (~> 3.0.0)
   factory_bot_rails
   jbuilder (~> 2.9)
@@ -499,8 +497,6 @@ DEPENDENCIES
   rack-cors (~> 1.1)
   rails (~> 5.2.4.1)
   rails-controller-testing
-  rbnacl (>= 3.2, < 5.0)
-  rbnacl-libsodium
   rspec-collection_matchers
   rspec-rails (~> 3.9)
   rubocop (~> 0.79.0)


### PR DESCRIPTION
## Related GH issues

https://github.com/Vizzuality/trase/pull/656
https://github.com/Vizzuality/trase/pull/1032
https://github.com/Vizzuality/trase/pull/1102

## Description

[A while back we added 3 gems to the Gemfile](https://github.com/Vizzuality/trase/pull/656): `rbnacl`, `rbnacl-libsodium` and `bcrypt_pbkdf`. That helped solve an issue while deploying with Capistrano. The issue was caused by the fact that in order to use some kinds of keys those dependencies were required by net-ssh.

One of those gems, `rbnacl-libsodium`, is now discontinued, so it makes sense to revisit.

I think the root cause might have been to enable support for ed25519 keys, and if that is the case we should use the solution described in [net-ssh readme](https://github.com/net-ssh/net-ssh) and in [this issue](https://github.com/net-ssh/net-ssh/issues/478), which is to include `ed25519` and `bcrypt_pbkdf` dependencies (they are [listed as development dependencies](https://github.com/net-ssh/net-ssh/blob/master/net-ssh.gemspec), not runtime, therefore they don't get pulled in by bundler automatically).

## Testing instructions

Just try `cap staging deploy`
