### PR TITLE
add multi axis support for line chart

### DIFF
--- a/frontend/scripts/react-components/profile/profile-widgets/deforestation-widget.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-widgets/deforestation-widget.component.jsx
@@ -61,7 +61,7 @@ class DeforestationWidget extends React.PureComponent {
             );
           }
 
-          const { lines, unit, includedYears } = data[mainQuery];
+          const { lines, unit, includedYears, multiUnit = false } = data[mainQuery];
 
           if (!lines) {
             return null;
@@ -91,6 +91,7 @@ class DeforestationWidget extends React.PureComponent {
                         testId={testId}
                         lines={lines}
                         xValues={includedYears}
+                        multiUnit={multiUnit}
                         unit={unit}
                         margin={{ top: 0, right: 20, bottom: 30, left: 60 }}
                         settingsHeight={425}

--- a/frontend/scripts/react-components/profile/profile-widgets/line-widget.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-widgets/line-widget.component.jsx
@@ -48,7 +48,7 @@ class LineComponent extends React.PureComponent {
             return this.renderSpinner();
           }
 
-          const { lines, unit, includedYears } = data[chartUrl];
+          const { lines, unit, includedYears, multi_unit: multiUnit = false } = data[chartUrl];
 
           if (!lines) {
             return null;
@@ -68,6 +68,7 @@ class LineComponent extends React.PureComponent {
                   <div className="table-container page-break-inside-avoid">
                     <LineChart
                       testId={testId}
+                      multiUnit={multiUnit}
                       lines={lines}
                       xValues={includedYears}
                       unit={unit}


### PR DESCRIPTION
## Pivotal Tracker

none 

## Description

<img width="1367" alt="Screenshot 2020-08-25 at 11 54 32" src="https://user-images.githubusercontent.com/971129/91160717-0c28bc80-e6ca-11ea-9fe4-3547bc07a590.png">

This pr adds support for multiple axises, new property added to api multi_unit will determine if type=line should be represented as a secondary yaxis to the right. This is currently effecting the DEFORESTATION TRAJECTORY widget.

## Testing instructions

got to: http://localhost:8081/profile-country?nodeId=26&contextId=58 and make sure y2Axis appears

go to any other dashboard using the line chart and make sure any previous behaviour is still the same when `multi_unit` is set to false.