### PR TITLE
Return < 1 for less than 1 ton

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dynamic-sentence-widget/dynamic-sentence-widget.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dynamic-sentence-widget/dynamic-sentence-widget.selectors.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 import { getDynamicSentence } from 'react-components/dashboard-element/dashboard-element.selectors';
-import { format } from 'd3-format';
-import { DEFAULT_DASHBOARD_UNIT_FORMAT } from 'constants';
+import formatDynamicSentenceValue from 'utils/formatDynamicSentenceValue';
 
 const getData = (state, props) => props.data || null;
 const getConfig = (state, props) => props.config || null;
@@ -25,15 +24,12 @@ export const makeAddIndicatorsPartToSentence = () =>
         value: [{ name: `${yAxisLabel.text}`.toLowerCase() }],
         transform: 'capitalize'
       };
-
       const indicatorValuePart = {
         id: 'indicator-value',
         prefix: 'was',
         value: [
           {
-            name: data[0].y0
-              ? `${format(DEFAULT_DASHBOARD_UNIT_FORMAT)(data[0].y0)} ${yAxisLabel.suffix}`
-              : 'N/A'
+            name: formatDynamicSentenceValue(data[0].y0, yAxisLabel.suffix)
           }
         ]
       };

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/node-indicator-sentence-widget/node-indicator-sentence-widget.selectors.js
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/node-indicator-sentence-widget/node-indicator-sentence-widget.selectors.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
-import { format } from 'd3-format';
-import { DEFAULT_DASHBOARD_UNIT_FORMAT } from 'constants';
+import formatDynamicSentenceValue from 'utils/formatDynamicSentenceValue';
 
 const getData = (state, props) => props.data || null;
 const getMeta = (state, props) => props.meta || null;
@@ -39,9 +38,7 @@ export const makeGetNodeIndicatorSentenceParts = () =>
         prefix: temporal ? 'was' : 'equals',
         value: [
           {
-            name: data[0].y0
-              ? `${format(DEFAULT_DASHBOARD_UNIT_FORMAT)(data[0].y0)} ${indicatorValueSuffix}`
-              : 'N/A'
+            name: formatDynamicSentenceValue(data[0].y0, indicatorValueSuffix)
           }
         ]
       };

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { DEFAULT_DASHBOARD_UNIT_FORMAT } from 'constants';
 import Link from 'redux-first-router-link';
 import { format } from 'd3-format';
 import capitalize from 'lodash/capitalize';
@@ -8,6 +7,7 @@ import Paginate from 'react-components/shared/paginate';
 import Text from 'react-components/shared/text';
 import Heading from 'react-components/shared/heading';
 import Ellipsis from 'react-components/shared/ellipsis';
+import formatDynamicSentenceValue from 'utils/formatDynamicSentenceValue';
 
 import 'react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget-styles.scss';
 
@@ -66,7 +66,6 @@ function RankingWidget(props) {
   // property is snake_case
   // eslint-disable-next-line
   const totalValue = meta.aggregates?.total_value;
-  const formatTotal = format(DEFAULT_DASHBOARD_UNIT_FORMAT);
 
   const textColor = {
     dark: 'white',
@@ -97,7 +96,7 @@ function RankingWidget(props) {
                 </div>
                 <Text className="item-value" color={textColor} variant="mono" size="md">
                   {formatValue(item.x0)} {config.xAxisLabel && config.xAxisLabel.suffix} /{' '}
-                  {formatTotal(totalValue.x0)} {config.xAxisLabel && config.xAxisLabel.suffix}
+                  {formatDynamicSentenceValue(totalValue.x0, config.xAxisLabel && config.xAxisLabel.suffix)}
                 </Text>
               </div>
             </li>

--- a/frontend/scripts/utils/formatDynamicSentenceValue.js
+++ b/frontend/scripts/utils/formatDynamicSentenceValue.js
@@ -1,0 +1,10 @@
+import { format } from 'd3-format';
+import { DEFAULT_DASHBOARD_UNIT_FORMAT } from 'constants';
+
+export default (data, suffix) => {
+  if(!data) return 'N/A';
+  if(suffix === 't' && data < 1) {
+    return '<1 t';
+  }
+  return `${format(DEFAULT_DASHBOARD_UNIT_FORMAT)(data)}${suffix ? ` ${suffix}` : ''}`;
+}


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/9701591/90512415-696abe00-e15e-11ea-89cc-4b0808c49fa9.png)

The problem was not solved with the last PR as there were actualli some milli tons apart from the capitalisation. Now they are displayed as "< 1 t" for tons unit
 
## Testing instructions

http://localhost:8081/flows/data-view?selectedContextId=43&toolLayout=1&countries=50&commodities=87&exporters=13566&selectedColumnsIds=0_13-1_6-2_7-3_8
