### PR TITLE
Remove duplicated node types

### DIFF
--- a/app/services/api/v3/dashboards/filter_meta.rb
+++ b/app/services/api/v3/dashboards/filter_meta.rb
@@ -78,13 +78,11 @@ module Api
             select(
               'node_types.name AS node_type_name',
               'node_types.id AS node_type_id',
-              'profiles.name AS profile_type',
-              'context_node_type_properties.prefix AS property_prefix'
+              'MAX(profiles.name) AS profile_type',
+              'MAX(context_node_type_properties.prefix) AS property_prefix'
             ).group(
               'node_types.name',
-              'node_types.id',
-              'profiles.name',
-              'context_node_type_properties.prefix'
+              'node_types.id'
             )
 
           if @countries_ids.any?


### PR DESCRIPTION
by picking one from distinct profile type & prefix combinations

## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170319809

## Description

Initially I thought we could just remove profile type from that response to remove the duplicates, but sadly that breaks profile pages "browse" function. And wouldn't solve the problem anyway, because sometimes the difference would be in the prefix not the profile type:

<img width="534" alt="Screenshot 2020-02-06 at 17 01 40" src="https://user-images.githubusercontent.com/134055/73954662-6dda3280-4902-11ea-9555-6fd544d1c88d.png">

Changed the query instead, so that it groups by node type id / name only and picks `MAX` of whatever it finds in profile and prefix columns. In case of strings, `MAX` will pick whatever is "biggest" in lexicographic order, including a not-null value over a null value. Not perfect. Ideally we wouldn't need the profile name / prefix value before the commodity is selected, because it's impossible to render a link anyway.


