### PR TITLE
Fix/countries production tooltip

### DIFF
--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.actions.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.actions.js
@@ -1,4 +1,4 @@
-import { PROFILE_STEPS } from 'constants';
+import { PROFILE_STEPS, NODE_TYPES } from 'constants';
 
 export const PROFILES__SET_MORE_PANEL_DATA = 'PROFILES__SET_MORE_PANEL_DATA';
 export const PROFILES__SET_PANEL_DATA = 'PROFILES__SET_PANEL_DATA';
@@ -82,7 +82,7 @@ export const goToProfile = () => (dispatch, getState) => {
     panels.sources.activeItems.length > 0 &&
     data.sources[panels.sources.activeTab] &&
     data.sources[panels.sources.activeTab][0] &&
-    data.sources[panels.sources.activeTab][0].nodeType === 'COUNTRY OF PRODUCTION';
+    data.sources[panels.sources.activeTab][0].nodeType === NODE_TYPES.countryOfProduction;
   const isCountryProfile = isDestinationCountryProfile || isProductionCountryProfile;
   const getProfileType = () => {
     if (isCountryProfile) return 'country';

--- a/frontend/scripts/react-components/shared/profile-selector/profile-selector.reducer.js
+++ b/frontend/scripts/react-components/shared/profile-selector/profile-selector.reducer.js
@@ -2,6 +2,7 @@ import immer from 'immer';
 import createReducer from 'utils/createReducer';
 import fuzzySearch from 'utils/fuzzySearch';
 import { getPanelName } from 'utils/getProfilePanelName';
+import { NODE_TYPES } from 'constants';
 import {
   PROFILES__SET_ACTIVE_STEP,
   PROFILES__SET_PANEL_DATA,
@@ -62,7 +63,7 @@ const profilesReducer = {
       }
 
       // Select country of production item (there is only one) when country of production its the first tab
-      if (panelName === 'sources' && data && data[0].nodeType === 'COUNTRY OF PRODUCTION') {
+      if (panelName === 'sources' && data && data[0].nodeType === NODE_TYPES.countryOfProduction) {
         draft.panels.sources.activeTab = tab;
         draft.panels.sources.activeItems = [data[0].id];
 
@@ -184,7 +185,10 @@ const profilesReducer = {
 
       // If a country source is selected set the country item as active
       if (panel === 'sources') {
-        const { tabs: { sources }, data } = state;
+        const {
+          tabs: { sources },
+          data
+        } = state;
         const countryTab = sources.find(t => t.profile_type === 'country');
         if (activeTab === countryTab.id) {
           draft.panels.sources.activeItems = [data.sources[countryTab.id][0].id];

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -328,7 +328,6 @@ function Sankey(props) {
           };
         })
         .filter(Boolean);
-      console.log('node', nodeIndicators, nodeAttributes, node);
       tooltip.items.push(...nodeIndicators);
 
       if (otherNodeCount) {

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -307,7 +307,14 @@ function Sankey(props) {
           : node.x + sankeyColumnsWidth,
       y: node.y - tooltipPadding
     };
-    if (nodeAttributes && selectedMapDimensions && selectedMapDimensions.length > 0) {
+
+    // Importer countries (Country of production) should only show the trade volume on the tooltip
+    if (
+      nodeAttributes &&
+      selectedMapDimensions &&
+      selectedMapDimensions.length > 0 &&
+      node.type !== NODE_TYPES.countryOfProduction
+    ) {
       const nodeIndicators = selectedMapDimensions
         .map(dimension => {
           const meta = getNodeMeta(dimension, node, nodeAttributes, selectedResizeBy, nodeHeights);
@@ -321,7 +328,7 @@ function Sankey(props) {
           };
         })
         .filter(Boolean);
-
+      console.log('node', nodeIndicators, nodeAttributes, node);
       tooltip.items.push(...nodeIndicators);
 
       if (otherNodeCount) {


### PR DESCRIPTION
DONT MERGE: We still want to confirm if we want to remove the whole tooltip or keep trade volume

## Asana
https://app.asana.com/0/1187619191620560/1199241958941726/f

## Description

![image](https://user-images.githubusercontent.com/9701591/107223375-67e7c780-6a16-11eb-8e53-5893456b4dd7.png)

Only show any trade volume on the Importer countries tooltip

## Testing instructions

Go to the Sankey (e.g. Brazil - Soy )- Choose Country of production on the first column - Hover over the Country of production node