### PR TITLE
Change margin to fit tick label

### DIFF
--- a/frontend/scripts/react-components/profile/profile-components/scatterplot/scatterplot.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-components/scatterplot/scatterplot.component.jsx
@@ -23,7 +23,7 @@ class Scatterplot extends Component {
       top: 20,
       right: 13,
       bottom: 30,
-      left: 29
+      left: 39
     };
     this.state = {
       selectedTabIndex: props.xDimensionSelectedIndex || 0


### PR DESCRIPTION
## Pivotal Tracker

https://app.asana.com/0/1187619191620560/1199241958938734/f

## Description

Very small change just adjusting the margin of the scatterplot left axis labels

![image](https://user-images.githubusercontent.com/9701591/100334709-6d677100-2fd4-11eb-9aa7-bc9f185fb62f.png)


## Testing instructions

Try with different profiles