### PR TITLE
Schema rename

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,7 +22,7 @@ TRASE_REMOTE_USER=main_ro # this user defined in remote database with read-only 
 TRASE_REMOTE_PASSWORD=
 TRASE_REMOTE_SERVER=trase_server
 TRASE_LOCAL_FDW_SCHEMA=main # this schema in local database where remote tables are mapped
-TRASE_LOCAL_MIRROR_SCHEMA=tool_tables # this schema in local database where remote tables are restored
+TRASE_LOCAL_MIRROR_SCHEMA=trase_earth # this schema in local database where remote tables are restored
 TRASE_LOCAL_SCHEMA=public # this schema in local database where target tables are
 
 API_HOST=http://localhost:3000 # base url of API

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - ./cc-test-reporter before-build
 
       script:
-        - TRASE_LOCAL_MIRROR_SCHEMA=tool_tables TRASE_LOCAL_SCHEMA=public bundle exec rspec spec --fail-fast
+        - TRASE_LOCAL_MIRROR_SCHEMA=trase_earth TRASE_LOCAL_SCHEMA=public bundle exec rspec spec --fail-fast
 
       after_script:
         - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/lib/tasks/db_remote_import.rake
+++ b/lib/tasks/db_remote_import.rake
@@ -12,7 +12,7 @@ namespace :db do
     desc 'Restores data from S3 and imports from local schema'
     task import: :environment do
       unless ENV['SCHEMA_VERSION'].present?
-        abort('Please provide database version as env var e.g. SCHEMA_VERSION=MAIN/tool_tables_20181128.dump.gz')
+        abort('Please provide database version as env var e.g. SCHEMA_VERSION=MAIN/trase_earth_20181128.dump.gz')
       end
       with_update_lock do |database_update|
         Api::V3::Import::MirrorImport.new.call(database_update, ENV['SCHEMA_VERSION'])


### PR DESCRIPTION
## Description

Renames `tool_tables` to `trase_earth` to reflect the recent name change on Trase's systems.

@agnessa I presume we will need to update the environment variables on the various servers too? All future dumps we make will be using `trase_earth`, so we are good to do this 👍 
