### PR TITLE
If any of the blue keys is null (= blue record removed), delete yellow record

### DIFF
--- a/app/services/api/v3/import/restore_yellow_table.rb
+++ b/app/services/api/v3/import/restore_yellow_table.rb
@@ -45,7 +45,7 @@ module Api
             DELETE FROM #{@backup_table}
             USING (#{subquery_for_delete}) updated_identifiers
             WHERE #{@backup_table}.id = updated_identifiers.id
-            AND #{where_conditions.join(' AND ')}
+            AND #{where_conditions.join(' OR ')}
           SQL
           @table_class.connection.execute stmt
         end


### PR DESCRIPTION
## Pivotal Tracker

No link, bug identified when testing something else.

## Description

The issue affects restoring "yellow tables", that is tables managed via the CMS, which link to "blue tables", that are updated during the data update process. One step involves checking if any yellow table records became obsolete because of one or more of the blue table records they depend on got removed; the condition for checking that was incorrect.

## Testing instructions

In my case the process failed when restoring "quant_context_properties" - I had some defined where the quant involved got removed.
