### PR TITLE
Feature/add province on wood supplier profiles

### DIFF
--- a/app/services/api/v3/places/basic_attributes.rb
+++ b/app/services/api/v3/places/basic_attributes.rb
@@ -119,7 +119,8 @@ module Api
             label = "jurisdiction_#{chart_node_type.position + 1}"
             instance_variable_set("@#{label}", node)
             attributes[:"#{label}"] = node_name
-            attributes[:"#{label}_geo_id"] = node.geo_id if node
+            attributes[:"#{label}_geo_id"] = node&.geo_id
+            attributes[:"#{label}_label"] = node_type.name
           end
           attributes
         end

--- a/frontend/scripts/react-components/profile/profile-components/summary/place-summary.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-components/summary/place-summary.component.jsx
@@ -24,8 +24,10 @@ function PlaceSummary(props) {
       summary,
       jurisdictionName,
       jurisdictionGeoId,
-      jurisdiction1: stateName,
-      jurisdiction2: biomeName,
+      jurisdiction1: jurisdiction1Name,
+      jurisdiction1Label,
+      jurisdiction2: jurisdiction2Name,
+      jurisdiction2Label,
       headerAttributes
     } = {},
     profileMetadata: { mainTopojsonPath, mainTopojsonRoot, years } = {}
@@ -44,8 +46,8 @@ function PlaceSummary(props) {
       onChange: newYear => onChange('year', newYear)
     },
     { name: capitalize(countryName), label: 'Country' },
-    { name: capitalize(biomeName), label: 'Biome' },
-    { name: capitalize(stateName), label: 'State' }
+    { name: capitalize(jurisdiction2Name), label: jurisdiction2Label || 'Biome' },
+    { name: capitalize(jurisdiction1Name), label: jurisdiction1Label || 'State' }
   ];
 
   const renderMunicipalityMap = () => (


### PR DESCRIPTION
## Asana

https://app.asana.com/0/0/1199524591779678/f

## Description

I verified that when data is present (node_quals values for qual PROVINCE), the province will come up. However, it comes up as a "STATE".

<img width="837" alt="Screenshot 2021-02-18 at 10 46 37" src="https://user-images.githubusercontent.com/134055/108338765-ea227980-71d6-11eb-847d-0c41a37cb296.png">

I added a label property to the API and applied the change to the summary component (this is from local env where I didn't have the Indonesia wood pulp to test, so I did a dummy label test instead).

<img width="613" alt="Screenshot 2021-02-18 at 10 50 25" src="https://user-images.githubusercontent.com/134055/108339071-46859900-71d7-11eb-9299-66bc2b08a45c.png">

