### PR TITLE
Only keep 3 releases

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/syst
 # set :local_user, -> { `git config user.name`.chomp }
 
 # Default value for keep_releases is 5
-# set :keep_releases, 5
+set :keep_releases, 3
 
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure


### PR DESCRIPTION
node_modules has grown in size and old releases take up a lot of disk space; before upscaling the storage, just reduce the number of releases to keep
