### PR TITLE
add nat subnat highlight

### DIFF
--- a/frontend/scripts/react-components/explore/explore.component.jsx
+++ b/frontend/scripts/react-components/explore/explore.component.jsx
@@ -72,13 +72,31 @@ function Explore(props) {
   const clearStep =
     step === EXPLORE_STEPS.selected ? () => setCountry(null) : () => setCommodity(null);
 
+  const renderHighlighted = txt => (
+    <Text as="span" size="sm" weight="bold">
+       {translateText(txt)}
+    </Text>
+  );
+
   const renderTitle = isMobile => {
     const titleParts = ['commodity', 'source country', 'supply chain to explore'];
     return (
       <div className="step-title-container">
-        <Heading size="lg" align="center" data-test="step-title" className="notranslate">
-          {translateText(`${step}. Choose a ${titleParts[step - 1]}`)}
-        </Heading>
+        {step === 1 && (
+          <div className="row column">
+            <Heading size="lg" align="center" data-test="step-title" className="notranslate">
+              {translateText(`${step}. Choose a ${titleParts[step - 1]}`)}
+            </Heading>
+            <Heading size="sm" align="center">
+              {translateText('Options marked in')} {renderHighlighted('gray')} {translateText('provide')} {renderHighlighted('national-scale')} {translateText('data only')}
+            </Heading>
+          </div>
+        )}
+        {step !== 1 && (
+          <Heading size="lg" align="center" data-test="step-title" className="notranslate">
+            {translateText(`${step}. Choose a ${titleParts[step - 1]}`)}
+          </Heading>
+        )}
         <span>
           {step > EXPLORE_STEPS.selectCommodity && !isMobile && (
             <button
@@ -172,12 +190,12 @@ function Explore(props) {
                       <div className={cx('explore-grid', { [`rows${rowsNumber}`]: rowsNumber })}>
                         {step < EXPLORE_STEPS.selected &&
                           items.map(item => (
-                            <GridListItem
-                              item={item}
-                              enableItem={i => setItemFunction(i.id)}
-                              onHover={onItemHover}
-                              color="transparent"
-                            />
+                           <GridListItem
+                             item={item}
+                             enableItem={i => setItemFunction(i.id)}
+                             onHover={onItemHover}
+                             color={step !== 1 || item.isSubnational ? 'transparent' : 'strong-pink'}
+                           />
                           ))}
                       </div>
                     )}

--- a/frontend/scripts/react-components/explore/explore.component.jsx
+++ b/frontend/scripts/react-components/explore/explore.component.jsx
@@ -78,39 +78,46 @@ function Explore(props) {
     </Text>
   );
 
+  const renderBackButton = isMobile => (
+    <span>
+      {step > EXPLORE_STEPS.selectCommodity && !isMobile && (
+        <button
+          onClick={clearStep}
+          className="back-button"
+          data-test="featured-cards-back-button"
+        >
+          <Text variant="mono" size="lg" weight="bold" className="featured-cards-back">
+            <Icon color="pink" icon="icon-arrow" className="arrow-icon" />
+            BACK
+          </Text>
+        </button>
+      )}
+    </span>
+  )
+
   const renderTitle = isMobile => {
     const titleParts = ['commodity', 'source country', 'supply chain to explore'];
     return (
       <div className="step-title-container">
-        {step === 1 && (
+        {(step === 1 || step === 2) && (
           <div className="row column">
             <Heading size="lg" align="center" data-test="step-title" className="notranslate">
               {translateText(`${step}. Choose a ${titleParts[step - 1]}`)}
+              {renderBackButton(isMobile)}
             </Heading>
             <Heading size="sm" align="center">
               {translateText('Options marked in')} {renderHighlighted('gray')} {translateText('provide')} {renderHighlighted('national-scale')} {translateText('data only')}
             </Heading>
           </div>
         )}
-        {step !== 1 && (
-          <Heading size="lg" align="center" data-test="step-title" className="notranslate">
-            {translateText(`${step}. Choose a ${titleParts[step - 1]}`)}
-          </Heading>
+        {step === 3 && (
+          <>
+            <Heading size="lg" align="center" data-test="step-title" className="notranslate">
+              {translateText(`${step}. Choose a ${titleParts[step - 1]}`)}
+            </Heading>
+            {renderBackButton(isMobile)}
+          </>
         )}
-        <span>
-          {step > EXPLORE_STEPS.selectCommodity && !isMobile && (
-            <button
-              onClick={clearStep}
-              className="back-button"
-              data-test="featured-cards-back-button"
-            >
-              <Text variant="mono" size="lg" weight="bold" className="featured-cards-back">
-                <Icon color="pink" icon="icon-arrow" className="arrow-icon" />
-                BACK
-              </Text>
-            </button>
-          )}
-        </span>
       </div>
     );
   };
@@ -192,9 +199,11 @@ function Explore(props) {
                           items.map(item => (
                            <GridListItem
                              item={item}
+                             tooltip={item.isSubnational ? null : 'This data is currently only available at a national scale.'}
+                             tooltipCover
                              enableItem={i => setItemFunction(i.id)}
                              onHover={onItemHover}
-                             color={step !== 1 || item.isSubnational ? 'transparent' : 'strong-pink'}
+                             color={!item.isSubnational ? 'transparent' : 'strong-pink'}
                            />
                           ))}
                       </div>

--- a/frontend/scripts/react-components/explore/explore.selectors.js
+++ b/frontend/scripts/react-components/explore/explore.selectors.js
@@ -54,7 +54,8 @@ export const getCountries = createSelector(
       .filter(c => c.commodityId === commodityId)
       .map(c => ({
         name: c.countryName,
-        id: c.countryId
+        id: c.countryId,
+        isSubnational: !!c.subnationalYears
       }));
   }
 );

--- a/frontend/scripts/react-components/explore/explore.selectors.js
+++ b/frontend/scripts/react-components/explore/explore.selectors.js
@@ -24,7 +24,8 @@ export const getCommodities = createSelector([getContexts], contexts => {
   return uniqBy(
     contexts.map(c => ({
       name: c.commodityName,
-      id: c.commodityId
+      id: c.commodityId,
+      isSubnational: !!c.subnationalYears
     })),
     'name'
   );

--- a/frontend/scripts/react-components/shared/grid-list-item/grid-list-item.component.jsx
+++ b/frontend/scripts/react-components/shared/grid-list-item/grid-list-item.component.jsx
@@ -7,12 +7,29 @@ import Text from 'react-components/shared/text';
 
 import './grid-list-item.scss';
 
+function WrapWithTooltip({ tooltip, wrap, children }) {
+  if (wrap) {
+    return (
+      <HelpTooltip
+        theme="black-padding"
+        showInfoIcon={false}
+        className="size-sm"
+        text={tooltip}
+      >
+        {children}
+      </HelpTooltip>
+    );
+  }
+  return children;
+}
+
 function GridListItem(props) {
   const {
     item,
     style,
     isGroup,
     tooltip,
+    tooltipCover = false,
     isActive,
     isDisabled,
     enableItem,
@@ -46,31 +63,33 @@ function GridListItem(props) {
             className="grid-list-item-content"
             data-test={isToggleAll ? 'grid-list-item-toggle-all' : 'grid-list-item-button'}
           >
-            <button
-              type="button"
-              disabled={isDisabled}
-              onClick={isToggleAll ? item.setExcludingMode : () => onClick(item)}
-              onMouseEnter={onHover && !isToggleAll ? () => onHover(item) : undefined}
-              onMouseLeave={onHover && !isToggleAll ? () => onHover(null) : undefined}
-              className={cx('grid-list-item-button', {
-                '-active': !isToggleAll && isActive,
-                '-has-info': !isToggleAll && !!tooltip
-              })}
-              data-test={`grid-list-item-button-${testId}`}
-            >
-              <Text
-                as="p"
-                variant="mono"
-                weight="bold"
-                align="center"
-                title={item.name}
-                transform="capitalize"
-                className="grid-list-item-text"
+            <WrapWithTooltip tooltip={tooltip} wrap={tooltip && tooltipCover}>
+              <button
+                type="button"
+                disabled={isDisabled}
+                onClick={isToggleAll ? item.setExcludingMode : () => onClick(item)}
+                onMouseEnter={onHover && !isToggleAll ? () => onHover(item) : undefined}
+                onMouseLeave={onHover && !isToggleAll ? () => onHover(null) : undefined}
+                className={cx('grid-list-item-button', {
+                  '-active': !isToggleAll && isActive,
+                  '-has-info': !isToggleAll && !!tooltip && !tooltipCover
+                })}
+                data-test={`grid-list-item-button-${testId}`}
               >
-                {item.name}
-              </Text>
-            </button>
-            {tooltip && (
+                <Text
+                  as="p"
+                  variant="mono"
+                  weight="bold"
+                  align="center"
+                  title={item.name}
+                  transform="capitalize"
+                  className="grid-list-item-text"
+                >
+                  {item.name}
+                </Text>
+              </button>
+            </WrapWithTooltip>
+            {tooltip && !tooltipCover && (
               <div
                 className={cx('grid-list-item-info', {
                   '-item-active': !isToggleAll && isActive,
@@ -105,6 +124,7 @@ GridListItem.propTypes = {
   color: PropTypes.string,
   isActive: PropTypes.bool,
   tooltip: PropTypes.string,
+  tooltipCover: PropTypes.bool,
   isDisabled: PropTypes.bool,
   enableItem: PropTypes.func,
   disableItem: PropTypes.func,

--- a/frontend/scripts/react-components/shared/grid-list-item/grid-list-item.scss
+++ b/frontend/scripts/react-components/shared/grid-list-item/grid-list-item.scss
@@ -26,6 +26,25 @@
     }
   }
 
+  &.color-strong-pink {
+    .grid-list-item-button {
+      background-color: transparent;
+      border: 2px solid $strong-pink;
+
+      .grid-list-item-text {
+        color: $charcoal-grey;
+      }
+
+      &:hover {
+        background-color: $strong-pink;
+
+        .grid-list-item-text {
+          color: $white;
+        }
+      }
+    }
+  }
+
   &.color-white {
     .grid-list-item-button {
       background-color: $white;

--- a/frontend/scripts/react-components/shared/grid-list-item/grid-list-item.scss
+++ b/frontend/scripts/react-components/shared/grid-list-item/grid-list-item.scss
@@ -73,12 +73,18 @@
     justify-content: flex-start;
     height: 40px;
     width: 100%;
+    span {
+      display: block;
+      width: inherit;
+      height: inherit;
+    }
   }
 
   .grid-list-item-button {
     background-color: $medium-gray;
     border-radius: 4px;
     height: 100%;
+    width: 100%;
     flex: 1;
     padding: 0 20px;
     cursor: pointer;

--- a/frontend/scripts/react-components/shared/help-tooltip/help-tooltip.component.jsx
+++ b/frontend/scripts/react-components/shared/help-tooltip/help-tooltip.component.jsx
@@ -6,14 +6,28 @@ import Tippy from '@tippy.js/react';
 import 'tippy.js/dist/tippy.css';
 import './help-tooltip.scss';
 
+function tooltipContent(children, showInfoIcon, ReferenceComponent) {
+  if (!showInfoIcon) {
+    return <span>{children}</span>;
+  }
+  if (showInfoIcon && ReferenceComponent) {
+    return <ReferenceComponent />;
+  }
+  return (
+    <svg className="icon tooltip-react-icon">
+      <use xlinkHref="#icon-layer-info" />
+    </svg>
+  )
+}
+
 function HelpTooltipComponent(props) {
-  const { children, referenceComponent: ReferenceComponent, position, text, interactive } = props;
+  const { showInfoIcon, children, referenceComponent: ReferenceComponent, position, text, interactive } = props;
   const parsedText = interactive ? <div dangerouslySetInnerHTML={{ __html: text }} /> : text;
 
   return (
     <span className="c-help-tooltip">
       <Tippy
-        content={children || parsedText}
+        content={parsedText}
         animation="none"
         placement={position}
         arrow
@@ -25,13 +39,7 @@ function HelpTooltipComponent(props) {
         boundary="window"
         appendTo={document.body}
       >
-        {ReferenceComponent ? (
-          <ReferenceComponent />
-        ) : (
-          <svg className="icon tooltip-react-icon">
-            <use xlinkHref="#icon-layer-info" />
-          </svg>
-        )}
+        {tooltipContent(children, showInfoIcon, ReferenceComponent)}
       </Tippy>
     </span>
   );
@@ -39,6 +47,7 @@ function HelpTooltipComponent(props) {
 
 HelpTooltipComponent.propTypes = {
   text: PropTypes.string,
+  showInfoIcon: PropTypes.bool,
   children: PropTypes.any,
   position: PropTypes.string,
   referenceComponent: PropTypes.node,
@@ -46,7 +55,8 @@ HelpTooltipComponent.propTypes = {
 };
 
 HelpTooltipComponent.defaultProps = {
-  position: 'bottom'
+  position: 'bottom',
+  showInfoIcon: true
 };
 
 export default HelpTooltipComponent;

--- a/frontend/scripts/react-components/shared/help-tooltip/help-tooltip.component.jsx
+++ b/frontend/scripts/react-components/shared/help-tooltip/help-tooltip.component.jsx
@@ -21,7 +21,7 @@ function tooltipContent(children, showInfoIcon, ReferenceComponent) {
 }
 
 function HelpTooltipComponent(props) {
-  const { showInfoIcon, children, referenceComponent: ReferenceComponent, position, text, interactive } = props;
+  const { theme, showInfoIcon, children, referenceComponent: ReferenceComponent, position, text, interactive } = props;
   const parsedText = interactive ? <div dangerouslySetInnerHTML={{ __html: text }} /> : text;
 
   return (
@@ -31,7 +31,7 @@ function HelpTooltipComponent(props) {
         animation="none"
         placement={position}
         arrow
-        theme="blue"
+        theme={theme}
         duration={0}
         offset={20}
         zIndex={102}
@@ -46,6 +46,7 @@ function HelpTooltipComponent(props) {
 }
 
 HelpTooltipComponent.propTypes = {
+  theme: PropTypes.string,
   text: PropTypes.string,
   showInfoIcon: PropTypes.bool,
   children: PropTypes.any,
@@ -56,6 +57,7 @@ HelpTooltipComponent.propTypes = {
 
 HelpTooltipComponent.defaultProps = {
   position: 'bottom',
+  theme: 'blue',
   showInfoIcon: true
 };
 

--- a/frontend/scripts/react-components/shared/help-tooltip/help-tooltip.scss
+++ b/frontend/scripts/react-components/shared/help-tooltip/help-tooltip.scss
@@ -12,6 +12,10 @@
     }
   }
 
+  &.size-sm {
+    font-size: $font-size-regular;
+  }
+
   @media print {
     display: none;
   }

--- a/frontend/scripts/react-components/tool-links/tool-links.selectors.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.selectors.js
@@ -170,6 +170,14 @@ export const getExpandedNodesByRole = createSelector(
   getNodesByRole
 );
 
+export const getSubnationalYears = createSelector(
+  [getSelectedContext],
+  (selectedContext) => {
+    if (!selectedContext || !selectedContext.subnationalYears) return [];
+    return selectedContext.subnationalYears;
+  }
+)
+
 export const getToolGroupedCharts = makeGetGroupedCharts(getToolCharts);
 
 export const getToolLinksUrlProps = createStructuredSelector({
@@ -184,5 +192,6 @@ export const getToolLinksUrlProps = createStructuredSelector({
 
 export const getToolYearsProps = createStructuredSelector({
   selectedYears: getSelectedYears,
+  subNationalYears: getSubnationalYears,
   years: makeGetAvailableYears(getToolResizeBy, getToolRecolorBy, getSelectedContext)
 });

--- a/frontend/scripts/react-components/tool/timeline/timeline.component.jsx
+++ b/frontend/scripts/react-components/tool/timeline/timeline.component.jsx
@@ -4,6 +4,10 @@ import cx from 'classnames';
 import Tabs from 'react-components/shared/tabs';
 import Text from 'react-components/shared/text/text.component';
 import _range from 'lodash/range';
+import Tooltip from 'react-components/shared/help-tooltip/help-tooltip.component';
+
+import { translateText } from 'utils/transifex';
+
 import {
   useTimelineReducer,
   useSelectedYearsPropsState,
@@ -52,8 +56,7 @@ function getClassName(year, state) {
 }
 
 function Timeline(props) {
-  const { years, showBackground, visibleTabs, disabled } = props;
-
+  const { years, subNationalYears, showBackground, visibleTabs, disabled } = props;
   const [state, dispatch] = useTimelineReducer(props);
   useSelectedYearsPropsState(props, state, dispatch);
   useUpdateSelectedYears(props, state);
@@ -134,11 +137,16 @@ function Timeline(props) {
           {years.map((year, i) => {
             const isActive = year === state.start || year === state.end;
             const statusClassName = getClassName(year, state);
+            const isSubNational = subNationalYears.indexOf(year) > -1;
             return (
               <li
                 ref={i === 0 ? refs.item : undefined}
                 key={year}
-                className={cx('timeline-year-item', statusClassName)}
+                className={cx({
+                  'timeline-year-item': true,
+                  '-sub-national': isSubNational,
+                  [statusClassName]: true
+                })}
               >
                 <button
                   disabled={disabled || (!state.range && isActive)}
@@ -148,9 +156,20 @@ function Timeline(props) {
                   onClick={() => dispatch({ type: 'select', payload: year })}
                   data-test={`timeline-year-button-${year}`}
                 >
-                  <Text as="span" weight="bold" color={statusClassName ? 'white' : 'grey'}>
-                    {year}
-                  </Text>
+                  {!isSubNational && <Tooltip
+                    showInfoIcon={false}
+                    text={translateText('This data is currently only available at a national scale.')}
+                    className="size-sm"
+                  >
+                    <Text as="span" weight="bold" color={statusClassName ? 'white' : 'grey'}>
+                      {year}
+                    </Text>
+                  </Tooltip>}
+                  {isSubNational && (
+                    <Text as="span" weight="bold" color={statusClassName ? 'white' : 'grey'}>
+                      {year}
+                    </Text>
+                  )}
                 </button>
               </li>
             );
@@ -170,6 +189,7 @@ Timeline.propTypes = {
   visibleTabs: PropTypes.array,
   showBackground: PropTypes.bool,
   years: PropTypes.array.isRequired,
+  subNationalYears: PropTypes.array.isRequired,
   disabled: PropTypes.bool,
   selectYears: PropTypes.func.isRequired, // eslint-disable-line
   selectedYears: PropTypes.array.isRequired // eslint-disable-line

--- a/frontend/scripts/react-components/tool/timeline/timeline.scss
+++ b/frontend/scripts/react-components/tool/timeline/timeline.scss
@@ -127,8 +127,20 @@
     border-radius: 4px;
     background-color: $white;
 
+    &.-sub-national {
+      border: 2px solid $strong-pink;
+      &.-start,
+      &.-end {
+        background-color: $strong-pink;
+      }
+    }
+
     &.-active {
       background-color: $charcoal-grey-faded;
+      &.-sub-national {
+        background-color: $strong-pink;
+        color: $white;
+      }
     }
 
     &.-start,
@@ -137,6 +149,8 @@
     }
 
     .timeline-year-button {
+      display: flex;
+      align-items: center;
       padding: 6px 12px;
       height: 100%;
       width: 100%;

--- a/frontend/styles/_tooltip.scss
+++ b/frontend/styles/_tooltip.scss
@@ -4,7 +4,7 @@
   border-radius: 0;
 }
 
-.tippy-tooltip.blue-theme .tippy-content{
+.tippy-tooltip.blue-theme .tippy-content {
   background-color: $charcoal-grey;
   color: $white;
   padding: 16px;
@@ -19,7 +19,6 @@
     cursor: pointer;
   }
 }
-
 
 .tippy-tooltip.blue-theme[data-animatefill] {
   background-color: transparent
@@ -58,3 +57,16 @@
   font-weight: $font-weight-light;
   line-height: $line-height-md;
 }
+
+// Black Theme with padding
+.tippy-tooltip.black-padding-theme .tippy-content {
+  background-color: $charcoal-grey;
+  color: $white;
+  border-radius: 0;
+  padding: 7px;
+  font-family: $font-family-2;
+  font-size: $font-size-regular;
+  font-weight: $font-weight-light;
+  line-height: $line-height-md;
+}
+


### PR DESCRIPTION
## Pivotal Tracker

Please include the link(s)

## Description

This pr adds highlight difference between nat/subnat when choosing a commodity and years within sankey timeline. 

## Testing instructions

1. Go to /explore and make sure highlighting works as expected
2. Enter sankey, make sure years that does not have subnat data display a tooltip letting the user know that data is only national. 
3. On sankey, make sure sub nat years are highlighted and does not display a tooltip. 

@agnessa would be awesome if we could verify the data works correctly, I'm now using `subnationalYears` instead of `isSubnational` as we discussed from the context API, so after this PR is merged we can safely remove that key from the endpoint. 