### PR TITLE
Fixed ncont values legend

### DIFF
--- a/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
+++ b/app/services/api/v3/dashboards/charts/multi_year_ncont_overview.rb
@@ -19,11 +19,11 @@ module Api
           end
 
           def call
-            break_by_values_indexes = ncont_break_by_values_map
+            break_by_values = @query.map { |e| e['break_by'] }.uniq.sort
 
             data_by_x = {}
             @query.each do |record|
-              idx = break_by_values_indexes[record['break_by']]
+              idx = break_by_values.index(record['break_by'])
               data_by_x[record['x']] ||= {}
               data_by_x[record['x']]["y#{idx}"] = record['y0']
             end
@@ -39,7 +39,7 @@ module Api
               info: info
             }
 
-            break_by_values_indexes.each do |break_by, idx|
+            break_by_values.each.with_index do |break_by, idx|
               @meta[:"y#{idx}"] = series_legend_meta(break_by, @cont_attribute)
             end
 

--- a/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
+++ b/app/services/api/v3/dashboards/charts/single_year_ncont_node_type_view.rb
@@ -24,14 +24,14 @@ module Api
           end
 
           def call
-            break_by_values_indexes = ncont_break_by_values_map
+            break_by_values = @query.map { |e| e['break_by'] }.uniq.sort
 
             data_by_x = {}
             x_labels_profile_info = []
             profile = profile_for_node_type_id(@node_type.id)
             @top_n_and_others_query.each do |record|
               x_labels_profile_info << {id: record['id'], profile: profile}
-              break_by_values_indexes.each do |break_by, idx|
+              break_by_values.each.with_index do |break_by, idx|
                 data_by_x[record['x']] ||= {}
                 data_by_x[record['x']]["y#{idx}"] = record['per_break_by'][break_by]
               end
@@ -49,7 +49,7 @@ module Api
               info: info
             }
 
-            break_by_values_indexes.each do |break_by, idx|
+            break_by_values.each.with_index do |break_by, idx|
               @meta[:"y#{idx}"] = series_legend_meta(break_by, @cont_attribute)
             end
 

--- a/app/services/concerns/api/v3/dashboards/charts/flow_values_helpers.rb
+++ b/app/services/concerns/api/v3/dashboards/charts/flow_values_helpers.rb
@@ -100,25 +100,6 @@ module Api
             }
           end
 
-          def ncont_break_by_values
-            ncont_attr_table = @ncont_attribute.flow_values_class.table_name
-            @ncont_attribute.
-              flow_values_class.
-              from("partitioned_#{ncont_attr_table} #{ncont_attr_table}").
-              where(
-                @ncont_attribute.attribute_id_name => @ncont_attribute.original_id
-              ).
-              select(Arel.sql('value::TEXT AS text_value')).
-              order(Arel.sql('value::TEXT')).
-              distinct.map { |r| r['text_value'] }
-          end
-
-          def ncont_break_by_values_map
-            Hash[
-              ncont_break_by_values.map.with_index { |v, idx| [v, idx] }
-            ]
-          end
-
           def swap_x_and_y
             @data = @data.map do |object|
               swap_x_and_y_keys_in_hash(object)

--- a/spec/services/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/multi_year_ncont_overview_spec.rb
@@ -58,9 +58,10 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNcontOverview do
         shared_parameters_hash.merge(companies_ids: [api_v3_exporter2_node.id])
       }
       it 'summarized flows matching exporter per ncont' do
-        expect(data.size).to eq(1)
+        # only flow4 matches, forest500=4, volume=25
+        expect(meta[:y0][:label]).to eq('4')
         expect(data[0][:x]).to eq(2015)
-        expect(data[0][:y0]).to eq(nil)
+        expect(data[0][:y0]).to eq(25)
       end
     end
 
@@ -88,9 +89,10 @@ RSpec.describe Api::V3::Dashboards::Charts::MultiYearNcontOverview do
         )
       }
       it 'summarized flows matching exporter AND importer per ncont' do
-        expect(data.size).to eq(1)
+        # only flow4 matches, forest500=4, volume=25
+        expect(meta[:y0][:label]).to eq('4')
         expect(data[0][:x]).to eq(2015)
-        expect(data[0][:y3]).to eq(25)
+        expect(data[0][:y0]).to eq(25)
       end
     end
 

--- a/spec/services/api/v3/dashboards/charts/single_year_ncont_node_type_view_spec.rb
+++ b/spec/services/api/v3/dashboards/charts/single_year_ncont_node_type_view_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
   }
 
   let(:data) { result[:data] }
+  let(:meta) { result[:meta] }
 
   describe :call do
     context 'when no flow path filters' do
@@ -59,8 +60,10 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
         shared_parameters_hash.merge(companies_ids: [api_v3_exporter1_node.id])
       }
       it 'it summarized flows matching exporter per biome' do
-        expect(data[0][:x2]).to eq(20)
-        expect(data[0][:x3]).to be_nil
+        # all flows except flow4 match
+        # flow5 forest500=5, volume=30
+        expect(meta[:x3][:label]).to eq('5')
+        expect(data[0][:x3]).to eq(30)
       end
     end
 
@@ -74,8 +77,10 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
         )
       }
       it 'it summarized flows matching exporter per biome' do
-        expect(data[0][:x2]).to be_nil
-        expect(data[0][:x3]).to be_nil
+        # all flows except flow3 and flow4 match
+        # flow5 forest500=5, volume=30
+        expect(meta[:x2][:label]).to eq('5')
+        expect(data[0][:x2]).to eq(30)
       end
     end
 
@@ -88,7 +93,9 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
         )
       }
       it 'summarized flows matching either exporter per biome' do
-        # y0 is the stack for value '1.0'
+        # all flows match
+        # flow 1, forest500=1, volume=10
+        expect(meta[:x0][:label]).to eq('1')
         expect(data[0][:x0]).to eq(10)
       end
     end
@@ -102,9 +109,11 @@ RSpec.describe Api::V3::Dashboards::Charts::SingleYearNcontNodeTypeView do
         )
       }
       it 'summarized flows matching exporter AND importer per biome' do
-        expect(data[0][:x0]).to eq(nil)
-        # y3 is the stack for value '3.0'
-        expect(data[0][:x3]).to eq(25)
+        # only flow4 matches, forest500=4, volume=25
+        expect(meta[:x0][:label]).to eq('4')
+        expect(data[0][:x0]).to eq(25)
+        expect(meta[:x1]).to be_nil
+        expect(data[0][:x1]).to be_nil
       end
     end
 

--- a/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
+++ b/spec/support/schemas/dashboards_charts_multi_year_ncont_overview.json
@@ -17,8 +17,7 @@
         "required": [
           "x",
           "y0",
-          "y1",
-          "y4"
+          "y1"
         ],
         "properties": {
           "y0": {
@@ -27,14 +26,6 @@
           },
           "y1": {
             "$id": "#/properties/data/items/properties/y1",
-            "type": "number"
-          },
-          "y2": {
-            "$id": "#/properties/data/items/properties/y2",
-            "type": "number"
-          },
-          "y3": {
-            "$id": "#/properties/data/items/properties/y3",
             "type": "number"
           },
           "x": {
@@ -53,9 +44,6 @@
         "x",
         "y0",
         "y1",
-        "y2",
-        "y3",
-        "y4",
         "info"
       ],
       "properties": {
@@ -249,126 +237,6 @@
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/y1/properties/tooltip/properties/suffix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                }
-              }
-            }
-          }
-        },
-        "y2": {
-          "$id": "#/properties/meta/properties/y2",
-          "type": "object",
-          "required": [
-            "label",
-            "tooltip"
-          ],
-          "properties": {
-            "label": {
-              "$id": "#/properties/meta/properties/y2/properties/label",
-              "type": ["integer", "number", "string"]
-            },
-            "tooltip": {
-              "$id": "#/properties/meta/properties/y2/properties/tooltip",
-              "type": "object",
-              "required": [
-                "prefix",
-                "format",
-                "suffix"
-              ],
-              "properties": {
-                "prefix": {
-                  "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/prefix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "format": {
-                  "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/format",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "suffix": {
-                  "$id": "#/properties/meta/properties/y2/properties/tooltip/properties/suffix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                }
-              }
-            }
-          }
-        },
-        "y3": {
-          "$id": "#/properties/meta/properties/y3",
-          "type": "object",
-          "required": [
-            "label",
-            "tooltip"
-          ],
-          "properties": {
-            "label": {
-              "$id": "#/properties/meta/properties/y3/properties/label",
-              "type": ["integer", "number", "string"]
-            },
-            "tooltip": {
-              "$id": "#/properties/meta/properties/y3/properties/tooltip",
-              "type": "object",
-              "required": [
-                "prefix",
-                "format",
-                "suffix"
-              ],
-              "properties": {
-                "prefix": {
-                  "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/prefix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "format": {
-                  "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/format",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "suffix": {
-                  "$id": "#/properties/meta/properties/y3/properties/tooltip/properties/suffix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                }
-              }
-            }
-          }
-        },
-        "y4": {
-          "$id": "#/properties/meta/properties/y4",
-          "type": "object",
-          "required": [
-            "label",
-            "tooltip"
-          ],
-          "properties": {
-            "label": {
-              "$id": "#/properties/meta/properties/y4/properties/label",
-              "type": ["integer", "number", "string"]
-            },
-            "tooltip": {
-              "$id": "#/properties/meta/properties/y4/properties/tooltip",
-              "type": "object",
-              "required": [
-                "prefix",
-                "format",
-                "suffix"
-              ],
-              "properties": {
-                "prefix": {
-                  "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/prefix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "format": {
-                  "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/format",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "suffix": {
-                  "$id": "#/properties/meta/properties/y4/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
                 }

--- a/spec/support/schemas/dashboards_charts_single_year_ncont_node_type_view.json
+++ b/spec/support/schemas/dashboards_charts_single_year_ncont_node_type_view.json
@@ -18,8 +18,6 @@
           "x0",
           "x1",
           "x2",
-          "x3",
-          "x4",
           "y"
         ],
         "properties": {
@@ -33,14 +31,6 @@
           },
           "x2": {
             "$id": "#/properties/data/items/properties/x2",
-            "type": ["number", "null"]
-          },
-          "x3": {
-            "$id": "#/properties/data/items/properties/x3",
-            "type": ["number", "null"]
-          },
-          "x4": {
-            "$id": "#/properties/data/items/properties/x4",
             "type": ["number", "null"]
           },
           "y": {
@@ -61,8 +51,6 @@
         "x0",
         "x1",
         "x2",
-        "x3",
-        "x4",
         "info"
       ],
       "properties": {
@@ -299,88 +287,6 @@
                 },
                 "suffix": {
                   "$id": "#/properties/meta/properties/x2/properties/tooltip/properties/suffix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                }
-              }
-            }
-          }
-        },
-        "x3": {
-          "$id": "#/properties/meta/properties/x3",
-          "type": "object",
-          "required": [
-            "label",
-            "tooltip"
-          ],
-          "properties": {
-            "label": {
-              "$id": "#/properties/meta/properties/x3/properties/label",
-              "type": "string",
-              "pattern": "^(.*)$"
-            },
-            "tooltip": {
-              "$id": "#/properties/meta/properties/x3/properties/tooltip",
-              "type": "object",
-              "required": [
-                "prefix",
-                "format",
-                "suffix"
-              ],
-              "properties": {
-                "prefix": {
-                  "$id": "#/properties/meta/properties/x3/properties/tooltip/properties/prefix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "format": {
-                  "$id": "#/properties/meta/properties/x3/properties/tooltip/properties/format",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "suffix": {
-                  "$id": "#/properties/meta/properties/x3/properties/tooltip/properties/suffix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                }
-              }
-            }
-          }
-        },
-        "x4": {
-          "$id": "#/properties/meta/properties/x4",
-          "type": "object",
-          "required": [
-            "label",
-            "tooltip"
-          ],
-          "properties": {
-            "label": {
-              "$id": "#/properties/meta/properties/x4/properties/label",
-              "type": "string",
-              "pattern": "^(.*)$"
-            },
-            "tooltip": {
-              "$id": "#/properties/meta/properties/x4/properties/tooltip",
-              "type": "object",
-              "required": [
-                "prefix",
-                "format",
-                "suffix"
-              ],
-              "properties": {
-                "prefix": {
-                  "$id": "#/properties/meta/properties/x4/properties/tooltip/properties/prefix",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "format": {
-                  "$id": "#/properties/meta/properties/x4/properties/tooltip/properties/format",
-                  "type": "string",
-                  "pattern": "^(.*)$"
-                },
-                "suffix": {
-                  "$id": "#/properties/meta/properties/x4/properties/tooltip/properties/suffix",
                   "type": "string",
                   "pattern": "^(.*)$"
                 }


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/n/projects/2380431/stories/171324947

## Description

Bug present in "multi year overview" and "single year node type view" when ncont attribute "biome" selected - the legend would include biomes from both Brazil and Paraguay.

Fixed by retrieving values from data.

## Testing instructions

Before
<img width="585" alt="Screenshot 2020-02-18 at 12 35 33" src="https://user-images.githubusercontent.com/134055/74732895-7825f600-524b-11ea-9269-cc13cb0fe004.png">

After
<img width="581" alt="Screenshot 2020-02-18 at 12 37 35" src="https://user-images.githubusercontent.com/134055/74732905-7ceaaa00-524b-11ea-9c57-80caf8f273db.png">


