### PR TITLE
Feature/not supported resize

### DIFF
--- a/frontend/docs/frontend/router.md
+++ b/frontend/docs/frontend/router.md
@@ -14,6 +14,5 @@ The app is using `redux-first-router` to handle SPA like navigation.
 - `team` The team page, is hidden because SEI hasn't make up their mind about the content. They told us to leave it hidden until the content is ready.
 - `teamMember` The team member detail page
 - `about` the about pages
-- `notSupportedOnMobile` the page that appears when trying to navigate to the tool or the data download in a mobile phone
 - `logisticsMap` The logistics map page.
 - `NOT_FOUND` The 404 page.

--- a/frontend/scripts/react-components/data-portal/data-portal.component.jsx
+++ b/frontend/scripts/react-components/data-portal/data-portal.component.jsx
@@ -13,6 +13,10 @@ import {
   getURLFromParams
 } from 'utils/getURLFromParams';
 
+import useWindowSize from 'utils/hooks/useWindowSize';
+import NotSupportedComponent from 'react-components/mobile/not-supported.component';
+import { BREAKPOINTS } from 'constants';
+
 import 'styles/layouts/l-data.scss';
 import 'styles/components/data/custom-dataset.scss';
 import 'styles/components/shared/veil.scss';
@@ -47,6 +51,7 @@ function DataPortal(props) {
     onDownloadTriggered,
     selectedContext
   } = props;
+
   function reducer(state, action) {
     switch (action.type) {
       case 'closeForm':
@@ -209,6 +214,9 @@ function DataPortal(props) {
     }
   }
   const [state, dataPortalDispatch] = useReducer(reducer, initialState);
+
+  const { width } = useWindowSize();
+
   useEffect(() => {
     if (state.formVisible) {
       onDataDownloadFormLoaded();
@@ -286,6 +294,10 @@ function DataPortal(props) {
 
     dataPortalDispatch({ type: 'setDownloaded', payload: true });
   };
+
+  if (width <= BREAKPOINTS.small) {
+    return <NotSupportedComponent />;
+  }
 
   return (
     <div className="l-data">

--- a/frontend/scripts/react-components/logistics-map/logistics-map.component.jsx
+++ b/frontend/scripts/react-components/logistics-map/logistics-map.component.jsx
@@ -18,6 +18,9 @@ import LogisticsMapDownload from 'react-components/logistics-map/logistics-map-d
 import ToolBar from 'react-components/shared/tool-bar';
 import Timeline from 'react-components/tool/timeline/timeline.component';
 import ListModal from 'react-components/shared/list-modal';
+import useWindowSize from 'utils/hooks/useWindowSize';
+import NotSupportedComponent from 'react-components/mobile/not-supported.component';
+import { BREAKPOINTS } from 'constants';
 
 import 'vizzuality-components/dist/map.css';
 import 'leaflet/dist/leaflet.css';
@@ -48,6 +51,8 @@ function LogisticsMap(props) {
   } = props;
   const Tooltip = p => <UnitsTooltip {...p.data} />;
 
+  const { width } = useWindowSize();
+
   const onSelectHub = hub => {
     selectHub(hub.value);
     closeModal();
@@ -57,6 +62,10 @@ function LogisticsMap(props) {
     selectInspectionLevel(hub.value);
     closeModal();
   };
+
+  if (width <= BREAKPOINTS.tablet) {
+    return <NotSupportedComponent />;
+  }
 
   return (
     <div className="l-logistics-map">

--- a/frontend/scripts/react-components/logistics-map/logistics-map.component.jsx
+++ b/frontend/scripts/react-components/logistics-map/logistics-map.component.jsx
@@ -9,7 +9,7 @@ import WRIIcons from 'vizzuality-components/dist/icons';
 
 import { Layer, LayerManager } from 'layer-manager/dist/components';
 import { PluginLeaflet } from 'layer-manager';
-import { BASEMAPS } from 'constants';
+import { BASEMAPS, BREAKPOINTS } from 'constants';
 import UnitsTooltip from 'react-components/shared/units-tooltip/units-tooltip.component';
 import SimpleModal from 'react-components/shared/simple-modal/simple-modal.component';
 import LogisticsMapLegend from 'react-components/logistics-map/logistics-map-legend/logistics-map-legend.component';
@@ -20,7 +20,6 @@ import Timeline from 'react-components/tool/timeline/timeline.component';
 import ListModal from 'react-components/shared/list-modal';
 import useWindowSize from 'utils/hooks/useWindowSize';
 import NotSupportedComponent from 'react-components/mobile/not-supported.component';
-import { BREAKPOINTS } from 'constants';
 
 import 'vizzuality-components/dist/map.css';
 import 'leaflet/dist/leaflet.css';

--- a/frontend/scripts/react-components/shared/tool-bar/tool-bar.component.jsx
+++ b/frontend/scripts/react-components/shared/tool-bar/tool-bar.component.jsx
@@ -42,7 +42,7 @@ function ToolBar(props) {
         className={cx('slot-item', {
           '-no-hover': item.noHover,
           '-no-border': item.noBorder,
-          '-no-padding': item.noPadding
+          '-no-padding-right': item.noPaddingRight
         })}
         onMouseEnter={() => setId(item.id)}
         onMouseLeave={() => setId(null)}

--- a/frontend/scripts/react-components/shared/tool-bar/tool-bar.scss
+++ b/frontend/scripts/react-components/shared/tool-bar/tool-bar.scss
@@ -71,9 +71,9 @@
         border: 0;
       }
 
-      &.-no-padding {
+      &.-no-padding-right {
         > * {
-          padding: 0 0 20px 0;
+          padding: 20px 0 20px 20px;
         }
       }
     }
@@ -101,14 +101,6 @@
             > * {
               padding: 0 40px 0 24px;
             }
-          }
-        }
-      }
-
-      .slot-item {
-        &.-no-padding {
-          > * {
-            padding: 0 0 0 24px;
           }
         }
       }

--- a/frontend/scripts/react-components/shared/tool-bar/tool-bar.selectors.js
+++ b/frontend/scripts/react-components/shared/tool-bar/tool-bar.selectors.js
@@ -174,7 +174,7 @@ export const getToolBar = createSelector(
               type: 'button',
               show: true,
               noHover: true,
-              noPadding: true,
+              noPaddingRight: true,
               children: 'Browse Companies'
             },
             {

--- a/frontend/scripts/react-components/tool/tool.component.jsx
+++ b/frontend/scripts/react-components/tool/tool.component.jsx
@@ -8,8 +8,10 @@ import SplittedView from 'react-components/tool/splitted-view';
 import Timeline from 'react-components/tool/timeline';
 import ToolBar from 'react-components/shared/tool-bar';
 import MapLayout from 'react-components/tool/map-layout';
-
 import UrlSerializer from 'react-components/shared/url-serializer';
+import useWindowSize from 'utils/hooks/useWindowSize';
+import NotSupportedComponent from 'react-components/mobile/not-supported.component';
+import { BREAKPOINTS } from 'constants';
 
 import 'styles/components/shared/veil.scss';
 import 'styles/components/shared/dropdown.scss';
@@ -64,6 +66,9 @@ const Tool = props => {
     noLinksFound,
     activeModal
   } = props;
+
+  const { width } = useWindowSize();
+
   useEffect(() => {
     evManager.addEventListener(window, 'resize', resizeSankeyTool);
     const body = document.querySelector('body');
@@ -110,6 +115,10 @@ const Tool = props => {
     ),
     [noLinksFound, mapSidebarOpen, section, toolYearProps, selectYears, activeModal]
   );
+
+  if (width <= BREAKPOINTS.tablet) {
+    return <NotSupportedComponent />;
+  };
 
   return (
     <div>

--- a/frontend/scripts/router/router.js
+++ b/frontend/scripts/router/router.js
@@ -3,7 +3,6 @@ import { connectRoutes, NOT_FOUND, redirect, replace } from 'redux-first-router'
 import restoreScroll from 'redux-first-router-restore-scroll';
 import parseURL from 'utils/parseURL';
 import qs from 'qs';
-import { BREAKPOINTS } from 'constants';
 import withSidebarNavLayout from 'react-components/nav/sidebar-nav/with-sidebar-nav-layout.hoc';
 import getPageTitle from 'scripts/router/page-title';
 
@@ -47,12 +46,6 @@ const loadInitialDashboardData = (...args) =>
   import('../react-components/dashboard-element/dashboard-element.thunks').then(module =>
     module.loadInitialDashboardData(...args)
   );
-
-const pagesSupportedLimit = {
-  data: 'small',
-  tool: 'tablet',
-  map: 'tablet'
-};
 
 // We await for all thunks using Promise.all, this makes the result then-able and allows us to
 // add an await solely to the thunks that need it.
@@ -185,19 +178,6 @@ export const routes = {
     thunk: loadPageData(getPageStaticContent),
     layout: withSidebarNavLayout
   },
-  notSupportedOnMobile: {
-    path: '/not-supported',
-    Component: lazy(() =>
-      import(
-        /* webpackChunkName: "not-supported" */ '../react-components/mobile/not-supported.component'
-      )
-    ),
-    title: getPageTitle,
-    nav: {
-      className: '-light'
-    },
-    thunk: loadPageData()
-  },
   logisticsMap: {
     path: '/logistics-map',
     Component: lazy(() =>
@@ -241,14 +221,7 @@ const config = {
 
     return route;
   },
-  onBeforeChange: (dispatch, getState, { action }) => {
-    const supportedLimit = pagesSupportedLimit[action.type];
-    if (supportedLimit && window.innerWidth <= BREAKPOINTS[supportedLimit]) {
-      return dispatch(redirect({ type: 'notSupportedOnMobile' }));
-    }
-
-    return dispatchThunks(redirectToExplore)(dispatch, getState, { action });
-  },
+  onBeforeChange: (dispatch, getState, { action }) =>  dispatchThunks(redirectToExplore)(dispatch, getState, { action }),
   onAfterChange: (dispatch, getState, { action }) => {
     const currentLanguage = action.meta.location?.current?.query?.lang;
     const previousLanguage = action.meta.location?.prev?.query?.lang;


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171606888

## Description

On tool, logistics map and download pages the not-supported trigger has been updated to work on resize. Also, the extra route was removed.

![resize](https://user-images.githubusercontent.com/9701591/75807192-3fc30380-5d85-11ea-99c3-92901a34709d.gif)

Extra: Fixed buttons style on logistics map page

![image](https://user-images.githubusercontent.com/9701591/75807296-684afd80-5d85-11ea-8217-1f58fb280c78.png)


## Testing instructions

Resize the window or try different widths on those pages
