### PR TITLE
Fix/unit modal

### DIFF
--- a/frontend/scripts/react-components/shared/list-modal/list-modal.component.jsx
+++ b/frontend/scripts/react-components/shared/list-modal/list-modal.component.jsx
@@ -19,7 +19,7 @@ export default function ListModal(props) {
           items={items}
           height={
             items.length > COLUMN_COUNT
-              ? Math.min(200, (items.length % COLUMN_COUNT) * 50 + 50)
+              ? Math.ceil(items.length / COLUMN_COUNT) * 50
               : 50
           }
           width={750}

--- a/frontend/scripts/react-components/tool/tool.actions.js
+++ b/frontend/scripts/react-components/tool/tool.actions.js
@@ -57,7 +57,7 @@ export function loadMapVectorData() {
           .then(
             topoJSON =>
               new Promise(resolve => {
-                const [key] = Object.keys(topoJSON.objects);
+                const [key] = topoJSON.objects && Object.keys(topoJSON.objects);
                 setTimeout(() => {
                   const geoJSON = topojsonFeature(topoJSON, topoJSON.objects[key]);
                   setGeoJSONMeta(


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171511229

## Description

The height function was fixed. No limits for the height also as it could be higher than 200px

![image](https://user-images.githubusercontent.com/9701591/75433268-fbcc9a80-594f-11ea-8d26-7e2aedb86ac4.png)

## Testing instructions

Pick Brazil Chicken. Open Units modal by clicking on the selectors' bar item. The modal should show all 6 elements.
