### PR TITLE
Reset tooltip

### DIFF
--- a/frontend/scripts/react-components/tool/mapbox-map/mapbox-map.component.jsx
+++ b/frontend/scripts/react-components/tool/mapbox-map/mapbox-map.component.jsx
@@ -210,6 +210,7 @@ function MapBoxMap(props) {
     const geoFeature = features.find(f => f.sourceLayer === sourceLayer);
     if (geoFeature) {
       const { properties, source, id } = geoFeature;
+
       if (map && lastHoveredGeo.id && layerIds.includes(lastHoveredGeo.source)) {
         map.setFeatureState({ ...lastHoveredGeo }, { hover: false });
       }
@@ -242,8 +243,15 @@ function MapBoxMap(props) {
       }
 
       const node = highlightedNodesData[0];
+
       if (node?.name) {
         setTooltip({ x: center.x, y: center.y, name: node?.name, values: properties });
+      } else {
+        // Reset last and current tooltip
+        lastHoveredGeo = {};
+        setTooltip(null);
+        updateTooltipValues(null);
+        clearHoveredFeatureState('hover');
       }
     }
 


### PR DESCRIPTION
## Description

Reset tooltip items when we change of context

![image](https://user-images.githubusercontent.com/9701591/95446299-628f4900-0960-11eb-90e9-fbf91ace5627.png)


## Testing instructions

Before:

- Go to Brazil-Soy: Select a unit layer with the edit layers modal
- Hover over a region: You should see one or two tooltip items
- Go to Ecuador-Shrimp
- Hover over a region: The same items were remaining

Now:

- ...
- Tooltip items are reset