### PR TITLE
Disable AppSignal in staging, demo and indonesiademo

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -44,7 +44,7 @@ production:
 
 staging:
   <<: *defaults
-  active: true
+  active: false
 
 sandbox:
   <<: *defaults
@@ -52,8 +52,8 @@ sandbox:
 
 demo:
   <<: *defaults
-  active: true
+  active: false
 
 indonesiademo:
   <<: *defaults
-  active: true
+  active: false


### PR DESCRIPTION
Leave exception reporting in sandbox and production to reduce noise.