### PR TITLE
Include env name in map attributes export for Carto sync

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,3 +33,6 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=
 S3_BUCKET_NAME= # name of bucket where db dumps are stored
+
+CARTO_ACCOUNT=
+CARTO_TOKEN=

--- a/app/services/api/v3/map_attributes_carto_sync.rb
+++ b/app/services/api/v3/map_attributes_carto_sync.rb
@@ -1,0 +1,47 @@
+# This service is startted by MapAttributesExport.
+module Api
+  module V3
+    class MapAttributesCartoSync
+      def initialize(carto_name)
+        @carto_name = carto_name
+      end
+
+      def call
+        # get list of current synchronisations from Carto
+        list = sync_tables_list
+        # find the one we need by name
+        sync = list.find { |s| s['name'] == @carto_name }
+        return unless sync
+
+        # force sync
+        force_sync(sync['id'])
+      end
+
+      private
+
+      def host
+        "#{ENV['CARTO_ACCOUNT']}.carto.com"
+      end
+
+      def auth
+        "api_key=#{ENV['CARTO_TOKEN']}"
+      end
+
+      def sync_tables_list
+        uri = URI("https://#{host}/api/v1/synchronizations/?#{auth}")
+        request = Net::HTTP::Get.new(uri.path + '?' + uri.query)
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(request) }
+        data = JSON.parse(response.body)
+        data['synchronizations']
+      end
+
+      def force_sync(import_id)
+        uri = URI("https://#{host}/api/v1/synchronizations/#{import_id}/sync_now?#{auth}")
+        request = Net::HTTP::Put.new(uri.path + '?' + uri.query)
+        request['Content-Type'] = 'application/json'
+        request['Content-Length'] = 0
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |http| http.request(request) }
+      end
+    end
+  end
+end

--- a/app/services/api/v3/map_attributes_export.rb
+++ b/app/services/api/v3/map_attributes_export.rb
@@ -17,6 +17,7 @@ module Api
         generate_csv
         unless Rails.env.development? || Rails.env.test?
           upload_to_s3
+          Api::V3::MapAttributesCartoSync.new(Rails.env, @carto_name)
         end
       end
 

--- a/app/services/api/v3/map_attributes_export.rb
+++ b/app/services/api/v3/map_attributes_export.rb
@@ -6,12 +6,11 @@ module Api
     class MapAttributesExport
       EXPORT_DIR = 'tmp/export'.freeze
       S3_PREFIX = 'SITE_CONTENT'.freeze
-      FILENAME = 'map_attributes_values.csv.gz'.freeze
 
       def initialize
-        @local_filename = EXPORT_DIR + '/' + FILENAME
-        @s3_filename =
-          S3_PREFIX + '/' + Rails.env.upcase + '/' + FILENAME
+        @carto_name = "map_attributes_values_#{Rails.env.downcase}"
+        @local_filename = EXPORT_DIR + '/' + @carto_name + '.csv.gz'
+        @s3_filename = S3_PREFIX + '/' + Rails.env.upcase + '/' + @carto_name + '.csv.gz'
       end
 
       def call
@@ -58,9 +57,9 @@ module Api
         S3::CannedAcl.instance.call(@s3_filename, 'public-read')
       end
 
-        def dir_exists?
-          File.directory?(EXPORT_DIR)
-        end
+      def dir_exists?
+        File.directory?(EXPORT_DIR)
+      end
     end
   end
 end

--- a/spec/services/api/v3/map_attributes_export_spec.rb
+++ b/spec/services/api/v3/map_attributes_export_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V3::MapAttributesExport do
     end
     let(:subject) { Api::V3::MapAttributesExport.new }
     it 'should generate file' do
-      filepath = 'spec/support/export/' + Api::V3::MapAttributesExport::FILENAME
+      filepath = 'spec/support/export/map_attributes_values_test.csv.gz'
       subject.call
       expect(File).to exist(filepath)
     end


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1199888630756445/1200090386437941/f

## Description

Apparently file name matters for Carto sync; include the environment name in the exported file name so that it matches the expected table name.
