### PR TITLE
add exporter/importer groups in uppercase condition

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
@@ -23,8 +23,7 @@ function RankingWidget(props) {
   // Companies needs their title to be uppercase
   const companyWidgets = ['EXPORTER', 'IMPORTER', 'EXPORTER GROUP', 'IMPORTER GROUP'];
   const titleUpper = companyWidgets.indexOf(nodeType.toUpperCase()) > -1;
-  console.log('Node type', nodeType);
-  console.log('Title upper', titleUpper);
+
   useEffect(() => {
     setWidth(ref.current ? ref.current.offsetWidth : 0);
   }, [ref]);

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/ranking-widget/ranking-widget.component.jsx
@@ -21,8 +21,10 @@ function RankingWidget(props) {
     info: { node_type: nodeType }
   } = meta;
   // Companies needs their title to be uppercase
-  const titleUpper = nodeType === 'EXPORTER';
-
+  const companyWidgets = ['EXPORTER', 'IMPORTER', 'EXPORTER GROUP', 'IMPORTER GROUP'];
+  const titleUpper = companyWidgets.indexOf(nodeType.toUpperCase()) > -1;
+  console.log('Node type', nodeType);
+  console.log('Title upper', titleUpper);
   useEffect(() => {
     setWidth(ref.current ? ref.current.offsetWidth : 0);
   }, [ref]);


### PR DESCRIPTION
This pr fixes an issue for importer/exporter group widgets, not uppercasing CO labels.