### PR TITLE
Add country name from profile meta

### DIFF
--- a/frontend/scripts/react-components/profile/profile-components/summary/country-summary.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-components/summary/country-summary.component.jsx
@@ -15,7 +15,7 @@ function CountrySummary(props) {
     year,
     onChange,
     openModal,
-    profileMetadata: { years, activity, commodities, activities, commodityId, countryName } = {}
+    profileMetadata: { years, activity, commodities, activities, commodityId, name: countryName } = {}
   } = props;
   const renderCountryMap = () => (
     <div className="c-overall-info page-break-inside-avoid">
@@ -24,7 +24,9 @@ function CountrySummary(props) {
           topoJSONPath="./vector_layers/WORLD.topo.json"
           topoJSONRoot="world"
           getPolygonClassName={d =>
-            d.properties.name === countryName ? '-isCurrent' : ''
+            d.properties.name.toLowerCase() === countryName.toLowerCase()
+              ? '-isCurrent'
+              : ''
           }
           useRobinsonProjection
         />
@@ -86,7 +88,7 @@ function CountrySummary(props) {
               >
                 <SummaryTitle
                   sticky={status === Sticky.STATUS_FIXED}
-                  name={countryName || '[CountryName]'}
+                  name={countryName}
                   activity={activity}
                   openModal={openModal}
                 />


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172048393

We have the country name coming from the profile meta now. And the country is rendered in red.

![image](https://user-images.githubusercontent.com/9701591/77943866-3e222800-72be-11ea-996c-98b72d5730e4.png)
