### PR TITLE
Add Trase Finance Link

### DIFF
--- a/frontend/scripts/react-components/nav/top-nav/top-nav.scss
+++ b/frontend/scripts/react-components/nav/top-nav/top-nav.scss
@@ -1,6 +1,6 @@
 @import 'styles/settings';
 
-$desktop-nav-min-width: 960px;
+$desktop-nav-min-width: 1060px;
 $desktop-nav-sides-margin: 20px;
 
 .c-nav {

--- a/frontend/scripts/router/nav-links.js
+++ b/frontend/scripts/router/nav-links.js
@@ -55,6 +55,11 @@ let nav = [
   {
     name: 'About',
     page: 'about'
+  },
+  {
+    name: 'Trase Finance',
+    page: 'https://trase.finance',
+    external: true
   }
 ];
 


### PR DESCRIPTION
## Description
A new Trase finance link has been added to the navbar linking to trase.finance

![image](https://user-images.githubusercontent.com/9701591/83136252-763fbe80-a0e7-11ea-8585-c9a147c3c11a.png)

The nav breakpoint to change to the hamburger button has been changed to 1060px.

Should we review the mobile view and add the logo?

![image](https://user-images.githubusercontent.com/9701591/83136259-7770eb80-a0e7-11ea-8b47-1469c6506650.png)

## Testing instructions

This link is included in the navbar so it should work in the different pages of Trase
