### PR TITLE
Don't show the link on Data if the flag is off

### DIFF
--- a/frontend/scripts/react-components/chart/tick/category-tick.component.jsx
+++ b/frontend/scripts/react-components/chart/tick/category-tick.component.jsx
@@ -18,7 +18,13 @@ function CategoryTick(props) {
   } = config;
   const node = nodeIds[payload.index];
   let url;
-  if (node && node.profile && !DISABLE_PROFILES) {
+
+  if (
+    node &&
+    node.profile &&
+    !DISABLE_PROFILES &&
+    !(node.profile === 'country' && !ENABLE_COUNTRY_PROFILES)
+  ) {
     url = {
       type: 'profile',
       payload: { profileType: node.profile },


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/9701591/105487430-609f8a80-5cb0-11eb-9329-0924d6a32d37.png)

We dont want to show this links to country profiles if they are not active
