### PR TITLE
Add total of commodity area only if we have it

### DIFF
--- a/app/services/api/v3/places/basic_attributes.rb
+++ b/app/services/api/v3/places/basic_attributes.rb
@@ -260,14 +260,19 @@ did not produce any #{@commodity_name} in \
 <span class=\"notranslate\">#{@year}</span>."
           end
 
-          "In <span class=\"notranslate\">#{@year}</span>, \
+          summary_text = "In <span class=\"notranslate\">#{@year}</span>, \
 <span class=\"notranslate\">#{@node.name.titleize}</span> produced \
 <span class=\"notranslate\">#{@commodity_production_formatted}</span> \
 <span class=\"notranslate\">#{@commodity_production_unit}</span> of \
-<span class=\"notranslate\">#{@commodity_name}</span> \
-occupying a total of \
-<span class=\"notranslate\">#{@commodity_area_formatted}</span> \
-<span class=\"notranslate\">#{@commodity_area_unit}</span> of land."
+<span class=\"notranslate\">#{@commodity_name}</span>"
+          if @commodity_area_formatted
+            summary_text << "\
+  occupying a total of \
+  <span class=\"notranslate\">#{@commodity_area_formatted}</span> \
+  <span class=\"notranslate\">#{@commodity_area_unit}</span> of land."
+          end
+
+          summary_text
         end
 
         # rubocop:disable Metrics/AbcSize


### PR DESCRIPTION
I couldn't test this as I didn't have the data for this specific context. Please feel free to make any modifications

https://app.asana.com/0/1187619191620560/1199231338050928/f

![image](https://user-images.githubusercontent.com/9701591/100204817-a20bf780-2f04-11eb-8a92-0d7ac531ac3c.png)

## Description

The total commodity and unit should only appear if we have it. Maybe we have to apply this too to the actors' basic_attributes.


## Testing instructions

Search for 'Pt Arari abadi' on the profiles page. The text should be correct, without the "occupying a total of land" part