### PR TITLE
Database update fixes

### DIFF
--- a/app/models/api/v3/context_node_type_property.rb
+++ b/app/models/api/v3/context_node_type_property.rb
@@ -65,7 +65,7 @@ module Api
       def self.blue_foreign_keys
         [
           {name: :context_node_type_id, table_class: Api::V3::ContextNodeType},
-          {name: :geometry_context_node_type_id, table_class: Api::V3::ContextNodeType}
+          {name: :geometry_context_node_type_id, table_class: Api::V3::ContextNodeType, nullable: true}
         ]
       end
 

--- a/app/services/api/v3/import/restore_yellow_table.rb
+++ b/app/services/api/v3/import/restore_yellow_table.rb
@@ -101,8 +101,14 @@ module Api
           @table_class.blue_foreign_keys.each.with_index do |fk, idx|
             table_alias = "t_#{idx}"
             select_list << "#{table_alias}.new_id AS new_#{fk[:name]}"
+            join_type =
+              if fk[:nullable]
+                'LEFT JOIN'
+              else
+                'JOIN'
+              end
             joins << <<~SQL
-              JOIN #{fk[:table_class].key_backup_table} #{table_alias}
+              #{join_type} #{fk[:table_class].key_backup_table} #{table_alias}
               ON #{table_alias}.id = t.#{fk[:name]}
             SQL
             update_set_expressions << "#{fk[:name]} = updated_identifiers.new_#{fk[:name]}"


### PR DESCRIPTION
Previously context node type ids could be restored incorrectly because the nullable geometry id was not handled properly

Also, schema renamed from tool_tables to trase_earth

