### PR TITLE
Fixes failing validation when creating users (regression from token authentication)

### DIFF
--- a/app/models/content/user.rb
+++ b/app/models/content/user.rb
@@ -30,5 +30,10 @@ module Content
     devise :database_authenticatable,
            :recoverable, :rememberable, :trackable, :validatable
     include DeviseTokenAuth::Concerns::User
+
+    before_validation do |user|
+      user.provider ||= 'email'
+      user.uid ||= email
+    end
   end
 end


### PR DESCRIPTION
## Description

Creating users in the CMS was affected by db changes related to token authentication. We need to populate provider / uid fields, otherwise validations prevent the user from saving.