### PR TITLE
Feature/remove home map

### DIFF
--- a/frontend/scripts/react-components/explore/explore.component.jsx
+++ b/frontend/scripts/react-components/explore/explore.component.jsx
@@ -158,7 +158,6 @@ function Explore(props) {
                               enableItem={i => setItemFunction(i.id)}
                               onHover={onItemHover}
                               color="transparent"
-                              isActive={highlightedCommodityIds.includes(item.id)}
                             />
                           ))}
                       </div>

--- a/frontend/scripts/react-components/home/home.component.jsx
+++ b/frontend/scripts/react-components/home/home.component.jsx
@@ -100,7 +100,11 @@ const Home = props => {
     </div>
   );
 
-  const content = CONSOLIDATE_INSIGHTS ? [sliders, entryPoints, map] : [entryPoints, map, sliders];
+  let content = CONSOLIDATE_INSIGHTS ? [sliders, entryPoints] : [entryPoints, sliders];
+
+  if (!ENABLE_TOOL_PANEL) {
+    content = CONSOLIDATE_INSIGHTS ? [sliders, entryPoints, map] : [entryPoints, map, sliders];
+  }
 
   return (
     <div className="l-homepage">


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171537818

## Description
- Explore: Remove highlighting on commodities when hovering over countries ()
![image](https://user-images.githubusercontent.com/9701591/75546392-b5973a00-5a28-11ea-911f-2232b9379060.png)
- Home: Remove map
![image](https://user-images.githubusercontent.com/9701591/75546428-cc3d9100-5a28-11ea-8b50-b99f8c2e9e4e.png)