### PR TITLE
Feature/recent card

### DIFF
--- a/frontend/scripts/react-components/explore/explore.actions.js
+++ b/frontend/scripts/react-components/explore/explore.actions.js
@@ -39,6 +39,9 @@ export const goToTool = (destination, card) => dispatch => {
         linkParams: card
       }
     });
+    const { commodities: commodityId, countries: countryId } = card.links.sankey.payload.serializerParams;
+    const serializedParams = `${countryId}-${commodityId}`;
+    localStorage.setItem('recentCard', serializedParams);
     dispatch(card.links[destination]);
   });
 };

--- a/frontend/scripts/react-components/explore/explore.selectors.js
+++ b/frontend/scripts/react-components/explore/explore.selectors.js
@@ -107,31 +107,60 @@ export const getCountryQuickFacts = createSelector([getQuickFacts], quickFacts =
   return countryQuickFacts;
 });
 
-export const getCards = createSelector([getSankeyCards, getContexts], (cards, contexts) => {
-  if (!cards || contexts.length === 0) {
-    return [];
-  }
-
-  return cards.data.map((options, index) => {
-    const context = contexts.find(
-      ctx => ctx.countryId === options.countryId && ctx.commodityId === options.commodityId
-    );
-    return {
-      index,
-      id: options.id,
-      title: options.title,
-      subtitle: options.subtitle,
-      countryId: options.countryId,
-      commodityId: options.commodityId,
-      countryName: context.countryName,
-      commodityName: context.commodityName,
-      links: {
-        sankey: translateLink(options, cards.meta),
-        dashboard: translateLink(options, cards.meta, 'dashboard')
+const getRecentCard = () => {
+  const recentCard = localStorage.getItem('recentCard');
+  if (!recentCard) return null;
+  const [countryId, commodityId] = recentCard.split('-');
+  return {
+    data: [
+      {
+        id: 0,
+        title: 'Recently opened supply chain',
+        subtitle: null,
+        countryId: parseInt(countryId, 10),
+        commodityId: parseInt(commodityId, 10)
       }
-    };
-  });
-});
+    ],
+    meta: [{}]
+  };
+}
+
+const getCardsWithRecentCard = createSelector(
+  [getSankeyCards, getRecentCard],
+  (cards, recentCard) => {
+    if (!cards) return recentCard;
+    return recentCard ? { data: [...recentCard.data, ...cards.data], meta: cards.meta } : cards;
+  }
+);
+
+export const getCards = createSelector(
+  [getCardsWithRecentCard, getContexts, getRecentCard],
+  (cards, contexts) => {
+    if (!cards || contexts.length === 0) {
+      return [];
+    }
+
+    return cards.data.map((options, index) => {
+      const context = contexts.find(
+        ctx => ctx.countryId === options.countryId && ctx.commodityId === options.commodityId
+      );
+      return {
+        index,
+        id: options.id,
+        title: options.title,
+        subtitle: options.subtitle,
+        countryId: options.countryId,
+        commodityId: options.commodityId,
+        countryName: context.countryName,
+        commodityName: context.commodityName,
+        links: {
+          sankey: translateLink(options, cards.meta),
+          dashboard: translateLink(options, cards.meta, 'dashboard')
+        }
+      };
+    });
+  }
+);
 
 export const getCardsWithDefault = createSelector(
   [getCards, getSelectedCommodityId, getSelectedCountryId, getContexts, getSankeyCardsLoading],

--- a/frontend/scripts/react-components/explore/explore.selectors.js
+++ b/frontend/scripts/react-components/explore/explore.selectors.js
@@ -115,6 +115,7 @@ const getRecentCard = () => {
     data: [
       {
         id: 0,
+        recentCard: true,
         title: 'Recently opened supply chain',
         subtitle: null,
         countryId: parseInt(countryId, 10),
@@ -147,6 +148,7 @@ export const getCards = createSelector(
       return {
         index,
         id: options.id,
+        recentCard: options.recentCard,
         title: options.title,
         subtitle: options.subtitle,
         countryId: options.countryId,

--- a/frontend/scripts/react-components/explore/featured-cards/featured-card.component.jsx
+++ b/frontend/scripts/react-components/explore/featured-cards/featured-card.component.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Text from 'react-components/shared/text';
+import PropTypes from 'prop-types';
+import { ImgBackground } from 'react-components/shared/img';
+import cx from 'classnames';
+
+import 'react-components/explore/featured-cards/featured-cards.scss';
+
+const FeaturedCard = ({ card, openModal, step }) => {
+  const { recentCard, title, subtitle, countryName, commodityName } = card;
+  const stepIds = { 1: '', 2: `-${commodityName}`, 3: `-${commodityName}-${countryName}` };
+  const cardStepId = stepIds[step];
+  return (
+    <div className={cx("c-featured-card", { "recent-card": recentCard })}>
+      <ImgBackground
+        as="button"
+        onClick={() => openModal(card)}
+        className="featured-card-button"
+        data-test={`featured-card${cardStepId}`}
+        src={`'/images/featured-links/${countryName}.svg'`}
+      >
+        {!recentCard && <Text
+          variant="mono"
+          align="center"
+          weight="bold"
+          size="lg"
+          transform="uppercase"
+          color="white"
+        >
+          <span className="featured-card-country-name">{countryName}</span>
+          <span className="featured-card-commodity-name">{commodityName}</span>
+        </Text>}
+        <Text
+          variant="mono"
+          align="center"
+          weight="bold"
+          transform="uppercase"
+          color="white"
+          lineHeight={recentCard ? "md" : "lg"}
+          size={recentCard ? "md" : "rg"}
+          className="featured-card-text"
+          title={title}
+        >
+          {title}
+        </Text>
+        <Text
+          variant="mono"
+          align="center"
+          transform="uppercase"
+          color="white"
+          weight="bold"
+          className="featured-card-text"
+          title={subtitle}
+        >
+          {subtitle}
+        </Text>
+      </ImgBackground>
+    </div>
+  );
+};
+
+FeaturedCard.propTypes = {
+  step: PropTypes.number,
+  card: PropTypes.object.isRequired,
+  openModal: PropTypes.func.isRequired
+};
+
+export default FeaturedCard;

--- a/frontend/scripts/react-components/explore/featured-cards/featured-cards.component.jsx
+++ b/frontend/scripts/react-components/explore/featured-cards/featured-cards.component.jsx
@@ -5,68 +5,10 @@ import PropTypes from 'prop-types';
 import capitalize from 'lodash/capitalize';
 import { useTransition, animated } from 'react-spring/web.cjs';
 import ResizeListener from 'react-components/shared/resize-listener.component';
-import { ImgBackground } from 'react-components/shared/img';
 import cx from 'classnames';
+import FeaturedCard from './featured-card.component';
 
 import 'react-components/explore/featured-cards/featured-cards.scss';
-
-const FeaturedCard = ({ card, openModal, step }) => {
-  const { title, subtitle, countryName, commodityName } = card;
-  const stepIds = { 1: '', 2: `-${commodityName}`, 3: `-${commodityName}-${countryName}` };
-  const cardStepId = stepIds[step];
-  return (
-    <div className="c-featured-card">
-      <ImgBackground
-        as="button"
-        onClick={() => openModal(card)}
-        className="featured-card-button"
-        data-test={`featured-card${cardStepId}`}
-        src={`'/images/featured-links/${countryName}.svg'`}
-      >
-        <Text
-          variant="mono"
-          align="center"
-          weight="bold"
-          size="lg"
-          transform="uppercase"
-          color="white"
-        >
-          <span className="featured-card-country-name">{countryName}</span>
-          <span className="featured-card-commodity-name">{commodityName}</span>
-        </Text>
-        <Text
-          variant="mono"
-          align="center"
-          weight="bold"
-          transform="uppercase"
-          color="white"
-          lineHeight="lg"
-          className="featured-card-text"
-          title={title}
-        >
-          {title}
-        </Text>
-        <Text
-          variant="mono"
-          align="center"
-          transform="uppercase"
-          color="white"
-          weight="bold"
-          className="featured-card-text"
-          title={subtitle}
-        >
-          {subtitle}
-        </Text>
-      </ImgBackground>
-    </div>
-  );
-};
-
-FeaturedCard.propTypes = {
-  step: PropTypes.number,
-  card: PropTypes.object.isRequired,
-  openModal: PropTypes.func.isRequired
-};
 
 const FeaturedCards = props => {
   const { countryName, commodityName, step, cards, openModal } = props;

--- a/frontend/scripts/react-components/explore/featured-cards/featured-cards.scss
+++ b/frontend/scripts/react-components/explore/featured-cards/featured-cards.scss
@@ -53,6 +53,10 @@ $card-min-width: 180px;
   background-color: $strong-pink;
   border-radius: 5px;
 
+  &.recent-card {
+    background-color: $charcoal-grey;
+  }
+
   .featured-card-button {
     height: 100px;
     width: 100%;
@@ -62,6 +66,12 @@ $card-min-width: 180px;
     background-size: auto 90%;
     background-position: center;
     background-repeat: no-repeat;
+  }
+
+  &.recent-card {
+    .featured-card-button {
+      padding: 25px 20px 20px;
+    }
   }
 
   .featured-card-country-name {
@@ -81,9 +91,11 @@ $card-min-width: 180px;
     }
   }
 
-  .featured-card-text {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  &:not(.recent-card) {
+    .featured-card-text {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171812493

## Description
This feature adds a recent card into the explore cards once the user enters the tool once.
The information of the card is stored in localStorage when the user accesses the tool through the modal.

![image](https://user-images.githubusercontent.com/9701591/77346763-0ef83d80-6d37-11ea-889f-6672e3cde900.png)

## Testing instructions

- Go to 'explore page' (Data tool in the menu) and click in any card
- Click on Data tool again and the Recent card should show
- It should be updated when we click on other card