### PR TITLE
Align label to the right

### DIFF
--- a/frontend/scripts/react-components/profile/profile-components/scatterplot/scatterplot.scss
+++ b/frontend/scripts/react-components/profile/profile-components/scatterplot/scatterplot.scss
@@ -64,6 +64,7 @@
 
     .axis--label-text {
       fill: black;
+      text-anchor: end;
     }
 
     path {


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1195054825337974/1199241958938734/f

## Description

Label should be aligned to the right to avoid being cut

## Testing instruction

- Go to Minerva profile
- Go to last chart
- Select last tab
- x axis label should read correctly