### PR TITLE
Terminate refresh worker immediately if context is no longer available

### DIFF
--- a/app/workers/node_with_flows_refresh_actor_basic_attributes_worker.rb
+++ b/app/workers/node_with_flows_refresh_actor_basic_attributes_worker.rb
@@ -6,14 +6,17 @@ class NodeWithFlowsRefreshActorBasicAttributesWorker
                   backtrace: true
 
   def perform(node_id, context_id)
+    context = Api::V3::Context.find(context_id)
     node_with_flows = Api::V3::Readonly::NodeWithFlows.
       without_unknowns.
       without_domestic.
       find_by(
-        id: node_id, context_id: context_id
+        id: node_id, context_id: context.id
       )
     return unless node_with_flows
 
     node_with_flows.refresh_actor_basic_attributes
+  rescue ActiveRecord::RecordNotFound
+    # no-op
   end
 end


### PR DESCRIPTION
## Asana

https://appsignal.com/vizzuality/sites/5ac78a01fc940e7ec5927d5b/exceptions/incidents/320

## Description

When context goes missing after the worker had been scheduled, it fails with an exception way down in the basic attributes service. Instead it should bail out immediately, silently.
