### PR TITLE
Add scroll offset to y tooltip reference

### DIFF
--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -295,6 +295,7 @@ function Sankey(props) {
     const rect = getRect(toolLayout);
     const nodeHeight = nodeHeights[node.id];
     const otherNodeCount = otherNodes && otherNodes[node.id] && otherNodes[node.id].count;
+    const scrollY = scrollContainerRef?.current?.scrollTop || 0;
     const tooltipPadding = 10;
     const minTooltipWidth = 180;
     const tooltip = {
@@ -313,7 +314,7 @@ function Sankey(props) {
         node.x + sankeyColumnsWidth + tooltipPadding > rect.width - minTooltipWidth
           ? node.x
           : node.x + sankeyColumnsWidth,
-      y: node.y - tooltipPadding
+      y: node.y - tooltipPadding - scrollY
     };
 
     // Importer countries (Country of production) should only show the trade volume on the tooltip


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1198886845396491/1199904387610021/f

## Description

Scrolling was not working well with tooltips on the nodes of the sankey. When you select all nodes and you scrolled the tooltip was misplaced or gone.

![image](https://user-images.githubusercontent.com/9701591/109187248-018ed300-7792-11eb-96e5-48c5bd2f35d1.png)

## Testing instructions

- Go to any context with many nodes ex. Brazil-Soy
- Change 'Change view' to "All nodes"
- Scroll down
- Hover over a node - The tooltip should appear correctly
