### PR TITLE
Add indicator colors for soy and beef products

### DIFF
--- a/frontend/styles/_settings.scss
+++ b/frontend/styles/_settings.scss
@@ -196,9 +196,18 @@ $recolorby-qual-thematic-bovine-offals: #a6611a;
 $recolorby-qual-thematic-live-cattle-exports: #e7298a;
 $recolorby-qual-thematic-processed-beef-products: #7570b3;
 
+$recolorby-qual-thematic-beef: #43f3f3;
+$recolorby-qual-thematic-beef-boneless: #8c28ff;
+$recolorby-qual-thematic-beef-offals: #72ea28;
+$recolorby-qual-thematic-meat-preparations: #ffb314;
+
 $recolorby-qual-thematic-green: #31a354;
 $recolorby-qual-thematic-roasted: #a6611a;
 $recolorby-qual-thematic-processed: #7570b3;
+
+$recolorby-qual-thematic-soybean-oil: #f7fcb9;
+$recolorby-qual-thematic-soybean: #31a354;
+$recolorby-qual-thematic-soybean-cake: #e48716;
 
 $recolorby-qual-thematic-oil: #f7fcb9;
 $recolorby-qual-thematic-bean: #31a354;
@@ -304,12 +313,19 @@ $recolorby-colors: (
   'recolorby-qual-thematic-live-cattle-exports': $recolorby-qual-thematic-live-cattle-exports,
   'recolorby-qual-thematic-processed-beef-products':
     $recolorby-qual-thematic-processed-beef-products,
+  'recolorby-qual-thematic-beef': $recolorby-qual-thematic-beef,
+  'recolorby-qual-thematic-beef-boneless': $recolorby-qual-thematic-beef-boneless,
+  'recolorby-qual-thematic-beef-offals': $recolorby-qual-thematic-beef-offals,
+  'recolorby-qual-thematic-meat-preparations': $recolorby-qual-thematic-meat-preparations,
   'recolorby-qual-thematic-green': $recolorby-qual-thematic-green,
   'recolorby-qual-thematic-roasted': $recolorby-qual-thematic-roasted,
   'recolorby-qual-thematic-processed': $recolorby-qual-thematic-processed,
   'recolorby-qual-thematic-bean': $recolorby-qual-thematic-bean,
   'recolorby-qual-thematic-cake': $recolorby-qual-thematic-cake,
   'recolorby-qual-thematic-oil': $recolorby-qual-thematic-oil,
+  'recolorby-qual-thematic-soybeans': $recolorby-qual-thematic-bean,
+  'recolorby-qual-thematic-soybean-cake': $recolorby-qual-thematic-cake,
+  'recolorby-qual-thematic-soybean-oil': $recolorby-qual-thematic-oil,
   'recolorby-qual-thematic-crude-palm-oil': $recolorby-qual-thematic-crude-palm-oil,
   'recolorby-qual-thematic-refined-palm-oil': $recolorby-qual-thematic-refined-palm-oil,
   'recolorby-qual-thematic-paper-grade-pulp': $recolorby-qual-thematic-paper-grade-pulp,


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1199888630756445/1200121713476651/f
## Description

Set up colors for the new indicator product. Which will have different values for each commodity. Right now we added the colors for soy and meat. This should work for example in Argentina - Soy as well as Paraguay - Soy
![image](https://user-images.githubusercontent.com/9701591/114154844-2180ed00-9921-11eb-9a84-597ccead0489.png)


## Testing instructions

Go to the Sankey in Paraguay - Beef for example. Choose product on the change indicator button. You should see the new colors