### PR TITLE
Downgraded capistrano-passenger back to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ group :development do
   gem 'capistrano-bundler'
   gem 'capistrano-yarn'
   gem 'capistrano-nvm'
-  gem 'capistrano-passenger'
+  gem 'capistrano-passenger', '~> 0.2.0'
   gem 'capistrano-rails', '~> 1.6', require: false
   gem 'capistrano-rvm'
   gem 'ed25519', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,7 +499,7 @@ DEPENDENCIES
   capistrano (~> 3.16)
   capistrano-bundler
   capistrano-nvm
-  capistrano-passenger
+  capistrano-passenger (~> 0.2.0)
   capistrano-rails (~> 1.6)
   capistrano-rvm
   capistrano-yarn


### PR DESCRIPTION
(undefined method `[]' for nil:NilClass)
