### PR TITLE
Add thematic colors for zero deforestation commitment

### DIFF
--- a/frontend/styles/_settings.scss
+++ b/frontend/styles/_settings.scss
@@ -256,6 +256,8 @@ $recolorby-colors: (
   'recolorby-qual-thematic-cocoa-paste': $recolorby-qual-thematic-cocoa-paste,
   'recolorby-qual-thematic-cocoa-powder': $recolorby-qual-thematic-cocoa-powder,
   'recolorby-qual-thematic-yungas': $recolorby-qual-thematic-yungas,
+  'recolorby-qual-thematic-yes': $recolorby-linear-yellow-green-2,
+  'recolorby-qual-thematic-no': $recolorby-stars-red-blue-2,
   'recolorby-stars-red-blue-0': $recolorby-stars-red-blue-0,
   'recolorby-stars-red-blue-1': $recolorby-stars-red-blue-1,
   'recolorby-stars-red-blue-2': $recolorby-stars-red-blue-2,


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9701591/99526446-8bf9b680-299b-11eb-9219-cfb8099e41e0.png)
New colors added for Zero deforestation commitment indicator on Cote d'ivoire - Cocoa and Indonesia - Wood Pulp
yes - green
no - red
Unknown remains gray

## Testing instructions

Go to those contexts and select ZDC indicator