### PR TITLE
Add cocoa product thematic colors

### DIFF
--- a/frontend/styles/_settings.scss
+++ b/frontend/styles/_settings.scss
@@ -189,6 +189,12 @@ $recolorby-qual-thematic-cake: #e48716;
 $recolorby-qual-thematic-crude-palm-oil: #e48716;
 $recolorby-qual-thematic-refined-palm-oil: #f7fcb9;
 
+$recolorby-qual-thematic-cocoa-waste: #80cdc1;
+$recolorby-qual-thematic-cocoa-butter: #517fee;
+$recolorby-qual-thematic-cocoa-beans: #a6611a;
+$recolorby-qual-thematic-cocoa-paste: #e7298a;
+$recolorby-qual-thematic-cocoa-powder: #7570b3;
+
 $recolorby-linear-red-blue-7: #6f0119;
 $recolorby-linear-red-blue-6: #a50026;
 $recolorby-linear-red-blue-5: #d72f27;
@@ -243,6 +249,11 @@ $recolorby-colors: (
   'recolorby-qual-thematic-esteros-del-ibera': $recolorby-qual-thematic-esteros-del-ibera,
   'recolorby-qual-thematic-monte-de-llanuras-y-mesetas':
     $recolorby-qual-thematic-monte-de-llanuras-y-mesetas,
+  'recolorby-qual-thematic-cocoa-waste': $recolorby-qual-thematic-cocoa-waste,
+  'recolorby-qual-thematic-cocoa-butter': $recolorby-qual-thematic-cocoa-butter,
+  'recolorby-qual-thematic-cocoa-beans': $recolorby-qual-thematic-cocoa-beans,
+  'recolorby-qual-thematic-cocoa-paste': $recolorby-qual-thematic-cocoa-paste,
+  'recolorby-qual-thematic-cocoa-powder': $recolorby-qual-thematic-cocoa-powder,
   'recolorby-qual-thematic-yungas': $recolorby-qual-thematic-yungas,
   'recolorby-stars-red-blue-0': $recolorby-stars-red-blue-0,
   'recolorby-stars-red-blue-1': $recolorby-stars-red-blue-1,


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/story/show/175070916

## Description
WIP: Waiting for pallette approval and knowing if we need to add colors for Coffee too.

![image](https://user-images.githubusercontent.com/9701591/94788943-986a8580-03d4-11eb-9255-459b02e9d604.png)


## Testing instructions

Go to Brazil cocoa and select 'Product' indicator
