### PR TITLE
Feature/gdp format

### DIFF
--- a/frontend/scripts/constants.js
+++ b/frontend/scripts/constants.js
@@ -3,6 +3,7 @@ export const NUM_DECIMALS = {
   // resize by
   'trade volume': 0,
   volume: 0,
+  gdp: 0,
   'land use': 0,
   'financial flow': 0,
   'territorial deforestation': 0,
@@ -33,6 +34,10 @@ export const NUM_DECIMALS = {
   area: 0,
   percentage: 1,
   tons: 0
+};
+
+export const NUM_EXPONENT_ROUNDING = {
+  gdp: 6 // millions
 };
 
 export const NUM_DECIMALS_DEFAULT = 1;

--- a/frontend/scripts/react-components/profile/profile-components/summary/actor-summary.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-components/summary/actor-summary.component.jsx
@@ -116,7 +116,7 @@ class ActorSummary extends React.PureComponent {
             {tooltip && <HelpTooltip text={tooltip} />}
           </Text>
           <Text as="span" variant="mono" size="lg" weight="bold">
-            {formatValue(value, indicatorKey)}
+            {formatValue(value, name)}
           </Text>
           <Text as="span" variant="mono" size="lg" weight="bold">
             {' '}

--- a/frontend/scripts/react-components/profile/profile-components/summary/country-summary.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-components/summary/country-summary.component.jsx
@@ -94,7 +94,7 @@ function CountrySummary(props) {
           </Text>
         )}
         <Text as="span" variant="mono" size="lg" weight="bold">
-          {formatValue(value, indicatorKey)}
+          {formatValue(value, name)}
         </Text>
         {suffix && suffix !== 'people' && (
           <Text as="span" variant="mono" size="lg" weight="bold">

--- a/frontend/scripts/react-components/profile/profile-components/summary/place-summary.component.jsx
+++ b/frontend/scripts/react-components/profile/profile-components/summary/place-summary.component.jsx
@@ -84,7 +84,7 @@ function PlaceSummary(props) {
                 {tooltip && <HelpTooltip text={tooltip} />}
               </Text>
               <Text as="span" variant="mono" size="lg" weight="bold">
-                {formatValue(value, indicatorKey)}
+                {formatValue(value, name)}
               </Text>
               <Text as="span" variant="mono" size="lg" weight="bold">
                 {' '}

--- a/frontend/scripts/utils/formatValue.js
+++ b/frontend/scripts/utils/formatValue.js
@@ -1,4 +1,5 @@
-import { NUM_DECIMALS, NUM_DECIMALS_DEFAULT } from 'constants';
+import { NUM_DECIMALS, NUM_DECIMALS_DEFAULT, NUM_EXPONENT_ROUNDING } from 'constants';
+import { formatPrefix } from 'd3-format';
 
 // returns a value rounded to numDecimals
 export default (value, dimensionName) => {
@@ -10,11 +11,15 @@ export default (value, dimensionName) => {
   }
 
   let maximumFractionDigits = NUM_DECIMALS_DEFAULT;
-
   const dimensionNameLower = dimensionName.toLowerCase();
 
   if (NUM_DECIMALS[dimensionNameLower] !== undefined) {
     maximumFractionDigits = NUM_DECIMALS[dimensionNameLower];
+  }
+
+  const exponentToRoundTo = NUM_EXPONENT_ROUNDING[dimensionNameLower];
+  if (exponentToRoundTo) {
+    return formatPrefix(',.0', parseFloat(`1e${exponentToRoundTo}`))(value);
   }
 
   if (maximumFractionDigits === 0 && value < 1 && value > 0) {

--- a/frontend/scripts/utils/transifex.js
+++ b/frontend/scripts/utils/transifex.js
@@ -1,7 +1,6 @@
 export function translateText(str) {
   const { Transifex } = window;
   if (typeof Transifex !== 'undefined' && str) {
-    console.log('translatable', str);
     return Transifex.live.translateText(str);
   }
   console.warn('Attempted translation before transifex finished loading:', str);


### PR DESCRIPTION
## Asana

https://app.asana.com/0/0/1200124803845193/f

## Description

GDP should be rounded to millions on country profiles. This is specified on the constants.
Also, fix the decimals of place and actor profiles. No example is given as there are probably none. But they could be. NUM_DECIMALS constant has the decimals for each indicator that should be the same in all the platform.

![image](https://user-images.githubusercontent.com/9701591/114434853-c6baf000-9bc3-11eb-86e8-86ad1460994f.png)

## Testing instructions

Go to Argentina Beef (f.e) and check the summary indicators
