### PR TITLE
Add loading state to be sure that unit layer is loaded

### DIFF
--- a/frontend/scripts/react-components/tool/map/map.component.jsx
+++ b/frontend/scripts/react-components/tool/map/map.component.jsx
@@ -68,6 +68,7 @@ function MapBoxMap(props) {
   const [viewport, setViewport] = useState({ ...defaultMapView });
   const [loaded, setLoaded] = useState(false);
   const [updatedTooltipValues, updateTooltipValues] = useState(tooltipValues);
+  const [layersLoading, setLayersLoading] = useState(false);
   const [mapAttribution, setMapAttribution] = useState(null);
   const [tooltipData, setTooltip] = useState(null);
 
@@ -146,7 +147,8 @@ function MapBoxMap(props) {
     sourceLayer,
     linkedGeoIds,
     baseLayerInfo,
-    darkBasemap
+    darkBasemap,
+    layersLoading
   );
 
   // Start Tooltip values
@@ -211,9 +213,21 @@ function MapBoxMap(props) {
     );
   }
 
+  // TODO: Find a better solution to fix the race condition not loading the unit layer choropleth on time
+  const unitLayersNotInMap =
+    map && !map.getStyle().layers.some(l => l['source-layer'] === sourceLayer);
+
+  useEffect(() => {
+    if (unitLayersNotInMap) {
+      setLayersLoading(true);
+    }
+    if (layersLoading && !unitLayersNotInMap) {
+      setLayersLoading(false);
+    }
+  }, [unitLayersNotInMap, setLayersLoading]);
+
   const orderedLayers = layers.map(l => ({ ...l, zIndex: layerOrder[l.id] }));
   const minimized = toolLayout === TOOL_LAYOUT.right;
-
   return (
     <div
       ref={mapContainerRef}

--- a/frontend/scripts/react-components/tool/map/map.hooks.js
+++ b/frontend/scripts/react-components/tool/map/map.hooks.js
@@ -11,10 +11,11 @@ export function useChoroplethFeatureState(
   sourceLayer,
   linkedGeoIds,
   baseLayerInfo,
-  darkBasemap
+  darkBasemap,
+  layersLoading
 ) {
   useEffect(() => {
-    if (map && choropleth) {
+    if (map && choropleth && !layersLoading) {
       const choroplethLayerIds = unitLayers?.filter(l => l.hasChoropleth).map(u => u.id);
       const source = choroplethLayerIds && choroplethLayerIds[0]; // Only first choropleth layer is highlighted
       const geoIds = Object.keys(choropleth);
@@ -73,7 +74,16 @@ export function useChoroplethFeatureState(
         });
       }
     }
-  }, [choropleth, map, unitLayers, sourceLayer, linkedGeoIds, baseLayerInfo, darkBasemap]);
+  }, [
+    choropleth,
+    map,
+    unitLayers,
+    sourceLayer,
+    linkedGeoIds,
+    baseLayerInfo,
+    darkBasemap,
+    layersLoading
+  ]);
 }
 
 export function useFitToBounds({


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1199888630756445/1200090386437943/f

## Description

This solution could be improved

The problem is that the unit layer (Eg. paraguay_department) was not loaded on time sometimes to show the choropleth. So the map was showing without the colored choropleth but with a legend.

I added a loading layers state to fix this.

Probably this check is running too many times and can be improved

Also, we have to check if this is the only cause of the missing choropleth

## Testing instructions

Go to a context (Paraguay soy) you should see the choropleth at first no matter how many times you reload (It was showing intermittently before)