### PR TITLE
OPTIMISE ACTOR -> EXPORTING COMPANIES ENDPOINT

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -254,7 +254,6 @@ Style/ExpandPathArguments:
 Style/GuardClause:
   Exclude:
     - 'app/models/api/v3/context_node_type_property.rb'
-    - 'app/services/api/v3/actors/exporting_companies_plot.rb'
     - 'app/services/api/v3/download/flow_download_query_builder.rb'
     - 'app/services/api/v3/places/mini_sankey.rb'
     - 'app/services/api/v3/places/trajectory_deforestation_plot.rb'


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/170797923

## Description

Use partitioned_flow_values in exporting_companies plot. Also fetch data one attribute at a time. Previously we have 2 queries - first one to fetch the production values (axis y) and a second one to fetch x values for a number of attributes. Now each attribute on x is fetched separately, which makes the query simpler (grouping) and so the 3 queries are faster than 2 queries were. The ruby logic was amended to match, also simplifying how data from those combined queries is pulled into the result.

## Testing instructions

Test difference with Brazil beef, e.g. `/api/v3/contexts/6/actors/23723/exporting_companies?year=2017`
