### PR TITLE
Improve pluralize

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -153,6 +153,7 @@
     "lodash": "^4.17.15",
     "luma.gl": "7.3.2",
     "node-sass": "^4.13.1",
+    "pluralize": "^8.0.0",
     "plyr": "^3.5.6",
     "promise.prototype.finally": "^3.1.2",
     "prop-types": "^15.7.2",

--- a/frontend/scripts/utils/pluralize.js
+++ b/frontend/scripts/utils/pluralize.js
@@ -1,21 +1,21 @@
 import camelCase from 'lodash/camelCase';
+import pluralize from 'pluralize';
 
 export default name => {
   const camelCasedName = camelCase(name);
-  const plural = {
-    logisticsHub: 'logistics hubs',
+  const pluralException = {
     portOfImport: 'ports of import',
-    economicBloc: 'economic blocs',
     portOfExport: 'ports of export',
     districtOfExport: 'districts of export',
     countryOfProduction: 'country of production'
   }[camelCasedName];
-
-  if (!plural) {
-    return camelCasedName.endsWith('y')
-      ? camelCasedName.replace(/y$/, 'ies').toLowerCase()
-      : `${camelCasedName}s`.toLowerCase();
+  if (pluralException) {
+    return pluralException;
   }
-
-  return plural;
+  const words = name.toLowerCase().trim().split(' ');
+  if (words.length > 1) {
+    words[words.length - 1] = pluralize(words[words.length - 1]);
+    return words.join(' ');
+  }
+  return pluralize(camelCasedName.toLowerCase());
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -12740,6 +12740,11 @@ pluralize@^1.2.1:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
   integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 plyr@^3.5.6:
   version "3.5.10"
   resolved "https://registry.yarnpkg.com/plyr/-/plyr-3.5.10.tgz#631fb379135abd17ea822817db3046b484c8166c"


### PR DESCRIPTION
https://app.asana.com/0/1187619191620560/1199244035527549/f

This PR improves the pluralize function using the pluralize package and pluralizing by default the last word of a string. The exceptions are less now.

![image](https://user-images.githubusercontent.com/9701591/100076038-06fe1980-2e41-11eb-927e-f9d48a993f14.png)


## Testing instructions

Go to the data section of Ecuador - Shrimp. You should see all correct plurals, including 'parishes' and 'exporter groups'