### PR TITLE
Fix context change crash

### DIFF
--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.saga.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.saga.js
@@ -223,16 +223,20 @@ function* syncSearchedNodes() {
 }
 
 function* broadcastContextChange() {
-  const previousContext = { countryId: null, commodityId: null };
+  let previousContext = { countryId: null, commodityId: null };
 
   function* onPanelSave() {
-    const { contexts } = yield select(state => state.app);
+    const { contexts, selectedContextId } = yield select(state => state.app);
     const { countries, commodities } = yield select(state => state.nodesPanel);
     const context = contexts.find(
       ctx =>
         ctx.countryId === countries.draftSelectedNodeId &&
         ctx.commodityId === commodities.draftSelectedNodeId
     );
+    const stateContext = contexts.find(ctx => ctx.id === selectedContextId);
+    if (stateContext) {
+      previousContext = stateContext;
+    }
     if (
       countries.draftSelectedNodeId !== previousContext.countryId ||
       commodities.draftSelectedNodeId !== previousContext.commodityId

--- a/frontend/scripts/react-components/nodes-panel/nodes-panel.saga.js
+++ b/frontend/scripts/react-components/nodes-panel/nodes-panel.saga.js
@@ -223,20 +223,17 @@ function* syncSearchedNodes() {
 }
 
 function* broadcastContextChange() {
-  let previousContext = { countryId: null, commodityId: null };
+  const previousContext = { countryId: null, commodityId: null };
 
   function* onPanelSave() {
-    const { contexts, selectedContextId } = yield select(state => state.app);
+    const { contexts } = yield select(state => state.app);
     const { countries, commodities } = yield select(state => state.nodesPanel);
     const context = contexts.find(
       ctx =>
         ctx.countryId === countries.draftSelectedNodeId &&
         ctx.commodityId === commodities.draftSelectedNodeId
     );
-    const stateContext = contexts.find(ctx => ctx.id === selectedContextId);
-    if (stateContext) {
-      previousContext = stateContext;
-    }
+
     if (
       countries.draftSelectedNodeId !== previousContext.countryId ||
       commodities.draftSelectedNodeId !== previousContext.commodityId

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -123,21 +123,9 @@ const toolLinksReducer = {
     });
   },
   [NODES_PANEL__SAVE](state, action) {
+    // payload only on new context
     if (action.payload) {
-      return immer(state, draft => {
-        // Don't reset columns in data as we need the columns and selection for tab selected columns
-        Object.assign(draft, {
-          selectedRecolorBy: toolLinksInitialState.selectedRecolorBy,
-          selectedResizeBy: toolLinksInitialState.selectedResizeBy,
-          selectedBiomeFilterName: toolLinksInitialState.selectedBiomeFilterName,
-          extraColumn: toolLinksInitialState.extraColumn,
-          extraColumnNodeId: toolLinksInitialState.extraColumnNodeId,
-          detailedView: toolLinksInitialState.detailedView,
-          highlightedNodeId: toolLinksInitialState.highlightedNodeId,
-          selectedColumnsIds: toolLinksInitialState.selectedColumnsIds,
-          data: { ...toolLinksInitialState.data, columns: state.data.columns }
-        });
-      });
+      return onContextChange(state);
     }
     return state;
   },


### PR DESCRIPTION
It seems that changing a context was breaking the map.

We were deleting the columns to be able to select the column of the node selected on the panel and this was breaking the context change.

We can reset everything on context change on the NODES_PANEL reducer on tool links. The problem was that the context change or not was not properly known on nodes-panel.saga

Now the context can be changed and the change of column still works

## Testing instructions

Go to the tool and select a different context on the panel (country + commodity) and save - It shouldn't break
Also, select a node from a different column on source - It should be selected when we save
Remember that some of the nodes don't work right now. E.g Abaete doesn't work but Abadia de Goias does