### PR TITLE
Allow country menu profile link

### DIFF
--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -294,6 +294,10 @@ export const PROFILE_TYPES = {
   traders: 'companies'
 };
 
+export const NODE_TYPES = {
+  countryOfProduction: 'COUNTRY OF PRODUCTION'
+};
+
 export const DEFAULT_DASHBOARD_UNIT_FORMAT = '.4~s';
 
 export const NODE_TYPE_PANELS = {


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1187619191620560/1199241958938727/f

## Description

The country of production node is always "selected" but not actually. As we just have one node and its the full country its not selectable but we still want to see the link to the country profile.

Solution: On hover of the country profile node you will always see the 'Go to country profile' link. If some other node is selected you will be able to expand, clear, ...

![countrylink](https://user-images.githubusercontent.com/9701591/100351924-84b25880-2fec-11eb-8644-d7bf19b3c4e0.gif)

## Testing instructions

Remember to have ENABLE_COUNTRY_PROFILES set to true on the env. Go to any context with a country of production column and select it. You should be able to see and use the link on hover