### PR TITLE
Fix URL for insights page

### DIFF
--- a/frontend/scripts/react-components/nav/top-nav-redesign/tabs/tools-insights.component.jsx
+++ b/frontend/scripts/react-components/nav/top-nav-redesign/tabs/tools-insights.component.jsx
@@ -74,7 +74,7 @@ const ToolsInsights = () => {
           </li>
           <li>
             <a
-              href="https://insights.trase.earth/insights"
+              href="https://insights.trase.earth"
               className="sites-menu-link"
               onMouseOver={() => setActiveCard(2)}
               onFocus={() => setActiveCard(2)}

--- a/frontend/scripts/router/nav-links.js
+++ b/frontend/scripts/router/nav-links.js
@@ -56,7 +56,7 @@ let nav = [
   },
   !ENABLE_TOP_NAV_REDESIGN && {
     name: 'Insights',
-    page: 'https://insights.trase.earth/insights',
+    page: 'https://insights.trase.earth',
     external: true
   },
   {


### PR DESCRIPTION
The top nav bar is linking to https://insights.trase.earth/insights. I'm not sure if this was intentional, but these days it should be https://insights.trase.earth

