### PR TITLE
Removed agricultural exports / imports value (incorrectly calculated)

### DIFF
--- a/app/services/api/v3/country_profiles/basic_attributes.rb
+++ b/app/services/api/v3/country_profiles/basic_attributes.rb
@@ -50,7 +50,7 @@ module Api
         HEADER_ATTRIBUTES = [
           'wb.population.value',
           'wb.gdp.value',
-          'com_trade.value.value',
+          # TODO: value of agricultural exports / imports
           'wb.land_area.value',
           'wb.agricultural_land_area.value',
           'wb.forested_land_area.value'


### PR DESCRIPTION
## Pivotal Tracker

This value will come from FAO and will be supplied through node quants, at present nothing to show there.

https://basecamp.com/1756858/projects/12498794/todos/410599687#comment_759372992

