### PR TITLE
Return number of aggregated OTHER nodes

### DIFF
--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -2,7 +2,7 @@ module Api
   module V3
     module Flows
       class Filter
-        attr_reader :errors, :flows, :active_nodes, :total_height, :other_nodes_ids,
+        attr_reader :errors, :flows, :active_nodes, :total_height, :other_nodes,
                     :cont_attribute, :ncont_attribute
         # params:
         # node_types_ids - list of node type ids
@@ -192,11 +192,11 @@ module Api
         end
 
         def initialize_active_nodes
-          active_nodes_by_position =
+          active_nodes_by_position, @other_nodes =
             if @selected_nodes.none?
-              active_nodes_for_overview # overview mode
+              nodes_for_overview # overview mode
             else
-              active_nodes_for_expand # expanded mode
+              nodes_for_expand # expanded mode
             end
 
           @active_nodes_ids_by_position = Hash[
@@ -215,54 +215,62 @@ module Api
             reduce(:merge)
         end
 
-        def active_nodes_for_overview
+        def nodes_for_overview
           active_nodes = {}
+          other_nodes = []
           @active_node_types_positions.map.with_index do |position, i|
             flows_through_position = flows_totals_per_node(position)
-            active_nodes[position] = active_nodes_for_position(
-              flows_through_position, @other_nodes_ids[i]
-            )
+            active_nodes[position], other_nodes[i] =
+              active_nodes_for_position(
+                flows_through_position, @other_nodes_ids[i]
+              )
           end
-          active_nodes
+          [active_nodes, other_nodes]
         end
 
-        def active_nodes_for_expand
+        def nodes_for_expand
           active_nodes = {}
+          other_nodes = []
           @active_node_types_positions.map.with_index do |position, i|
             flows_through_position = flows_totals_per_node(position)
-            active_nodes[position] =
+            other_node_id = @other_nodes_ids[i]
+            active_nodes[position], other_nodes[i] =
               if @selected_nodes_by_position.key?(position)
                 active_nodes_for_expanded_position(
-                  flows_through_position, @other_nodes_ids[i]
+                  flows_through_position, other_node_id
                 )
               else
                 active_nodes_for_position(
-                  flows_through_position, @other_nodes_ids[i]
+                  flows_through_position, other_node_id
                 )
               end
           end
-          active_nodes
+          [active_nodes, other_nodes]
         end
 
         def active_nodes_for_position(flows_through_position, other_node_id)
           result = {other_node_id => 0}
+          other = {id: other_node_id, count: 0}
           flows_through_position.each.with_index do |flow, i|
             if i < @limit || @locked_nodes_ids.include?(flow['node_id'])
               result[flow['node_id']] = flow['total']
             else
               result[other_node_id] += flow['total']
+              other[:count] += 1
             end
           end
-          result
+          [result, other]
         end
 
         def active_nodes_for_expanded_position(flows_through_position, other_node_id)
           result = {other_node_id => 0}
+          other = {id: other_node_id, count: 0}
           flows_through_position.each do |flow|
             if @selected_nodes_ids.include?(flow['node_id']) || @locked_nodes_ids.include?(flow['node_id'])
               result[flow['node_id']] = flow['total']
             else
               result[other_node_id] += flow['total']
+              other[:count] += 1
             end
           end
           result

--- a/app/services/api/v3/flows/result.rb
+++ b/app/services/api/v3/flows/result.rb
@@ -8,10 +8,11 @@ module Api
         def initialize(filter_flows)
           @errors = filter_flows.errors
           return if @errors.any?
+
           @flows = filter_flows.flows
           @active_nodes = filter_flows.active_nodes
           @total_height = filter_flows.total_height
-          @other_nodes_ids = filter_flows.other_nodes_ids
+          @other_nodes = filter_flows.other_nodes
           @cont_attribute = filter_flows.cont_attribute
           @ncont_attribute = filter_flows.ncont_attribute
           initialize_data
@@ -61,14 +62,16 @@ module Api
         end
 
         def initialize_include
+          node_heights = @active_nodes.map do |node_id, value|
+            {
+              id: node_id,
+              height: format('%0.6f', (value / @total_height)).to_f,
+              quant: format('%0.6f', value).to_f
+            }
+          end
           @include = {
-            node_heights: @active_nodes.map do |node_id, value|
-              {
-                id: node_id,
-                height: format('%0.6f', (value / @total_height)).to_f,
-                quant: format('%0.6f', value).to_f
-              }
-            end
+            node_heights: node_heights,
+            other_nodes: @other_nodes
           }
         end
 


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171932938

## Description

Adds to flows endpoint information about number of nodes aggregated as "OTHER"

`include`->`otherNodes`

It is an array (corresponding to column positions), e.g.:
"otherNodes":[{"id":38980,"count":2152},{"id":38983,"count":305},{"id":38984,"count":209},{"id":38985,"count":63}]}}
