### PR TITLE
Capitalise region names on the place profiles

### DIFF
--- a/app/services/api/v3/places/basic_attributes.rb
+++ b/app/services/api/v3/places/basic_attributes.rb
@@ -257,13 +257,13 @@ module Api
           return '' unless @commodity_production
 
           if @commodity_production.zero?
-            return "<span class=\"notranslate\">#{@node.name.titleize}</span> \
+            return "<span class=\"notranslate\">#{@node.name.capitalize}</span> \
 did not produce any #{@commodity_name} in \
 <span class=\"notranslate\">#{@year}</span>."
           end
 
           summary_text = "In <span class=\"notranslate\">#{@year}</span>, \
-<span class=\"notranslate\">#{@node.name.titleize}</span> produced \
+<span class=\"notranslate\">#{@node.name.capitalize}</span> produced \
 <span class=\"notranslate\">#{@commodity_production_formatted}</span> \
 <span class=\"notranslate\">#{@commodity_production_unit}</span> of \
 <span class=\"notranslate\">#{@commodity_name}</span>"
@@ -331,7 +331,7 @@ production#{state_ranking_text}."
         def summary_of_top_exporter_and_top_consumer
           top_exporter = @top_exporters.first
           if top_exporter.present?
-            top_exporter_name = top_exporter['name']&.titleize
+            top_exporter_name = top_exporter['name']&.capitalize
             if @total_exports.present?
               percentage_total_exports = helper.number_to_percentage(
                 ((top_exporter[:value] || 0) / @total_exports) * 100,
@@ -345,7 +345,7 @@ production#{state_ranking_text}."
 
           if top_exporter && percentage_total_exports && top_consumer
             " The largest exporter of #{@commodity_name} in \
-<span class=\"notranslate\">#{@node.name.titleize}</span> was \
+<span class=\"notranslate\">#{@node.name.capitalize}</span> was \
 <span class=\"notranslate\">#{top_exporter_name}</span>, which accounted for \
 <span class=\"notranslate\">#{percentage_total_exports}</span> of \
 the total exports, and the main destination was \


### PR DESCRIPTION
## Asana

https://app.asana.com/0/inbox/1191186791596033

## Description

These can be companies (notably for Indonesia Wood Pulp) where the capitalisation is a trademark. To get around this we always present these company names in UPPERCASE to make it clear that we are not implying any specific capitalisation.

This PR relates to the following screenshot of a indonesia pulp wood wood supplier profile:

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/5887227/107486854-ced7be80-6b85-11eb-870a-9eeba7a741c6.png">

## Testing instructions

Check the wood supplier profiles for indonesia wood pulp and ensure that the company names are always in capitals.

