### PR TITLE
Parts should retain case

### DIFF
--- a/frontend/scripts/react-components/shared/tags-group/tag.component.jsx
+++ b/frontend/scripts/react-components/shared/tags-group/tag.component.jsx
@@ -47,9 +47,9 @@ function Tag(props) {
 
   const renderName = () => {
     if (part.value.length > 1) {
-      return part.name ? translateText(`${part.value.length} ${part.name || part.panel}`).toLowerCase() : null;
+      return part.name ? translateText(`${part.value.length} ${part.name || part.panel}`) : null;
     }
-    return part.value[0].name ? translateText(part.value[0].name).toLowerCase() : null;
+    return part.value[0].name ? translateText(part.value[0].name) : null;
   };
 
   return (


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/174356544

## Description

Dynamic sentence (tag component at the end) was applying lowercase except for some explicit transforms. We shouldn't do this. In this case, "Mt" was being transformed into "mt".

![image](https://user-images.githubusercontent.com/9701591/90419098-58ff0880-e0b6-11ea-91f6-d6d4ba0e18e9.png)

## Testing instructions

http://localhost:8081/flows/data-view?toolLayout=1&countries=107&commodities=6&selectedColumnsIds=0_24-1_6-2_7-3_8