### PR TITLE
Chore/splitting basic attribute refresh job per node

### DIFF
--- a/app/models/api/v3/chart_attribute.rb
+++ b/app/models/api/v3/chart_attribute.rb
@@ -107,18 +107,22 @@ module Api
       end
 
       def update_node_with_flows_actor_basic_attributes(chart_id)
-        chart = Api::V3::Chart.find(chart_id)
-        profile = chart.profile
-        nodes_ids = Api::V3::Readonly::NodeWithFlows.
-          where(
-            context_node_type_id: profile.context_node_type_id
-          ).
+        nodes_with_flows = Api::V3::Readonly::NodeWithFlows.
+          select(:id, :context_id).
           without_unknowns.
           without_domestic.
-          pluck(:id)
-        NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-          nodes_ids.uniq
-        )
+          where(
+            context_node_type_id: Api::V3::Profile.
+              select(:context_node_type_id).
+              where(
+                id: Api::V3::Chart.select(:profile_id).where(id: chart_id)
+              )
+          )
+        nodes_with_flows.each do |node|
+          NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+            node.id, node.context_id
+          )
+        end
       end
 
       private_class_method def self.active_ids

--- a/app/models/api/v3/ind_commodity_property.rb
+++ b/app/models/api/v3/ind_commodity_property.rb
@@ -53,15 +53,20 @@ module Api
         update_node_with_flows_actor_basic_attributes(commodity_id, ind_id)
       end
 
-      def update_node_with_flows_actor_basic_attributes(commodity_id, _ind_id)
-        nodes_ids = Api::V3::Readonly::NodeWithFlows.
-          where(commodity_id: commodity_id).
+      def update_node_with_flows_actor_basic_attributes(commodity_id, ind_id)
+        nodes_with_flows = Api::V3::Readonly::NodeWithFlows.
+          select(:id, :context_id).
           without_unknowns.
           without_domestic.
-          pluck(:id)
-        NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-          nodes_ids.uniq
-        )
+          where(
+            commodity_id: commodity_id,
+            id: Api::V3::NodeInd.select(:node_id).where(ind_id: ind_id).distinct
+          )
+        nodes_with_flows.each do |node|
+          NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+            node.id, node.context_id
+          )
+        end
       end
     end
   end

--- a/app/models/api/v3/ind_context_property.rb
+++ b/app/models/api/v3/ind_context_property.rb
@@ -53,15 +53,20 @@ module Api
         update_node_with_flows_actor_basic_attributes(context_id, ind_id)
       end
 
-      def update_node_with_flows_actor_basic_attributes(context_id, _ind_id)
-        nodes_ids = Api::V3::Readonly::NodeWithFlows.
-          where(context_id: context_id).
+      def update_node_with_flows_actor_basic_attributes(context_id, ind_id)
+        nodes_with_flows = Api::V3::Readonly::NodeWithFlows.
+          select(:id, :context_id).
           without_unknowns.
           without_domestic.
-          pluck(:id)
-        NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-          nodes_ids.uniq
-        )
+          where(
+            context_id: context_id,
+            id: Api::V3::NodeInd.select(:node_id).where(ind_id: ind_id).distinct
+          )
+        nodes_with_flows.each do |node|
+          NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+            node.id, node.context_id
+          )
+        end
       end
     end
   end

--- a/app/models/api/v3/ind_country_property.rb
+++ b/app/models/api/v3/ind_country_property.rb
@@ -53,15 +53,20 @@ module Api
         update_node_with_flows_actor_basic_attributes(country_id, ind_id)
       end
 
-      def update_node_with_flows_actor_basic_attributes(country_id, _ind_id)
-        nodes_ids = Api::V3::Readonly::NodeWithFlows.
-          where(country_id: country_id).
+      def update_node_with_flows_actor_basic_attributes(country_id, ind_id)
+        nodes_with_flows = Api::V3::Readonly::NodeWithFlows.
+          select(:id, :context_id).
           without_unknowns.
           without_domestic.
-          pluck(:id)
-        NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-          nodes_ids.uniq
-        )
+          where(
+            country_id: country_id,
+            id: Api::V3::NodeInd.select(:node_id).where(ind_id: ind_id).distinct
+          )
+        nodes_with_flows.each do |node|
+          NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+            node.id, node.context_id
+          )
+        end
       end
     end
   end

--- a/app/models/api/v3/profile.rb
+++ b/app/models/api/v3/profile.rb
@@ -97,14 +97,16 @@ module Api
       end
 
       def update_node_with_flows_actor_basic_attributes(context_node_type_id)
-        nodes_ids = Api::V3::Readonly::NodeWithFlows.
-          where(context_node_type_id: context_node_type_id).
+        nodes_with_flows = Api::V3::Readonly::NodeWithFlows.
+          select(:id, :context_id).
           without_unknowns.
           without_domestic.
-          pluck(:id)
-        NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-          nodes_ids.uniq
-        )
+          where(context_node_type_id: context_node_type_id)
+        nodes_with_flows.each do |node|
+          NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+            node.id, node.context_id
+          )
+        end
       end
     end
   end

--- a/app/models/api/v3/qual_commodity_property.rb
+++ b/app/models/api/v3/qual_commodity_property.rb
@@ -53,15 +53,20 @@ module Api
         update_node_with_flows_actor_basic_attributes(commodity_id, qual_id)
       end
 
-      def update_node_with_flows_actor_basic_attributes(commodity_id, _qual_id)
-        nodes_ids = Api::V3::Readonly::NodeWithFlows.
-          where(commodity_id: commodity_id).
+      def update_node_with_flows_actor_basic_attributes(commodity_id, qual_id)
+        nodes_with_flows = Api::V3::Readonly::NodeWithFlows.
+          select(:id, :context_id).
           without_unknowns.
           without_domestic.
-          pluck(:id)
-        NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-          nodes_ids.uniq
-        )
+          where(
+            commodity_id: commodity_id,
+            id: Api::V3::NodeQual.select(:node_id).where(qual_id: qual_id).distinct
+          )
+        nodes_with_flows.each do |node|
+          NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+            node.id, node.context_id
+          )
+        end
       end
     end
   end

--- a/app/models/api/v3/qual_context_property.rb
+++ b/app/models/api/v3/qual_context_property.rb
@@ -53,15 +53,20 @@ module Api
         update_node_with_flows_actor_basic_attributes(context_id, qual_id)
       end
 
-      def update_node_with_flows_actor_basic_attributes(context_id, _qual_id)
-        nodes_ids = Api::V3::Readonly::NodeWithFlows.
-          where(context_id: context_id).
+      def update_node_with_flows_actor_basic_attributes(context_id, qual_id)
+        nodes_with_flows = Api::V3::Readonly::NodeWithFlows.
+          select(:id, :context_id).
           without_unknowns.
           without_domestic.
-          pluck(:id)
-        NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-          nodes_ids.uniq
-        )
+          where(
+            context_id: context_id,
+            id: Api::V3::NodeQual.select(:node_id).where(qual_id: qual_id).distinct
+          )
+        nodes_with_flows.each do |node|
+          NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+            node.id, node.context_id
+          )
+        end
       end
     end
   end

--- a/app/services/api/v3/import/importer.rb
+++ b/app/services/api/v3/import/importer.rb
@@ -145,11 +145,11 @@ module Api
             without_unknowns.
             without_domestic.
             where(profile: Api::V3::Profile::ACTOR).
-            select(:id).
+            select(:id, :context_id).
             distinct.
             each do |node|
               NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
-                [node.id]
+                node.id, node.context_id
               )
             end
         end

--- a/app/workers/node_with_flows_refresh_actor_basic_attributes_worker.rb
+++ b/app/workers/node_with_flows_refresh_actor_basic_attributes_worker.rb
@@ -3,14 +3,17 @@ class NodeWithFlowsRefreshActorBasicAttributesWorker
 
   sidekiq_options queue: :default,
                   retry: 0,
-                  backtrace: true,
-                  unique: :until_executed,
-                  run_lock_expiration: 60 * 60 * 2, # 2 hrs
-                  log_duplicate_payload: true
+                  backtrace: true
 
-  def perform(node_with_flows_ids = [])
-    Api::V3::Readonly::NodeWithFlows.
-      where(id: node_with_flows_ids).
-      each(&:refresh_actor_basic_attributes)
+  def perform(node_id, context_id)
+    node_with_flows = Api::V3::Readonly::NodeWithFlows.
+      without_unknowns.
+      without_domestic.
+      find_by(
+        id: node_id, context_id: context_id
+      )
+    return unless node_with_flows
+
+    node_with_flows.refresh_actor_basic_attributes
   end
 end

--- a/spec/responses/api/v3/exporter_profile_spec.rb
+++ b/spec/responses/api/v3/exporter_profile_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe 'Exporter profile', type: :request do
     Api::V3::Readonly::NodeWithFlowsPerYear.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlows.refresh(sync: true)
     Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
-
-    NodeWithFlowsRefreshActorBasicAttributesWorker.new.perform(
-      Api::V3::Readonly::NodeWithFlows.where(profile: :actor).map(&:id)
-    )
+    Api::V3::Readonly::NodeWithFlows.where(profile: :actor).each(&:refresh_actor_basic_attributes)
   end
 
   let(:summary_params) { {year: 2015} }

--- a/spec/responses/api/v3/importer_profile_spec.rb
+++ b/spec/responses/api/v3/importer_profile_spec.rb
@@ -15,10 +15,7 @@ RSpec.describe 'Importer profile', type: :request do
     Api::V3::Readonly::NodeWithFlowsPerYear.refresh(sync: true)
     Api::V3::Readonly::NodeWithFlows.refresh(sync: true)
     Api::V3::Readonly::Attribute.refresh(sync: true, skip_dependents: true)
-
-    NodeWithFlowsRefreshActorBasicAttributesWorker.new.perform(
-      Api::V3::Readonly::NodeWithFlows.where(profile: :actor).map(&:id)
-    )
+    Api::V3::Readonly::NodeWithFlows.where(profile: :actor).each(&:refresh_actor_basic_attributes)
   end
 
   let(:summary_params) { {year: 2015} }

--- a/spec/workers/node_with_flows_refresh_actor_basic_attributes_worker_spec.rb
+++ b/spec/workers/node_with_flows_refresh_actor_basic_attributes_worker_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe NodeWithFlowsRefreshActorBasicAttributesWorker, type: :worker do
       find(api_v3_exporter1_node.id)
     expect(actor_with_flows.actor_basic_attributes).to be_nil
 
-    NodeWithFlowsRefreshActorBasicAttributesWorker.new.perform(
-      [api_v3_exporter1_node.id]
+    NodeWithFlowsRefreshActorBasicAttributesWorker.perform_async(
+      actor_with_flows.id, actor_with_flows.context_id
     )
 
     actor_with_flows.reload


### PR DESCRIPTION
This is related with improving sidekiq work distribution, as currently the basic attribute refresh job takes ages and blocks more important jobs that are added to the queue in the meantime.
