### PR TITLE
Fix/downloads radio button

### DIFF
--- a/frontend/scripts/analytics/tool.events.js
+++ b/frontend/scripts/analytics/tool.events.js
@@ -1,4 +1,5 @@
 import { TOGGLE_MAP_LAYERS_MENU, SET_CONTEXT } from 'app/app.actions';
+import { TOOL_LAYOUT } from 'constants';
 import {
   SELECT_CONTEXTUAL_LAYERS,
   SELECT_YEARS,
@@ -94,7 +95,7 @@ export default [
     type: CHANGE_LAYOUT,
     action: 'Change layout',
     category: 'Sankey',
-    getPayload: action => action.payload.toolLayout
+    getPayload: action => Object.keys(TOOL_LAYOUT)[action.payload.toolLayout]
   },
   {
     type: SELECT_BASEMAP,
@@ -117,6 +118,7 @@ export default [
     type: TOOL_LINKS__SWITCH_TOOL,
     action: 'Toggle tool',
     category: 'Sankey',
-    getPayload: action => action.payload.section || 'sankey'
+    getPayload: action =>
+      action.payload.section || 'sankey'
   }
 ];

--- a/frontend/scripts/react-components/data-portal/download-selector.component.jsx
+++ b/frontend/scripts/react-components/data-portal/download-selector.component.jsx
@@ -55,6 +55,7 @@ class DownloadSelector extends Component {
                   className="-red"
                   enabled={this.props.allSelected}
                   onClick={() => this.props.onAllSelected()}
+                  disabled={!this.props.enabled}
                 />
               </li>
             </ul>

--- a/frontend/scripts/react-components/nav/top-nav/top-nav.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav/top-nav.component.jsx
@@ -65,6 +65,7 @@ class TopNav extends React.PureComponent {
   handleToggleClick = () => this.setState(state => ({ menuOpen: !state.menuOpen }));
 
   renderDesktopMenu() {
+    const { backgroundVisible } = this.state;
     const { links, printable, showLogo, className, page } = this.props;
     const allLinks = [];
 
@@ -96,7 +97,7 @@ class TopNav extends React.PureComponent {
                     <Img
                       className="logo-image"
                       src={
-                        className === '-light' || className === '-egg-shell'
+                        className === '-light' || className === '-egg-shell' || backgroundVisible
                           ? '/images/logos/new-logo-trase-red.svg'
                           : '/images/logos/new-logo-trase-white.svg'
                       }

--- a/frontend/scripts/react-components/shared/radio-button/radio-button.component.jsx
+++ b/frontend/scripts/react-components/shared/radio-button/radio-button.component.jsx
@@ -5,13 +5,15 @@ import PropTypes from 'prop-types';
 import './radio-button.scss';
 
 function RadioButton(props) {
+  const { enabled, onClick, className, noSelfCancel, disabled } = props;
   return (
     <button
-      className={cx('c-radio-btn', props.className, {
-        '-enabled': props.enabled,
-        '-no-self-cancel': props.noSelfCancel
+      className={cx('c-radio-btn', className, {
+        '-enabled': enabled,
+        '-no-self-cancel': noSelfCancel
       })}
-      onClick={props.onClick}
+      onClick={onClick}
+      disabled={disabled}
     />
   );
 }
@@ -20,7 +22,8 @@ RadioButton.propTypes = {
   enabled: PropTypes.bool,
   onClick: PropTypes.func,
   className: PropTypes.string,
-  noSelfCancel: PropTypes.bool
+  noSelfCancel: PropTypes.bool,
+  disabled: PropTypes.bool
 };
 
 export default RadioButton;


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171669951

## Description

Radio button needed to be disabled

![image](https://user-images.githubusercontent.com/9701591/76237222-31b22e80-622e-11ea-82cc-001b2e4f9091.png)

Also added explicit labels to the analytics action of change the tool layout with the arrows

## Testing instructions

Go to download page and click on the disabled radio buttons. It shouldn't crash