### PR TITLE
Update 'volume' indicator number of decimals

### DIFF
--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -2,6 +2,7 @@
 export const NUM_DECIMALS = {
   // resize by
   'trade volume': 0,
+  'volume': 0,
   'land use': 0,
   'financial flow': 0,
   'territorial deforestation': 0,


### PR DESCRIPTION
Volume on the sankey tooltip was defaulting to one decimal. Now 0 decimals are specified

![image](https://user-images.githubusercontent.com/9701591/102204304-ff72e300-3ec9-11eb-9140-ea06210486e1.png)
