### PR TITLE
Remove interaction and add others node count

### DIFF
--- a/frontend/scripts/react-components/tool-links/tool-links.initial-state.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.initial-state.js
@@ -6,6 +6,7 @@ export default {
     nodes: null,
     links: null,
     nodeHeights: null,
+    otherNodes: null,
     nodeAttributes: null,
     nodesByColumnGeoId: null,
     charts: null

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -162,8 +162,12 @@ const toolLinksReducer = {
       const { links, linksMeta } = action.payload;
 
       draft.data.nodeHeights = {};
+      draft.data.otherNodes = {};
       linksMeta.nodeHeights.forEach(nodeHeight => {
         draft.data.nodeHeights[nodeHeight.id] = nodeHeight;
+      });
+      linksMeta.otherNodes.forEach(otherNode => {
+        draft.data.otherNodes[otherNode.id] = otherNode;
       });
       draft.data.links = links;
     });

--- a/frontend/scripts/react-components/tool/sankey/sankey-column.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey-column.component.jsx
@@ -27,7 +27,7 @@ function SankeyColumn(props) {
               '-selected': selectedNodesIds.includes(node.id)
             })}
             transform={`translate(0,${node.y})`}
-            onClick={() => list.length > 1 && onNodeClicked(node.id, node.isAggregated)}
+            onClick={() => list.length > 1 && !node.isAggregated && onNodeClicked(node.id)}
             onMouseOver={e => onNodeOver(e, node)}
             onMouseOut={e => onNodeOut(e, node)}
           >

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -176,6 +176,7 @@ function Sankey(props) {
     maxHeight,
     flowsLoading,
     nodeHeights,
+    otherNodes,
     nodeAttributes,
     selectedMapDimensions,
     sankeyColumnsWidth,
@@ -272,13 +273,10 @@ function Sankey(props) {
   };
 
   const onNodeOver = (e, node) => {
-    if (node.isAggregated) {
-      return;
-    }
-
     const rect = getRect(toolLayout);
 
     const nodeHeight = nodeHeights[node.id];
+    const otherNodeCount = otherNodes && otherNodes[node.id] && otherNodes[node.id].count
     const tooltipPadding = 10;
     const minTooltipWidth = 180;
     const tooltip = {
@@ -315,6 +313,14 @@ function Sankey(props) {
         .filter(Boolean);
 
       tooltip.items.push(...nodeIndicators);
+
+      if (otherNodeCount) {
+        tooltip.items.push({
+          title: pluralize(node.type),
+          unit: null,
+          value: otherNodeCount
+        });
+      }
     }
 
     if (selectedNodesIds.includes(node.id)) {
@@ -325,10 +331,7 @@ function Sankey(props) {
     onNodeHighlighted(node.id);
   };
 
-  const onNodeOut = (e, node) => {
-    if (node.isAggregated) {
-      return;
-    }
+  const onNodeOut = () => {
     setTooltipContent(null);
     onNodeHighlighted(null);
   };
@@ -444,6 +447,7 @@ Sankey.propTypes = {
   highlightedNodeId: PropTypes.number,
   gapBetweenColumns: PropTypes.number,
   nodeHeights: PropTypes.object,
+  otherNodes: PropTypes.object,
   nodeAttributes: PropTypes.object,
   selectedMapDimensions: PropTypes.array,
   onClearClick: PropTypes.func.isRequired, // eslint-disable-line

--- a/frontend/scripts/react-components/tool/sankey/sankey.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.js
@@ -26,6 +26,7 @@ const mapStateToProps = state => ({
   sankeySize: state.toolLayers.sankeySize,
   maxHeight: getSankeyMaxHeight(state),
   nodeHeights: state.toolLinks.data.nodeHeights,
+  otherNodes: state.toolLinks.data.otherNodes,
   nodeAttributes: state.toolLinks.data.nodeAttributes,
   sankeyColumnsWidth: state.toolLinks.sankeyColumnsWidth,
   selectedResizeBy: getSelectedResizeBy(state),

--- a/frontend/scripts/react-components/tool/sankey/sankey.scss
+++ b/frontend/scripts/react-components/tool/sankey/sankey.scss
@@ -42,7 +42,7 @@ $columns-selector-group-height: 50px;
 
     &.-is-aggregated > .sankey-node-rect {
       // the horizontal lines pattern is defined in the <defs> section of the SVG in flows.ejs
-      cursor: zoom-in;
+      cursor: default;
       fill: url('#isAggregatedPattern');
     }
 


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171812712

## Description

- Added the tooltip for 'Other' node with the count and the unit indicator information
- Removed the click interaction and changed the cursor to default

![image](https://user-images.githubusercontent.com/9701591/77532700-affd0a80-6e95-11ea-9003-0b711f1ed0de.png)

## Testing instructions

Go to the tool in Sankey view and hover over an 'Other' node