### PR TITLE
Optional contexts on analytics event

### DIFF
--- a/frontend/scripts/analytics/data-portal.events.js
+++ b/frontend/scripts/analytics/data-portal.events.js
@@ -17,8 +17,8 @@ export default [
       const payload = Object.assign(
         {},
         {
-          country: context.countryName,
-          commodity: context.commodityName
+          country: context?.countryName,
+          commodity: context?.commodityName
         },
         action.payload
       );


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1187619191620560/1199979503038581/f

## Description

The analytics event on the logistics download was causing an error as we dont have contexts for this

## Testing instructions

Go to downloads page. Select logistics bulk download and try to download one.
