### PR TITLE
fix crash when levels are not available on explore step 3

### DIFF
--- a/frontend/scripts/react-components/explore/explore.component.jsx
+++ b/frontend/scripts/react-components/explore/explore.component.jsx
@@ -229,8 +229,8 @@ function Explore(props) {
                             ))
                           ) : (
                             <div className="bubble">
-                              {(highlightedCountryIds.level1.length > 0 ||
-                                highlightedCountryIds.level2.length > 0 ||
+                              {(highlightedCountryIds?.level1.length > 0 ||
+                                highlightedCountryIds?.level2.length > 0 ||
                                 highlightedCommodityIds.length > 0) && (
                                 <>
                                   <Text


### PR DESCRIPTION
## Pivotal Tracker

https://www.pivotaltracker.com/n/projects/2380432/stories/175073497

## Description

This pr fixes crash happening on step 3 explore when levels are not available. 

## Testing instructions

Api URL needs to point to sandbox to reproduce, make sure step 3 does not crash. 