### PR TITLE
Feature/profiles importer countries selection

### DIFF
--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.component.jsx
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.component.jsx
@@ -21,8 +21,8 @@ function ProfilePanel(props) {
   } = props;
   const singularTypes = {
     sources: 'Source',
-    'importing countries': 'Importing country',
-    traders: 'Trader'
+    traders: 'Trader',
+    destinations: 'Importer country'
   };
   switch (step) {
     case PROFILE_STEPS.type:

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.fetch.saga.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.fetch.saga.js
@@ -25,7 +25,7 @@ import {
 function* getProfilesParams(step, options = {}) {
   const state = yield select();
   const {
-    panels: { countries, sources, companies },
+    panels: { countries, sources, companies, destinations },
     data
   } = state.profileSelector;
   const { page } = options;
@@ -53,8 +53,13 @@ function* getProfilesParams(step, options = {}) {
     } else if (countries) {
       params.countries_ids = activeItemParams(countries);
     }
+
     if (companies) {
       params.companies_ids = activeItemParams(companies);
+    }
+
+    if (destinations) {
+      params.destinations_ids = activeItemParams(destinations);
     }
   }
 

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.js
@@ -3,7 +3,6 @@ import ProfilePanelComponent from 'react-components/shared/profile-selector/prof
 import { PROFILE_TYPES } from 'constants';
 import { profileSelectorActions } from 'react-components/shared/profile-selector/profile-selector.register';
 
-// Importing countries panel is not ready yet
 const blocks = [
   {
     id: PROFILE_TYPES.sources,
@@ -11,12 +10,12 @@ const blocks = [
     imageUrl: '/images/dashboards/icon_sourcing.svg',
     whiteImageUrl: '/images/dashboards/icon_sourcing_white.svg'
   },
-  // {
-  //   id: PROFILE_TYPES.importing,
-  //   title: 'importing countries',
-  //   imageUrl: '/images/dashboards/icon_importing.svg',
-  //   whiteImageUrl: '/images/dashboards/icon_importing_white.svg'
-  // },
+  {
+    id: PROFILE_TYPES.importing,
+    title: 'importer countries',
+    imageUrl: '/images/dashboards/icon_importing.svg',
+    whiteImageUrl: '/images/dashboards/icon_importing_white.svg'
+  },
   {
     id: PROFILE_TYPES.traders,
     title: 'traders',

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.saga.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.saga.js
@@ -23,18 +23,23 @@ import {
 export function* fetchProfilesInitialData() {
   const profileSelector = yield select(state => state.profileSelector);
   const panelName = getPanelName(profileSelector);
-  if (panelName === 'type') return;
-  if (panelName === 'sources') {
-    yield fork(getProfilesData, 'countries');
-    // Fetch regions
-    if (profileSelector.panels.countries.activeItems.length > 0) {
-      yield fork(getProfilesTabs, 'sources');
-    }
-  } else if (panelName === 'companies') {
-    yield call(getProfilesData, 'countries');
-    yield fork(getProfilesTabs, 'companies');
-  } else {
-    yield fork(getProfilesData, panelName);
+  switch (panelName) {
+    case 'type':
+      break;
+    case 'sources':
+      yield fork(getProfilesData, 'countries');
+      // Fetch regions
+      if (profileSelector.panels.countries.activeItems.length > 0) {
+        yield fork(getProfilesTabs, 'sources');
+      }
+      break;
+    case 'companies':
+      yield call(getProfilesData, 'countries');
+      yield fork(getProfilesTabs, 'companies');
+      break;
+    default:
+      yield fork(getProfilesData, panelName);
+      break;
   }
 }
 

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.saga.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-panel.saga.js
@@ -37,6 +37,14 @@ export function* fetchProfilesInitialData() {
       yield call(getProfilesData, 'countries');
       yield fork(getProfilesTabs, 'companies');
       break;
+    case 'destinations': {
+      // We don't want to reset the destinations data if we have an active item and no tabs
+      const hasActiveItem = profileSelector.panels.destinations.activeItems.length > 0;
+      if (!hasActiveItem) {
+        yield call(getProfilesData, 'destinations');
+      }
+      break;
+    }
     default:
       yield fork(getProfilesData, panelName);
       break;

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profile-destinations-panel.scss
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profile-destinations-panel.scss
@@ -1,0 +1,20 @@
+@import 'styles/settings';
+
+.c-profile-destinations-panel {
+  width: 560px;
+  margin: 0 auto;
+
+  .profile-destinations-panel-pill-list {
+    margin-bottom: 39px;
+    overflow-x: hidden !important;
+  }
+
+  .profile-destinations-panel-search {
+    margin: 0 0 25px 0;
+  }
+
+  @media screen and (min-width: $breakpoint-laptop) {
+    width: initial;
+    margin: initial;
+  }
+}

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profile-step-panel.component.jsx
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profile-step-panel.component.jsx
@@ -7,6 +7,7 @@ import Text from 'react-components/shared/text';
 import ShrinkingSpinner from 'scripts/react-components/shared/shrinking-spinner/shrinking-spinner.component';
 import ProfilesCompaniesPanel from './profiles-companies-panel.component';
 import ProfilesSourcesPanel from './profiles-sources-panel.component';
+import ProfilesDestinationsPanel from './profiles-destinations-panel.component';
 import 'react-components/shared/profile-selector/profile-panel/profile-step-panel/profile-step-panel.scss';
 
 function ProfileStepPanel(props) {
@@ -26,7 +27,7 @@ function ProfileStepPanel(props) {
     data,
     profileType
   } = props;
-  const { sources, countries, companies } = panels;
+  const { sources, countries, companies, destinations } = panels;
   switch (profileType) {
     case 'sources':
       return (
@@ -51,6 +52,23 @@ function ProfileStepPanel(props) {
           sourcesRequired
         />
       );
+    case 'destinations': {
+      return (
+        <ProfilesDestinationsPanel
+          loading={destinations.loadingItems}
+          destinations={data.destinations}
+          nodeTypeRenderer={node => node.nodeType || 'Country'}
+          page={destinations.page}
+          searchDestinations={destinations.searchResults}
+          getSearchResults={getSearchResults}
+          loadingMoreItems={destinations.loadingItems}
+          getMoreItems={getMoreItems}
+          activeDestinationsItem={destinations.activeItems}
+          onSelectDestinationValue={item => setProfilesActiveItem(item, 'destinations')}
+          setSearchResult={item => setProfilesSearchResult(item, 'destinations')}
+        />
+      )
+    }
     case 'companies': {
       const toOption = d => ({ label: d.name, value: d.id });
       const options = data.countries?.map(toOption);

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profiles-destinations-panel.component.jsx
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profile-step-panel/profiles-destinations-panel.component.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SearchInput from 'react-components/shared/search-input/search-input.component';
+import GridList from 'react-components/shared/grid-list/grid-list.component';
+import { useFirstItem } from 'react-components/shared/grid-list/grid-list.hooks';
+import GridListItem from 'react-components/shared/grid-list-item/grid-list-item.component';
+import ResizeListener from 'react-components/shared/resize-listener.component';
+import { BREAKPOINTS } from 'constants';
+
+import './profile-destinations-panel.scss';
+
+function ProfilesDestinationsPanel(props) {
+  const {
+    page,
+    getMoreItems,
+    searchDestinations,
+    loading,
+    setSearchResult,
+    getSearchResults,
+    destinations,
+    nodeTypeRenderer,
+    onSelectDestinationValue,
+    activeDestinationsItem
+  } = props;
+
+  const itemToScrollTo = useFirstItem(destinations);
+
+
+  return (
+    <ResizeListener>
+      {({ windowWidth }) => {
+        const columnsCount = windowWidth > BREAKPOINTS.laptop ? 5 : 3;
+        const width = windowWidth > BREAKPOINTS.laptop ? 950 : 560;
+        return (
+          <div className="c-profile-destinations-panel">
+            <SearchInput
+              variant="bordered"
+              size="sm"
+              className="profile-destinations-panel-search"
+              items={searchDestinations}
+              placeholder="Search country"
+              onSelect={item =>
+                !item.nodeType ? onSelectDestinationValue(item) : setSearchResult(item)
+              }
+              onSearchTermChange={getSearchResults}
+              nodeTypeRenderer={nodeTypeRenderer}
+            />
+            <GridList
+              className="profile-destinations-panel-pill-list"
+              items={destinations}
+              height={destinations.length > columnsCount ? 200 : 50}
+              width={width}
+              rowHeight={50}
+              columnWidth={190}
+              columnCount={columnsCount}
+              page={page}
+              getMoreItems={getMoreItems}
+              loading={loading}
+              itemToScrollTo={itemToScrollTo}
+            >
+              {itemProps => (
+                <GridListItem
+                  {...itemProps}
+                  isActive={activeDestinationsItem.includes(itemProps.item?.id)}
+                  enableItem={onSelectDestinationValue}
+                  disableItem={onSelectDestinationValue}
+                />
+              )}
+            </GridList>
+          </div>
+        );
+      }}
+    </ResizeListener>
+  );
+}
+
+ProfilesDestinationsPanel.propTypes = {
+  loading: PropTypes.bool,
+  destinations: PropTypes.array,
+  nodeTypeRenderer: PropTypes.func,
+  page: PropTypes.number.isRequired,
+  activeDestinationsItem: PropTypes.array,
+  getMoreItems: PropTypes.func.isRequired,
+  searchDestinations: PropTypes.array.isRequired,
+  setSearchResult: PropTypes.func.isRequired,
+  getSearchResults: PropTypes.func.isRequired,
+  onSelectDestinationValue: PropTypes.func.isRequired
+};
+
+ProfilesDestinationsPanel.defaultProps = {
+  destinations: []
+};
+
+export default ProfilesDestinationsPanel;

--- a/frontend/scripts/react-components/shared/profile-selector/profile-panel/profiles-commodity-panel.component.jsx
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-panel/profiles-commodity-panel.component.jsx
@@ -44,7 +44,7 @@ ProfilesCommoditiesPanel.propTypes = {
   commodities: PropTypes.array,
   loading: PropTypes.bool,
   page: PropTypes.number.isRequired,
-  activeCommodities: PropTypes.object,
+  activeCommodities: PropTypes.array,
   getMoreItems: PropTypes.func.isRequired,
   onSelectCommodity: PropTypes.func.isRequired
 };

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.actions.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.actions.js
@@ -71,25 +71,37 @@ export const setProfilesLoadingItems = loadingItems => ({
     loadingItems
   }
 });
+
 export const goToProfile = () => (dispatch, getState) => {
   const { profileSelector, app } = getState();
   const { contexts } = app;
   const hasCompanies = profileSelector.panels.companies.activeItems.length > 0;
-  const profileType = hasCompanies ? 'actor' : 'place';
-  const nodeId = hasCompanies
-    ? profileSelector.panels.companies.activeItems[0]
-    : profileSelector.panels.sources.activeItems[0];
-  const query = { nodeId };
-  const commodity = profileSelector.panels.commodities.activeItems[0];
-  if (commodity) {
+  const hasDestinations = profileSelector.panels.destinations.activeItems.length > 0;
+  const getProfileType = () => {
+    if (hasDestinations) return 'country';
+    return hasCompanies ? 'actor' : 'place';
+  };
+  const getNodeId = () => {
+    if (hasDestinations) return profileSelector.panels.destinations.activeItems[0];
+    if (hasCompanies) return profileSelector.panels.companies.activeItems[0];
+    return profileSelector.panels.sources.activeItems[0];
+  };
+
+  const query = { nodeId: getNodeId() };
+
+  const commodityId = profileSelector.panels.commodities.activeItems[0];
+  if (commodityId) {
     const country = profileSelector.panels.countries.activeItems[0];
-    const contextId = contexts.find(c => c.countryId === country && c.commodityId === commodity)
+    const contextId = contexts.find(c => c.countryId === country && c.commodityId === commodityId)
       ?.id;
     if (contextId) {
       query.contextId = contextId;
+    } else {
+      query.commodityId = commodityId; // Destination profiles only have commodityId
     }
   }
-  dispatch({ type: 'profile', payload: { profileType, query } });
+
+  dispatch({ type: 'profile', payload: { profileType: getProfileType(), query } });
   dispatch(closeModal());
 };
 

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.initial-state.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.initial-state.js
@@ -43,7 +43,7 @@ export default {
     countries: [],
     sources: {},
     companies: {},
-    destinations: {}
+    destinations: []
   },
   tabs: {}
 };

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.initial-state.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.initial-state.js
@@ -16,6 +16,13 @@ export default {
       activeItems: [],
       activeTab: null
     },
+    destinations: {
+      page: 1,
+      searchResults: [],
+      loadingItems: false,
+      activeItems: [],
+      activeTab: null
+    },
     sources: {
       page: 1,
       searchResults: [],
@@ -35,7 +42,8 @@ export default {
     commodities: [],
     countries: [],
     sources: {},
-    companies: {}
+    companies: {},
+    destinations: {}
   },
   tabs: {}
 };

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.reducer.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.reducer.js
@@ -21,6 +21,13 @@ const profilesReducer = {
     return immer(state, draft => {
       const { activeStep } = action.payload;
 
+      const panelName = getPanelName(state);
+
+      // Reset page on destinations panel to load the first items
+      if (panelName === 'destinations') {
+        draft.panels.destinations.page = initialState.panels.destinations.page;
+      }
+
       draft.activeStep = activeStep;
     });
   },

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.selectors.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.selectors.js
@@ -2,13 +2,15 @@ import { createSelector } from 'reselect';
 import { PROFILE_STEPS } from 'constants';
 
 const getProfileSelectorTabs = state => state.profileSelector.tabs;
-const getCompaniesPanel = state => state.profileSelector.panels.companies;
-const getSourcesPanel = state => state.profileSelector.panels.sources;
 const getCountriesPanel = state => state.profileSelector.panels.countries;
+const getSourcesPanel = state => state.profileSelector.panels.sources;
+const getCompaniesPanel = state => state.profileSelector.panels.companies;
+const getDestinationsPanel = state => state.profileSelector.panels.destinations;
 
 const getCountriesData = state => state.profileSelector.data.countries;
 const getSourcesData = state => state.profileSelector.data.sources;
 const getCompaniesData = state => state.profileSelector.data.companies;
+const getDestinationsData = state => state.profileSelector.data.destinations;
 
 const getSourcesTab = state => state.profileSelector.panels.sources.activeTab;
 const getCompaniesTab = state => state.profileSelector.panels.companies.activeTab;
@@ -111,6 +113,13 @@ export const getCompaniesActiveItems = createSelector(
   [getCompaniesPanel, getCompaniesCountryData],
   getPanelActiveTabItems
 );
+export const getDestinationsActiveItems = createSelector(
+  [getDestinationsPanel, getDestinationsData],
+  (destinationsPanel, destinationsData) => {
+    if (!destinationsData || !destinationsData.length || !destinationsPanel.activeItems) return null;
+    return destinationsData.find(d => d.id === destinationsPanel.activeItems[0]);
+  }
+);
 
 export const getIsDisabled = createSelector(
   [getActiveStep, getPanels, getProfileType],
@@ -131,11 +140,12 @@ export const getIsDisabled = createSelector(
 );
 
 export const getDynamicSentence = createSelector(
-  [getSourcesActiveItems, getCompaniesActiveItems, getProfileType],
-  (sourcesActiveItems, companiesActiveItems, profileType) => {
+  [getSourcesActiveItems, getCompaniesActiveItems, getDestinationsActiveItems, getProfileType],
+  (sourcesActiveItems, companiesActiveItems, destinationsActiveItems, profileType) => {
     if (
       (profileType === 'sources' && !sourcesActiveItems) ||
-      (profileType === 'companies' && !companiesActiveItems)
+      (profileType === 'companies' && !companiesActiveItems) ||
+      (profileType === 'destinations' && !destinationsActiveItems)
     ) {
       return [];
     }
@@ -156,8 +166,15 @@ export const getDynamicSentence = createSelector(
         transform: 'capitalize',
         value: companiesActiveItems
       });
+    } else if (profileType === 'destinations') {
+      dynamicParts.push({
+        panel: 'destinations',
+        id: 'destinations',
+        prefix: 'See the',
+        transform: 'capitalize',
+        value: [destinationsActiveItems]
+      });
     }
-
     if (dynamicParts.length > 0) {
       dynamicParts.push({
         prefix: 'profile'

--- a/frontend/scripts/react-components/shared/tags-group/tag.component.jsx
+++ b/frontend/scripts/react-components/shared/tags-group/tag.component.jsx
@@ -45,6 +45,13 @@ function Tag(props) {
 
   const Component = as || Heading;
 
+  const renderName = () => {
+    if (part.value.length > 1) {
+      return part.name ? translateText(`${part.value.length} ${part.name || part.panel}`).toLowerCase() : null;
+    }
+    return part.value[0].name ? translateText(part.value[0].name).toLowerCase() : null;
+  };
+
   return (
     <Component
       size={size}
@@ -58,9 +65,7 @@ function Tag(props) {
         '-spaced': spaced
       })}
     >
-      {part.value.length > 1
-        ? translateText(`${part.value.length} ${part.name || part.panel}`)
-        : translateText(part.value[0].name)}
+      {renderName()}
       {!readOnly && clearPanel && (
         <button
           key={`button${part.id}`}

--- a/frontend/scripts/react-components/shared/tags-group/tags-group.component.jsx
+++ b/frontend/scripts/react-components/shared/tags-group/tags-group.component.jsx
@@ -21,7 +21,7 @@ function TagsGroup(props) {
           as="span"
           size={size}
           align="center"
-          key={part.id}
+          key={part.id || part.prefix}
           color={color}
           className="tag-group-part notranslate"
         >


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171836046

## Description

- Include Importer countries option




- Include Importer countries panel 


- Redirect to profile-country page: Still not implemented





## Testing instructions

Apply the CMS changes on the steps 1 and 2 of the "Database and CMS changes" of this PR: https://github.com/Vizzuality/trase/pull/1331

- Go to profiles page and click the Browse Places and Traders button
- Select importer countries
- Select a country. Try search too
- Click continue and select a commodity
- You should be redirected to a country page URL with the commodity id
