### PR TITLE
fix/mini-sankey-others-at-bottom

### DIFF
--- a/frontend/scripts/react-components/profile/profile-widgets/map-flows-widget.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-widgets/map-flows-widget.component.jsx
@@ -25,7 +25,6 @@ class MapFlowsWidget extends React.PureComponent {
   render() {
     const { nodeId, profileType, title, year, commodityName } = this.props;
     const params = { node_id: nodeId, year };
-    // context_id: contextId
 
     return (
       <Widget


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/173702389

## Description

On the mini sankey "country profiles" we should always show "others" at the bottom, no matter what percentage it has. 

## Testing instructions

go to any country profile, make sure others end up at the bottom, also make sure that the other nodes are still sorted high>low. 

