### PR TITLE
Fix/expanded nodes

### DIFF
--- a/frontend/docs/index.mdx
+++ b/frontend/docs/index.mdx
@@ -268,6 +268,12 @@ To enable then, simply execute once: `bin/git/init-hooks`
 
 ```
 
+#### Links and Nodes flow for the tool
+
+Links in the sankey are requested on the getToolLinksData fetch saga (flows endpoint)
+The links are filtered by the selected node which is imported as an expanded node from the nodesPanel (see getExpandedAndExcludedNodes in nodes-panel.selectors)
+This links contain the nodes on their path attribute and we fetch these nodes information afterwards to be able to show it (getToolNodesByLink)
+
 ### Components playground
 
 Online in: http://trase.surge.sh

--- a/frontend/scripts/index.jsx
+++ b/frontend/scripts/index.jsx
@@ -78,7 +78,7 @@ reducerRegistry.register('location', router.reducer);
 const reduxDevTools =
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ &&
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-    maxAge: 10,
+    maxAge: 200,
     stateSanitizer: state => ({
       ...state,
       toolLinks: {

--- a/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.scss
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-panel/dashboard-panel.scss
@@ -5,7 +5,7 @@
   flex-direction: column;
   position: relative;
   width: 100%;
-  height: 100%;
+  max-height: 90vh;
   background-color: $light-gray;
   overflow: hidden;
 

--- a/frontend/scripts/react-components/explore/explore.component.jsx
+++ b/frontend/scripts/react-components/explore/explore.component.jsx
@@ -293,7 +293,7 @@ function Explore(props) {
 }
 
 Explore.propTypes = {
-  items: PropTypes.object,
+  items: PropTypes.array,
   commodities: PropTypes.array,
   countries: PropTypes.array,
   commodity: PropTypes.object,

--- a/frontend/scripts/react-components/explore/featured-cards/featured-cards.component.jsx
+++ b/frontend/scripts/react-components/explore/featured-cards/featured-cards.component.jsx
@@ -126,7 +126,7 @@ FeaturedCards.propTypes = {
   commodityName: PropTypes.string,
   countryName: PropTypes.string,
   step: PropTypes.number,
-  cards: PropTypes.object,
+  cards: PropTypes.array,
   openModal: PropTypes.func.isRequired
 };
 

--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
@@ -491,12 +491,11 @@ const nodesPanelReducer = {
     });
   },
   [NODES_PANEL__SAVE](state) {
-    // Copies the panel selectedIds to draftSelectedIds on panel edit start
     return immer(state, draft => {
       Object.keys(state).forEach(name => {
         const moduleOptions = modules[name];
         if (moduleOptions) {
-          const panelData = draft[name];
+          const panelData = state[name];
           if (moduleOptions.hasMultipleSelection) {
             draft[name].selectedNodesIds = panelData.draftSelectedNodesIds;
           } else {
@@ -504,10 +503,8 @@ const nodesPanelReducer = {
           }
 
           if (moduleOptions.hasTabs) {
-            draft[name].savedActiveTab = state[name].activeTab;
-            draft[name].savedTabs = state[name].tabs;
-            console.log('s', name, state[name].activeTab, state);
-            // selectColumn(columnIndex, columnId, columnRole);
+            draft[name].savedActiveTab = panelData.activeTab;
+            draft[name].savedTabs = panelData.tabs;
           }
         }
       });

--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
@@ -141,7 +141,7 @@ const nodesPanelReducer = {
         // this means we navigated internally with hopes of expanding some nodes once we had the columns
         state.__temporaryExpandedNodes.forEach(node => {
           const { id, nodeType } = node;
-          // with the columns we fing the role
+          // with the columns we find the role
           const { role } = columns.find(col => col.name === nodeType);
           const name = pluralize(role);
           const moduleOptions = modules[name];
@@ -158,7 +158,6 @@ const nodesPanelReducer = {
             draft[name].data.nodes[id] = node;
           }
         });
-
         // finally we clear the temporary state.
         draft.__temporaryExpandedNodes = [];
       }
@@ -507,6 +506,8 @@ const nodesPanelReducer = {
           if (moduleOptions.hasTabs) {
             draft[name].savedActiveTab = state[name].activeTab;
             draft[name].savedTabs = state[name].tabs;
+            console.log('s', name, state[name].activeTab, state);
+            // selectColumn(columnIndex, columnId, columnRole);
           }
         }
       });

--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
@@ -441,7 +441,13 @@ const nodesPanelReducer = {
       return immer(state, draft => {
         draft[name].draftSelectedNodesIds = [];
         draft[name].excludingMode = mode;
+
+        if (moduleOptions.hasTabs) {
+          draft[name].activeTab = state[name].activeTab;
+        }
+
         const panelIndex = DASHBOARD_STEPS[name];
+
         Object.entries(DASHBOARD_STEPS).forEach(([currentPanel, step]) => {
           const currentModuleOptions = modules[name];
           if (panelIndex < step) {

--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.reducer.js
@@ -495,7 +495,7 @@ const nodesPanelReducer = {
       Object.keys(state).forEach(name => {
         const moduleOptions = modules[name];
         if (moduleOptions) {
-          const panelData = state[name];
+          const panelData = draft[name];
           if (moduleOptions.hasMultipleSelection) {
             draft[name].selectedNodesIds = panelData.draftSelectedNodesIds;
           } else {
@@ -556,11 +556,15 @@ const nodesPanelReducer = {
     });
   },
   [TOOL_LINKS__SELECT_COLUMN](state, action) {
-    const { columnRole } = action.payload;
+    const { columnRole, retainNodes } = action.payload;
     return immer(state, draft => {
       const name = pluralize(columnRole);
       // groups with multiple columns always allow for multiple selection
-      draft[name].selectedNodesIds = nodesPanelInitialState[name].selectedNodesIds;
+
+      // We don't want to reset the selected nodes if we saved from the panel and updated the tab columns
+      if (!retainNodes) {
+        draft[name].selectedNodesIds = nodesPanelInitialState[name].selectedNodesIds;
+      }
       draft[name].excludingMode = nodesPanelInitialState[name].excludingMode;
     });
   },

--- a/frontend/scripts/react-components/shared/tool-bar/tool-bar.component.jsx
+++ b/frontend/scripts/react-components/shared/tool-bar/tool-bar.component.jsx
@@ -39,6 +39,7 @@ function ToolBar(props) {
   function getListItem(item, ref) {
     return (
       <li
+        key={item.id}
         ref={ref}
         className={cx('slot-item', {
           '-no-hover': item.noHover,
@@ -60,6 +61,7 @@ function ToolBar(props) {
   function renderItemWithTooltip(item) {
     return (
       <Tippy
+        key={item.id}
         content={<ToolbarTooltip>{item.tooltip}</ToolbarTooltip>}
         placement="bottom-start"
         arrow={false}

--- a/frontend/scripts/react-components/tool-links/tool-links.actions.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.actions.js
@@ -97,13 +97,14 @@ export function expandSankey() {
   };
 }
 
-export function selectColumn(columnIndex, columnId, columnRole) {
+export function selectColumn(columnIndex, columnId, columnRole, retainNodes) {
   return {
     type: TOOL_LINKS__SELECT_COLUMN,
     payload: {
       columnId,
       columnIndex,
-      columnRole
+      columnRole,
+      retainNodes
     }
   };
 }

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -166,7 +166,8 @@ const toolLinksReducer = {
       linksMeta.nodeHeights.forEach(nodeHeight => {
         draft.data.nodeHeights[nodeHeight.id] = nodeHeight;
       });
-      linksMeta.otherNodes.forEach(otherNode => {
+      // TODO: otherNodes could have a null item. Remove filter Boolean when this is fixed
+      linksMeta.otherNodes.filter(Boolean).forEach(otherNode => {
         draft.data.otherNodes[otherNode.id] = otherNode;
       });
       draft.data.links = links;

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -92,18 +92,6 @@ const toolLinksReducer = {
       draft.chartsLoading = loading;
     });
   },
-  [NODES_PANEL__SAVE](state) {
-    return immer(state, draft => {
-      Object.assign(draft, {
-        selectedColumnsIds: toolLinksInitialState.selectedColumnsIds,
-        selectedBiomeFilterName: toolLinksInitialState.selectedBiomeFilterName,
-        extraColumn: toolLinksInitialState.extraColumn,
-        extraColumnNodeId: toolLinksInitialState.extraColumnNodeId,
-        highlightedNodeId: toolLinksInitialState.highlightedNodeId,
-        selectedNodesIds: toolLinksInitialState.selectedNodesIds
-      });
-    });
-  },
   [TOOL_LINKS_RESET_SANKEY](state) {
     return immer(state, draft => {
       Object.assign(draft, {
@@ -136,7 +124,19 @@ const toolLinksReducer = {
   },
   [NODES_PANEL__SAVE](state, action) {
     if (action.payload) {
-      return onContextChange(state);
+      return immer(state, draft => {
+        // Don't delete data and selectedNodesIds as we need the columns and selection for tab selected columns
+        Object.assign(draft, {
+          selectedRecolorBy: toolLinksInitialState.selectedRecolorBy,
+          selectedResizeBy: toolLinksInitialState.selectedResizeBy,
+          selectedBiomeFilterName: toolLinksInitialState.selectedBiomeFilterName,
+          extraColumn: toolLinksInitialState.extraColumn,
+          extraColumnNodeId: toolLinksInitialState.extraColumnNodeId,
+          detailedView: toolLinksInitialState.detailedView,
+          highlightedNodeId: toolLinksInitialState.highlightedNodeId,
+          selectedColumnsIds: toolLinksInitialState.selectedColumnsIds
+        });
+      });
     }
     return state;
   },
@@ -218,11 +218,11 @@ const toolLinksReducer = {
   [TOOL_LINKS__SELECT_COLUMN](state, action) {
     return immer(state, draft => {
       const { extraColumn, data, extraColumnNodeId, selectedNodesIds, selectedColumnsIds } = state;
-      const { columnId, columnIndex } = action.payload;
+      const { columnId, columnIndex, retainNodes } = action.payload;
+
       if (!selectedColumnsIds) {
         draft.selectedColumnsIds = [];
       }
-
       const column = data.columns[columnId];
       const isInColumn = nodeId => {
         const node = data.nodes[nodeId];
@@ -259,21 +259,17 @@ const toolLinksReducer = {
         // NODES CHANGES
 
         draft.selectedNodesIds = selectedNodesIds.filter(id => extraColumnNodeId !== id);
-        // draft.expandedNodesIds.filter(id => state.extraColumnNodeId !== id);
         draft.extraColumn = toolLinksInitialState.extraColumn;
         draft.extraColumnNodeId = toolLinksInitialState.extraColumnNodeId;
       }
-
-      draft.selectedNodesIds = selectedNodesIds.filter(isInColumn);
-      // draft.expandedNodesIds = state.expandedNodesIds.filter(isInColumn);
+      if (!retainNodes) {
+        draft.selectedNodesIds = selectedNodesIds.filter(isInColumn);
+      }
     });
   },
   [TOOL_LINKS__CHANGE_EXTRA_COLUMN](state, action) {
     return immer(state, draft => {
-      const { columnId, parentColumnId, nodeId } = action.payload;
-      const extraColumnNode =
-        state.data.nodes && state.data.nodes[state.extraColumnNodeId || nodeId];
-
+      const { columnId, parentColumnId } = action.payload;
       const wasInExtraColumn = id => {
         const node = draft.data.nodes[id];
         const column = draft.data.columns[node.columnId];
@@ -282,11 +278,6 @@ const toolLinksReducer = {
 
       if (columnId) {
         // Open extra column
-        if (extraColumnNode) {
-          // draft.expandedNodesIds = state.expandedNodesIds
-          //   .filter(expandedNodeId => draft.data.nodes[expandedNodeId].columnId !== parentColumnId)
-          //   .concat(extraColumnNode?.id);
-        }
         draft.extraColumnNodeId = action.payload.nodeId;
         draft.extraColumn = { id: columnId, parentId: parentColumnId };
       } else {

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -166,8 +166,7 @@ const toolLinksReducer = {
       linksMeta.nodeHeights.forEach(nodeHeight => {
         draft.data.nodeHeights[nodeHeight.id] = nodeHeight;
       });
-      // TODO: otherNodes could have a null item. Remove filter Boolean when this is fixed
-      linksMeta.otherNodes.filter(Boolean).forEach(otherNode => {
+      linksMeta.otherNodes.forEach(otherNode => {
         draft.data.otherNodes[otherNode.id] = otherNode;
       });
       draft.data.links = links;

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -125,7 +125,7 @@ const toolLinksReducer = {
   [NODES_PANEL__SAVE](state, action) {
     if (action.payload) {
       return immer(state, draft => {
-        // Don't delete data and selectedNodesIds as we need the columns and selection for tab selected columns
+        // Don't reset columns in data as we need the columns and selection for tab selected columns
         Object.assign(draft, {
           selectedRecolorBy: toolLinksInitialState.selectedRecolorBy,
           selectedResizeBy: toolLinksInitialState.selectedResizeBy,
@@ -134,7 +134,8 @@ const toolLinksReducer = {
           extraColumnNodeId: toolLinksInitialState.extraColumnNodeId,
           detailedView: toolLinksInitialState.detailedView,
           highlightedNodeId: toolLinksInitialState.highlightedNodeId,
-          selectedColumnsIds: toolLinksInitialState.selectedColumnsIds
+          selectedColumnsIds: toolLinksInitialState.selectedColumnsIds,
+          data: { ...toolLinksInitialState.data, columns: state.data.columns }
         });
       });
     }

--- a/frontend/scripts/react-components/tool-links/tool-links.saga.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.saga.js
@@ -21,7 +21,8 @@ import {
   TOOL_LINKS_RESET_SANKEY,
   setToolFlowsLoading,
   selectView,
-  setToolChartsLoading
+  setToolChartsLoading,
+  selectColumn
 } from './tool-links.actions';
 import {
   getToolColumnsData,
@@ -212,6 +213,26 @@ function* fetchMissingLockedNodes() {
   yield takeLatest([TOOL_LINKS__SET_NODES], performFetch);
 }
 
+function* selectSavedTabColumns() {
+  function* performSelect() {
+    const state = yield select();
+    const { toolLinks, nodesPanel } = state;
+    const { sources } = nodesPanel;
+    // TODO: const { exporters, importers, destinations } = nodesPanel;
+    const { savedTabs, savedActiveTab } = sources;
+    if (savedActiveTab) {
+      const tab = savedTabs.find(t => t.id === savedActiveTab);
+      const tabName = tab?.name;
+      const column = toolLinks.data.columns && Object.values(toolLinks.data.columns).find(c => c.name === tabName);
+      if (column) {
+        yield put(selectColumn(column.group, column.id, column.role, true));
+      }
+    }
+  }
+
+  yield takeLatest([nodesPanelActions.NODES_PANEL__SAVE], performSelect);
+}
+
 export default function* toolLinksSaga() {
   const sagas = [
     fetchLinks,
@@ -220,7 +241,8 @@ export default function* toolLinksSaga() {
     fetchMissingLockedNodes,
     fetchToolGeoColumnNodes,
     checkForceOverviewOnCollapse,
-    checkForceOverviewOnExpand
+    checkForceOverviewOnExpand,
+    selectSavedTabColumns
   ];
   yield all(sagas.map(saga => fork(saga)));
 }

--- a/frontend/scripts/react-components/tool/sankey/sankey.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.js
@@ -18,6 +18,11 @@ import Sankey from 'react-components/tool/sankey/sankey.component';
 import { toolLinksActions } from 'react-components/tool-links/tool-links.register';
 import { getSelectedMapDimensionsData } from 'react-components/tool-layers/tool-layers.selectors';
 
+// Links and Nodes flow
+// Links in the sankey are requested on the getToolLinksData fetch saga (flows endpoint)
+// The links are filtered by the selected node which is imported as an expanded node from the nodesPanel (see getExpandedAndExcludedNodes in nodes-panel.selectors)
+// This links contain the nodes on their path attribute and we fetch these nodes information afterwards to be able to show it (getToolNodesByLink)
+
 const mapStateToProps = state => ({
   links: getSankeyLinks(state),
   toolColumns: getToolColumns(state),


### PR DESCRIPTION
## Description

This PR fixes a problem with the selection on the panel. Previously when we selected an item that was inside a tab e.g. State, and we pressed save the selection was not shown because we didn't change the corresponding column and we cant show nodes that are in non selected columns.

Now we change the column to the one corresponding to the tab and the node is showing on the Sankey.

Extra: Now when we select a 'Select all' option in one of the tabs. The column will be selected on the Sankey showing the correct nodes

- Known problems:

There still is a problem when we select some municipalities and they are not shown. But this is because the fetch of sources for example is returning more municipalities than it should. For example in this call:

https://staging.trase.earth/api/v3/dashboards/sources?page=1&end_year=2017&start_year=2017&node_types_ids=3&countries_ids=27&order_by=volume

Abaete shouldn't show but it is there. This is causing the flows request to not be filtered because the selectedNode is not found on the flows and we show all the data.

## Testing instructions

With a context selected go to the panel and try selecting a state. 'State' is not the default column and it should change to it after saving. This should happen as well for Ports, ...

![image](https://user-images.githubusercontent.com/9701591/85923736-e6c82f80-b88d-11ea-9d6f-44ad58952a73.png)

![image](https://user-images.githubusercontent.com/9701591/85923748-fd6e8680-b88d-11ea-9997-cfad3a5e191a.png)
