### PR TITLE
Fix profile panel scroll

### DIFF
--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.component.jsx
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.component.jsx
@@ -4,6 +4,7 @@ import SimpleModal from 'react-components/shared/simple-modal/simple-modal.compo
 import { PROFILE_STEPS } from 'constants';
 import StepsTracker from 'react-components/shared/steps-tracker';
 import ProfilePanelFooter from 'react-components/shared/profile-selector/profile-panel-footer';
+import cx from 'classnames';
 
 import 'react-components/shared/profile-selector/profile-selector.scss';
 
@@ -19,7 +20,7 @@ function ProfilesSelectorModal(props) {
     <SimpleModal isOpen={isOpen} onRequestClose={onClose}>
       {isOpen && (
         <div className="c-profile-selector">
-          <div className="profile-content">
+          <div className={cx('profile-content', { '-with-sentence': dynamicSentenceParts.length })}>
             <StepsTracker
               steps={['Type', 'Profile', 'Commodity'].map(label => ({ label }))}
               activeStep={activeStep || 0}

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.scss
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.scss
@@ -1,5 +1,7 @@
 @import 'styles/settings';
 
+$profile-footer-max-height: 165px;
+
 .c-profile-selector {
   margin-top: 20px;
   position: relative;
@@ -16,8 +18,13 @@
   background-color: $light-gray;
 
   .profile-content {
+    height: calc(90vh - #{$profile-footer-max-height});
     flex: 1;
     overflow: auto;
     margin: 20px 0;
+
+    &.-with-sentence {
+      height: calc(90vh - #{$profile-footer-max-height + 35});
+    }
   }
 }


### PR DESCRIPTION
![scroll](https://user-images.githubusercontent.com/9701591/88311316-075e9a80-cd11-11ea-9725-ab3d77990ad9.gif)


## Description

This fixes the scroll on the profiles panel. Before, the save button wasn't clickable sometimes. Now we have a scroll like in the tool panel.