### PR TITLE
We need to parse 'YES' and 'NO' values for signatory quals

### DIFF
--- a/app/services/api/v3/country_profiles/basic_attributes.rb
+++ b/app/services/api/v3/country_profiles/basic_attributes.rb
@@ -158,9 +158,11 @@ module Api
         def declarations
           declarations = []
           nydf = @named_summary_attributes[:nydf]
-          declarations << nydf[:name] if nydf && nydf[:value]
+          is_nydf_signatory = (nydf && ActiveModel::Type::Boolean.new.cast(nydf[:value]))
+          declarations << nydf[:name] if is_nydf_signatory
           amsterdam = @named_summary_attributes[:amsterdam]
-          declarations << amsterdam[:name] if amsterdam && amsterdam[:value]
+          is_amsterdam_signatory = (amsterdam && ActiveModel::Type::Boolean.new.cast(amsterdam[:value]))
+          declarations << amsterdam[:name] if is_amsterdam_signatory
           return '' unless declarations.any?
 
           " #{@node.name} is a signatory to the " + declarations.join(' and the ') + '.'

--- a/config/initializers/boolean_false_values.rb
+++ b/config/initializers/boolean_false_values.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Type::Boolean::FALSE_VALUES += ['NO', 'No', 'no', :NO, :No, :no]


### PR DESCRIPTION
## Asana

https://app.asana.com/0/0/1200168441943759/f

## Description

Instead of checking for presence of the signatory quals, we need to parse the YES / NO values.

## Testing instructions

Argentina should not be a signatory of either nydf or adp. Belgium should be a signatory to nydf, but not adp. France should be a signatory to both.
