### PR TITLE
Don't show cookie banner on iframe

### DIFF
--- a/frontend/scripts/app/app.component.jsx
+++ b/frontend/scripts/app/app.component.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect } from 'react';
+import React, { lazy, Suspense, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import TopNav from 'react-components/nav/top-nav/top-nav.container';
 import CookieBanner from 'react-components/shared/cookie-banner';
@@ -6,6 +6,7 @@ import Feedback from 'react-components/shared/feedback';
 import Footer from 'react-components/shared/footer/footer.component';
 
 import isIe from 'utils/isIe';
+import isIframe from 'utils/isIframe';
 
 import SeoHandler from './seo-handler.component';
 
@@ -22,13 +23,14 @@ const pageContent = {
 function App() {
   const { routesMap, type, query } = useSelector(state => state.location);
   const { Component, layout, footer = true, feedback = true } = routesMap[type];
-
+  const [isInIframe, setIsInIframe] = useState(false);
   const pageKey = type === 'profile' ? `${type}-${query?.nodeId}` : type;
 
   useEffect(() => {
     if (isIe()) {
       document.body.classList.add('-is-legacy-browser');
     }
+    if (isIframe()) setIsInIframe(true);
   }, []);
   return (
     <Suspense fallback={null}>
@@ -38,7 +40,8 @@ function App() {
       </nav>
       <main>
         <Component key={pageKey} content={layout && layout(pageContent[type])} />
-        <CookieBanner />
+
+        {!isInIframe && <CookieBanner />}
         {feedback && <Feedback />}
       </main>
 

--- a/frontend/scripts/tests/iframe/index.html
+++ b/frontend/scripts/tests/iframe/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Iframe test</title>
+</head>
+<body>
+  <iframe src="http://localhost:8081" frameborder="0" height="700" width="1200"></iframe>
+</body>
+</html>

--- a/frontend/scripts/tests/iframe/index.html
+++ b/frontend/scripts/tests/iframe/index.html
@@ -6,6 +6,8 @@
   <title>Iframe test</title>
 </head>
 <body>
+  <!-- This is a html to test the app inside an iframe -->
+  <!-- To test run a server like SimpleHTTPServer on this directory -->
   <iframe src="http://localhost:8081" frameborder="0" height="700" width="1200"></iframe>
 </body>
 </html>

--- a/frontend/scripts/utils/isIframe.js
+++ b/frontend/scripts/utils/isIframe.js
@@ -1,0 +1,1 @@
+export default () => window.location !== window.parent.location;


### PR DESCRIPTION
## Description

Iframes containing the app shouldn't show the cookie banner


## Testing instructions

Run a server like [SimpleHTTPServer](https://www.pythonforbeginners.com/modules-in-python/how-to-use-simplehttpserver) in the tests/iframe folder. That should open the app inside an iframe. The banner shouldn't show