### PR TITLE
Fix/basic attributes missing from profile meta

### DIFF
--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -32,6 +32,8 @@ module Api
 
       NAMES = [ACTOR, PLACE, COUNTRY].freeze
 
+      alias_attribute :profile_type, :name
+
       belongs_to :context_node_type
       has_many :charts, -> { order(:position) }
 

--- a/app/serializers/api/v3/profiles/profile_meta_serializer.rb
+++ b/app/serializers/api/v3/profiles/profile_meta_serializer.rb
@@ -3,6 +3,7 @@ module Api
     module Profiles
       class ProfileMetaSerializer < ActiveModel::Serializer
         attributes :id,
+                   :name,
                    :context_id,
                    :commodity_id,
                    :country_id,
@@ -10,7 +11,7 @@ module Api
                    :commodities,
                    :activities,
                    :years,
-                   :name,
+                   :profile_type,
                    :main_topojson_path,
                    :main_topojson_root,
                    :adm_1_name,

--- a/app/services/api/v3/profiles/profile_meta.rb
+++ b/app/services/api/v3/profiles/profile_meta.rb
@@ -4,9 +4,9 @@ module Api
       class ProfileMeta
         include ActiveModel::Serialization
 
-        delegate :id, :context_id, :years, to: :@node_with_flows
+        delegate :id, :name, :context_id, :years, to: :@node_with_flows
         delegate :commodity_id, :country_id, to: :@context
-        delegate :name,
+        delegate :profile_type,
                  :main_topojson_path,
                  :main_topojson_root,
                  :adm_1_name,

--- a/lib/tasks/db_country_profiles.rake
+++ b/lib/tasks/db_country_profiles.rake
@@ -34,6 +34,9 @@ namespace :db do
           find_or_create_chart_node_type(
             top_countries_chart, country_of_import_node_type, 'destination'
           )
+          basic_attributes_chart = find_or_create_chart(
+            profile, :country_basic_attributes, 0, 'Basic attributes'
+          )
         end
 
         importer_context_node_types = Api::V3::ContextNodeType.where(
@@ -55,6 +58,9 @@ namespace :db do
           )
           find_or_create_chart_node_type(
             top_countries_chart, country_of_export_node_type, 'destination'
+          )
+          basic_attributes_chart = find_or_create_chart(
+            profile, :country_basic_attributes, 0, 'Basic attributes'
           )
         end
       end


### PR DESCRIPTION
## Description

* creating basic attributes chart objects for country profiles using the rake task
* adds node name to profile_meta

## Testing instructions

`bundle exec rake db:country_profiles:populate`
