### PR TITLE
Fix for missing chart type due to misspelt identifier

### DIFF
--- a/app/models/api/v3/chart.rb
+++ b/app/models/api/v3/chart.rb
@@ -79,7 +79,7 @@ module Api
         when 'actor_top_countries', 'actor_top_sources'
           :line_chart_with_map
         when
-          'actor_sustainability_table',
+          'actor_sustainability',
           'place_environmental_indicators',
           'place_socioeconomic_indicators',
           'place_agricultural_indicators',


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/173149769

## Description

Chart type comes empty and chart is not drawn, regression from refactoring code in preparation for country profiles

## Testing instructions

Any trader profile, e.g. Cargill Paraguay soy
Please include examples where relevant
