### PR TITLE
Remove no-translate.It is aready added on Tag

### DIFF
--- a/frontend/scripts/react-components/shared/tags-group/tags-group.component.jsx
+++ b/frontend/scripts/react-components/shared/tags-group/tags-group.component.jsx
@@ -23,7 +23,7 @@ function TagsGroup(props) {
           align="center"
           key={part.id || part.prefix}
           color={color}
-          className="tag-group-part notranslate"
+          className="tag-group-part"
         >
           {part.prefix && translateText(`${part.prefix} `)}
           {part.value && <Tag {...props} part={part} showDropdown={showDropdown} as={textAs} />}


### PR DESCRIPTION
## Asana

https://app.asana.com/0/0/1200265497316742/f

## Description

Very small change. The prefixes were not being sent to transifex as they had a notranslate class. This is still added on the Tag component so its fine removing it from the tag group

## Testing instructions

You can see that the profixes like "for" and "in" in the data view dont have a notranslate class anymore