### PR TITLE
Fix/data update clearing context node type properties

### DIFF
--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -21,7 +21,7 @@
 # Foreign Keys
 #
 #  fk_rails_...  (context_node_type_id => context_node_types.id) ON DELETE => cascade
-#  fk_rails_...  (geometry_context_node_type_id => context_node_types.id)
+#  fk_rails_...  (geometry_context_node_type_id => context_node_types.id) ON DELETE => nullify
 #
 
 module Api

--- a/app/services/api/v3/import/restore_yellow_table.rb
+++ b/app/services/api/v3/import/restore_yellow_table.rb
@@ -61,7 +61,7 @@ module Api
               LEFT JOIN #{fk[:table_class].key_backup_table} #{table_alias}
               ON #{table_alias}.id = t.#{fk[:name]}
             SQL
-            delete_where_conditions << "new_#{fk[:name]} IS NULL" # no nullable columns
+            delete_where_conditions << "#{@backup_table}.#{fk[:name]} IS NOT NULL AND new_#{fk[:name]} IS NULL" # no nullable columns
           end
 
           subquery_for_delete = <<~SQL

--- a/db/migrate/20200618100150_fix_geometry_context_node_type_id_fk.rb
+++ b/db/migrate/20200618100150_fix_geometry_context_node_type_id_fk.rb
@@ -1,0 +1,9 @@
+class FixGeometryContextNodeTypeIdFk < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :context_node_type_properties,
+      column: :geometry_context_node_type_id
+    add_foreign_key :context_node_type_properties,
+      :context_node_types,
+      column: :geometry_context_node_type_id, on_delete: :nullify
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -16651,7 +16651,7 @@ ALTER TABLE ONLY public.download_versions
 --
 
 ALTER TABLE ONLY public.context_node_type_properties
-    ADD CONSTRAINT fk_rails_40673dee59 FOREIGN KEY (geometry_context_node_type_id) REFERENCES public.context_node_types(id);
+    ADD CONSTRAINT fk_rails_40673dee59 FOREIGN KEY (geometry_context_node_type_id) REFERENCES public.context_node_types(id) ON DELETE SET NULL;
 
 
 --
@@ -17289,6 +17289,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200430115447'),
 ('20200501152755'),
 ('20200505120049'),
-('20200522153602');
+('20200522153602'),
+('20200618100150');
 
 


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/173448500

## Description

Because of newly added nullable column geo_context_node_type_id all context node types ended up cleared.
