### PR TITLE
Fix/layer modal

### DIFF
--- a/frontend/scripts/analytics/tool.events.js
+++ b/frontend/scripts/analytics/tool.events.js
@@ -112,7 +112,7 @@ export default [
     type: SELECT_CONTEXTUAL_LAYERS,
     action: 'Select contextual layers',
     category: 'Sankey',
-    getPayload: action => action.payload.contextualLayers.join(', ')
+    getPayload: action => action.payload.contextualLayers?.join(', ')
   },
   {
     type: TOOL_LINKS__SWITCH_TOOL,

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -216,7 +216,6 @@ const toolLinksReducer = {
   },
 
   [TOOL_LINKS__SELECT_COLUMN](state, action) {
-    // This is failing when we change a columns and we have 5 columns
     return immer(state, draft => {
       const { extraColumn, data, extraColumnNodeId, selectedNodesIds, selectedColumnsIds } = state;
       const { columnId, columnIndex } = action.payload;
@@ -233,7 +232,6 @@ const toolLinksReducer = {
       };
 
       // COLUMN CHANGES
-
       const extraColumnParentColumnPosition =
         extraColumn && data.columns[extraColumn.parentId].group;
 
@@ -244,7 +242,7 @@ const toolLinksReducer = {
           ? columnIndex + 1
           : columnIndex;
 
-      if (selectedColumnsIds && !selectedColumnsIds.includes(columnId)) {
+      if (!selectedColumnsIds || !selectedColumnsIds.includes(columnId)) {
         draft.selectedColumnsIds[correctedIndex] = columnId;
       }
 

--- a/frontend/scripts/tests/tool-links/reducer.test.js
+++ b/frontend/scripts/tests/tool-links/reducer.test.js
@@ -159,7 +159,7 @@ test(TOOL_LINKS__SET_LINKS, () => {
     { id: 1, path: [12, 34, 56] },
     { id: 2, path: [78, 90, 12] }
   ];
-  const linksMeta = { nodeHeights: [{ id: 1, height: 12345.34 }] };
+  const linksMeta = { nodeHeights: [{ id: 1, height: 12345.34 }], otherNodes: [] };
   const action = setToolLinks(links, linksMeta);
   const newState = reducer(initialState, action);
   expect(newState).toEqual({
@@ -167,7 +167,8 @@ test(TOOL_LINKS__SET_LINKS, () => {
     data: {
       ...initialState.data,
       links,
-      nodeHeights: { 1: linksMeta.nodeHeights[0] }
+      nodeHeights: { 1: linksMeta.nodeHeights[0] },
+      otherNodes: {}
     }
   });
 });


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/171924275

## Description

This fixes two little bugs:

- The columns were not changing some time at first when we didn't have any column selected. See basecamp issue

![image](https://user-images.githubusercontent.com/9701591/79256633-a4937280-7e88-11ea-94d5-c255036e2ec0.png)

- On production, the layer modal is not closing after changing a layer and saving. This cant be tested on local

![image](https://user-images.githubusercontent.com/9701591/79256664-ae1cda80-7e88-11ea-9e4a-a0f836ea6279.png)


## Testing instructions

- Go to Indonesia Palm Oil and change the last column: It should change the first time you select it