### PR TITLE
Handle error response from WB API

### DIFF
--- a/app/services/api/v3/countries_com_trade_indicators/world_request.rb
+++ b/app/services/api/v3/countries_com_trade_indicators/world_request.rb
@@ -17,9 +17,8 @@ module Api
           response = Net::HTTP.get_response(@uri)
           if response.code != '200'
             error = ComTradeError.new(response)
-            Rails.logger.error error
-            Appsignal.send_error(error)
-            return
+            # this is to force a retry on the job
+            raise error
           end
           body = response.body
           data = JSON.parse(body)

--- a/app/services/api/v3/countries_wb_indicators/api_service.rb
+++ b/app/services/api/v3/countries_wb_indicators/api_service.rb
@@ -11,7 +11,12 @@ module Api
             request_uri(wb_name, iso3, [start_year,end_year].compact.join(':').presence)
           )
 
-          return [] if response.code != '200'
+          if response.code != '200'
+            error = WbRequest::WBError.new(response)
+            Rails.logger.error error
+            Appsignal.send_error(error)
+            return nil
+          end
 
           formatted_indicators(wb_name, JSON.parse(response.body))
         end

--- a/app/services/api/v3/countries_wb_indicators/api_service.rb
+++ b/app/services/api/v3/countries_wb_indicators/api_service.rb
@@ -13,9 +13,8 @@ module Api
 
           if response.code != '200'
             error = WbRequest::WBError.new(response)
-            Rails.logger.error error
-            Appsignal.send_error(error)
-            return nil
+            # this is to force a retry on the job
+            raise error
           end
 
           formatted_indicators(wb_name, JSON.parse(response.body))

--- a/app/services/api/v3/countries_wb_indicators/wb_request.rb
+++ b/app/services/api/v3/countries_wb_indicators/wb_request.rb
@@ -14,6 +14,8 @@ module Api
           indicators_response = api_indicators(
             @indicator_name, @start_year, @end_year
           )
+          return unless indicators_response
+
           last_updated = indicators_response[:last_updated]
           return unless need_refreshing?(@indicator_name, last_updated)
 


### PR DESCRIPTION
## Pivotal Tracker

https://appsignal.com/vizzuality/sites/5a7350b4b504f531d85ecf75/exceptions/incidents/420?timestamp=2020-09-08T00%3A00%3A11Z

## Description

Context: the fix applies to a process that synchronises data in the Trase DB with 2 external APIs, the World Bank API and the Com Trade API. The processing happens in sidekiq jobs, and sometimes we get connectivity errors that result in data not being fully synchronised.

WB importer: was not handling http error codes from the API correctly, i.e. it was returning an empty array which ended up as a conversion error in the parsing logic that follows. Instead of that, we're now raising an exception, which has the additional effect of making sidekiq schedule a retry (sometimes there are connection issues with the WB AP). Removed the logic that reported the error to AppSignal, because that happens automatically when you raise an exception.
ComTrade API importer: same fix for raising the exception to schedule a retry.


