### PR TITLE
Add missing prop

### DIFF
--- a/frontend/scripts/react-components/profile/profile-widgets/map-flows-widget.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-widgets/map-flows-widget.component.jsx
@@ -23,8 +23,9 @@ class MapFlowsWidget extends React.PureComponent {
   }
 
   render() {
-    const { nodeId, profileType, title, year, commodityName } = this.props;
-    const params = { node_id: nodeId, year };
+    const { nodeId, profileType, title, year, commodityName, commodityId, contextId } = this.props;
+    const contextProp = contextId ? { context_id: contextId } : { commodity_id: commodityId };
+    const params = { node_id: nodeId, year, ...contextProp };
 
     return (
       <Widget


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9701591/104184585-f6ffc080-5413-11eb-9643-308a0bfbdeef.png)

## Asana

https://app.asana.com/0/1195054825337974/1197993057162668/f

## Description

This is part of the task, not the main purpose (that was solved before). The top destinations map widget was not showing as we were missing a param (context or commodity id depending if its an importer or exporter country)

## Testing instructions

Check exporting or importing countries profiles