### PR TITLE
Add unit to default chart on widgets

### DIFF
--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget-label.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget-label.component.jsx
@@ -10,18 +10,24 @@ const regularSuffix = (text, suffix) => (
 );
 
 const DashboardWidgetLabel = props => {
-  const { text, suffix } = props;
+  const { text, suffix, axis } = props;
   const isSuffixPercentage = suffix === '%';
+  const yAxisContent = isSuffixPercentage ? percentageSuffix(text, suffix) : regularSuffix(text, suffix);
   return (
-    <p className="widget-yAxis-label">
-      {isSuffixPercentage ? percentageSuffix(text, suffix) : regularSuffix(text, suffix)}
+    <p className={`widget-${axis}Axis-label`}>
+      {axis === 'y' ? yAxisContent : text}
     </p>
   );
 };
 
 DashboardWidgetLabel.propTypes = {
   text: PropTypes.string.isRequired,
-  suffix: PropTypes.string.isRequired
+  suffix: PropTypes.string.isRequired,
+  axis: PropTypes.string
+};
+
+DashboardWidgetLabel.defaultProps = {
+  axis: 'y'
 };
 
 export default DashboardWidgetLabel;

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.component.jsx
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.component.jsx
@@ -137,6 +137,12 @@ function DashboardWidget(props) {
               testId="widget-chart"
               containerRef={widgetBoxRef}
             />
+            {chartConfig.xAxisLabel && (
+              <DashboardWidgetLabel
+                axis="x"
+                text={chartConfig.xAxisLabel.suffix}
+              />
+            )}
           </React.Fragment>
         );
     }

--- a/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.scss
+++ b/frontend/scripts/react-components/dashboard-element/dashboard-widget/dashboard-widget.scss
@@ -62,18 +62,29 @@ $this: 'c-dashboard-widget';
       width: 100%;
     }
 
-    .widget-yAxis-label {
+    .axis-label {
       font-family: $font-family-1;
       font-size: 11px;
       position: relative;
-      top: 25px;
-      margin-left: 42px;
-      text-transform: uppercase;
 
       .widget-yAxis-label-unit {
         margin: 0 0 0 10px;
         text-transform: none;
       }
+    }
+
+    .widget-xAxis-label {
+      @extend .axis-label;
+      margin-right: 42px;
+      bottom: 25px;
+      text-align: right;
+    }
+
+    .widget-yAxis-label {
+      @extend .axis-label;
+      text-transform: uppercase;
+      top: 25px;
+      margin-left: 42px;
     }
 
     .widget-chart {
@@ -96,7 +107,7 @@ $this: 'c-dashboard-widget';
       border: solid 1px rgba($white, 0.13);
     }
 
-    .widget-yAxis-label {
+    .widget-yAxis-label, .widget-xAxis-label {
       color: $elephant;
     }
 
@@ -116,7 +127,7 @@ $this: 'c-dashboard-widget';
       background-color: $white;
     }
 
-    .widget-yAxis-label {
+    .widget-yAxis-label, .widget-xAxis-label {
       color: $charcoal-grey-faded;
     }
 


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1198886845396491/1199896185325402/f

## Description

Add suffix as the unit to the charts. We only need it on the default charts as the others have the unit implemented. Is important not to use caps as 't' is a different unit than 'T'

![image](https://user-images.githubusercontent.com/9701591/109666472-80f41c00-7b6f-11eb-8ad2-1fd897a78d3c.png)


## Testing instructions

Go to the data view of any context. You should be able to see the units on the lower right of the default charts. Change some indicator and units just to test