### PR TITLE
Added ability to lookup both value and year, to enrich tooltips

### DIFF
--- a/app/services/api/v3/actors/basic_attributes.rb
+++ b/app/services/api/v3/actors/basic_attributes.rb
@@ -76,12 +76,12 @@ module Api
             original_attribute = @chart_config.named_attribute(name)
             next nil unless original_attribute
 
-            value = @values.get(
+            attribute_value = @values.get(
               original_attribute.simple_type, original_attribute.id
             )
-            next nil unless value
+            next nil unless attribute_value&.value
 
-            values[name.to_sym] = value
+            values[name.to_sym] = attribute_value.value
 
             chart_attribute = @chart_config.named_chart_attribute(name)
             values[:header_attributes][chart_attribute.identifier.to_sym] =
@@ -94,13 +94,20 @@ module Api
           name_and_tooltip = get_name_and_tooltip.call(
             attribute: chart_attribute.readonly_attribute,
             context: @context,
-            defaults: Api::V3::AttributeNameAndTooltip::NameAndTooltip.new(chart_attribute.display_name, chart_attribute.tooltip_text)
+            defaults: Api::V3::AttributeNameAndTooltip::NameAndTooltip.new(
+              chart_attribute.display_name, chart_attribute.tooltip_text
+            )
           )
+          attribute_value = @values.get(attribute.simple_type, attribute.id)
+          year = attribute_value.year
+          tooltip_text = name_and_tooltip.tooltip_text || ''
+          tooltip_text += "(#{year})" if year && year != @year
           {
-            value: @values.get(attribute.simple_type, attribute.id),
+            value: attribute_value.value,
+            year: year,
             name: name_and_tooltip.display_name,
             unit: chart_attribute.unit,
-            tooltip: name_and_tooltip.tooltip_text
+            tooltip: tooltip_text
           }
         end
 

--- a/app/services/api/v3/country_profiles/basic_attributes.rb
+++ b/app/services/api/v3/country_profiles/basic_attributes.rb
@@ -42,17 +42,17 @@ module Api
         end
 
         def summary
-          surface_area_rank = @external_attribute_value.call 'wb.surface_area.rank'
-          population_rank = @external_attribute_value.call 'wb.population.rank'
-          gdp_rank = @external_attribute_value.call 'wb.gdp.rank'
+          surface_area_rank = @external_attribute_value.call('wb.surface_area.rank')
+          population_rank = @external_attribute_value.call('wb.population.rank')
+          gdp_rank = @external_attribute_value.call('wb.gdp.rank')
           summary = overview(surface_area_rank, population_rank, gdp_rank)
 
-          surface_area = @external_attribute_value.call 'wb.surface_area.value'
-          forested_land_area = @external_attribute_value.call 'wb.forested_land_area.value'
-          agricultural_land_area = @external_attribute_value.call 'wb.agricultural_land_area.value'
+          surface_area = @external_attribute_value.call('wb.surface_area.value')
+          forested_land_area = @external_attribute_value.call('wb.forested_land_area.value')
+          agricultural_land_area = @external_attribute_value.call('wb.agricultural_land_area.value')
           summary << land_summary(surface_area, forested_land_area, agricultural_land_area)
-          summary << hdi
-          summary << declarations
+          summary << hdi_summary
+          summary << declarations_summary
           summary
         end
 
@@ -70,9 +70,17 @@ module Api
           list = ExternalAttributesList.instance
           external = HEADER_ATTRIBUTES.map do |attribute_ref|
             attribute_def = list.call(attribute_ref, substitutions)
+            attribute_value = @external_attribute_value.call(attribute_ref)
+            year = attribute_value.year
+            tooltip = attribute_def[:tooltip]
+            tooltip += " (#{attribute_value.year})" if year && year != @year
             attribute_def.
               except(:short_name, :wb_name).
-              merge(value: @external_attribute_value.call(attribute_ref))
+              merge(
+                value: attribute_value.value,
+                year: year,
+                tooltip: tooltip
+              )
           end.compact
 
           external + @named_header_attributes.values
@@ -87,10 +95,10 @@ module Api
             original_attribute = @chart_config.named_attribute(name)
             next nil unless original_attribute
 
-            value = @values.get(
+            attribute_value = @values.get(
               original_attribute.simple_type, original_attribute.id
             )
-            next nil unless value
+            next nil unless attribute_value&.value
 
             chart_attribute = @chart_config.named_chart_attribute(name)
             values[chart_attribute.identifier.to_sym] =
@@ -105,11 +113,17 @@ module Api
             context: @context,
             defaults: Api::V3::AttributeNameAndTooltip::NameAndTooltip.new(chart_attribute.display_name, chart_attribute.tooltip_text)
           )
+
+          attribute_value = @values.get(attribute.simple_type, attribute.id)
+          year = attribute_value&.year
+          tooltip_text = name_and_tooltip.tooltip_text || ''
+          tooltip_text += "(#{year})" if year && year != @year
           {
-            value: @values.get(attribute.simple_type, attribute.id),
+            value: attribute_value.value,
+            year: year,
             name: name_and_tooltip.display_name,
             unit: chart_attribute.unit,
-            tooltip: name_and_tooltip.tooltip_text
+            tooltip: tooltip_text
           }
         end
 
@@ -119,23 +133,25 @@ module Api
 
         def overview(surface_area_rank, population_rank, gdp_rank)
           summary = "#{@node.name} is the world's"
-          summary << " #{surface_area_rank&.ordinalize} largest country by area"
-          summary << ", #{population_rank&.ordinalize} largest by population size"
-          summary << " and is the world's #{gdp_rank&.ordinalize} largest economy (by GDP)."
+          summary << " #{surface_area_rank&.value&.ordinalize || 'UNKNOWN'} largest country by area"
+          summary << ", #{population_rank&.value&.ordinalize || 'UNKNOWN'} largest by population size"
+          summary << " and is the world's #{gdp_rank&.value&.ordinalize || 'UNKNOWN'} largest economy (by GDP)."
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/PerceivedComplexity
         def land_summary(surface_area, forested_land_area, agricultural_land_area)
-          return '' unless surface_area && (forested_land_area || agricultural_land_area)
+          return '' unless surface_area&.value && (forested_land_area&.value || agricultural_land_area&.value)
 
           if forested_land_area
             forested_percent = helper.number_to_percentage(
-              (forested_land_area * 100.0) / surface_area,
+              (forested_land_area.value * 100.0) / surface_area.value,
               precision: 0
             )
           end
           if agricultural_land_area
             agricultural_percent = helper.number_to_percentage(
-              (agricultural_land_area * 100.0) / surface_area,
+              (agricultural_land_area.value * 100.0) / surface_area.value,
               precision: 0
             )
           end
@@ -147,15 +163,17 @@ module Api
             " Agriculture makes up #{agricultural_percent} of its area."
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/PerceivedComplexity
 
-        def hdi
+        def hdi_summary
           hdi = @named_summary_attributes[:hdi]
           return '' unless hdi && hdi[:value]
 
           " Its Human Development Index score is #{hdi[:value]}."
         end
 
-        def declarations
+        def declarations_summary
           declarations = []
           nydf = @named_summary_attributes[:nydf]
           is_nydf_signatory = (nydf && ActiveModel::Type::Boolean.new.cast(nydf[:value]))

--- a/app/services/api/v3/country_profiles/external_attribute_value.rb
+++ b/app/services/api/v3/country_profiles/external_attribute_value.rb
@@ -2,6 +2,7 @@ module Api
   module V3
     module CountryProfiles
       class ExternalAttributeValue
+        AttributeValue = Struct.new(:value, :year)
         # @param iso_code2 [String]
         # @param year [Integer]
         # @param activity [Symbol] e.g. :exporter, :importer
@@ -50,7 +51,7 @@ module Api
             first
           return nil unless row
 
-          row.send(property)
+          AttributeValue.new(row.send(property), row.send(:year))
         end
 
         # @param attribute_short_name [Symbol] e.g. :population
@@ -70,11 +71,13 @@ module Api
           )
           return nil unless row
 
-          if property == :rank
-            row.send(:"#{attribute_short_name}_rank")
-          else
-            row.send(attribute_short_name)
-          end
+          value =
+            if property == :rank
+              row.send(:"#{attribute_short_name}_rank")
+            else
+              row.send(attribute_short_name)
+            end
+          AttributeValue.new(value, row.send(:year))
         end
       end
     end

--- a/app/services/api/v3/node_attribute_values_preloader.rb
+++ b/app/services/api/v3/node_attribute_values_preloader.rb
@@ -2,6 +2,7 @@ module Api
   module V3
     class NodeAttributeValuesPreloader
       ORIGINAL_TYPES = %w(ind qual quant).freeze
+      AttributeValue = Struct.new(:value, :year)
 
       def initialize(node, year)
         @node = node
@@ -10,6 +11,7 @@ module Api
         @lazy_loaded = Set.new
       end
 
+      # returns AttributeValue
       def get(original_type, original_id)
         return nil unless ORIGINAL_TYPES.include?(original_type)
 
@@ -25,7 +27,7 @@ module Api
         attribute_values_rel = send(:"preload_#{original_type}_values")
         attributes_values_hash = Hash[
           attribute_values_rel.map do |attribute_value|
-            [attribute_value['original_id'], attribute_value.value]
+            [attribute_value['original_id'], AttributeValue.new(attribute_value.value, attribute_value.year)]
           end
         ]
 
@@ -34,17 +36,17 @@ module Api
       end
 
       def preload_ind_values
-        @node.node_inds.select(['ind_id AS original_id', :value]).
+        @node.node_inds.select(['ind_id AS original_id', :value, :year]).
           where('year = ? OR year IS NULL', @year)
       end
 
       def preload_qual_values
-        @node.node_quals.select(['qual_id AS original_id', :value]).
+        @node.node_quals.select(['qual_id AS original_id', :value, :year]).
           where('year = ? OR year IS NULL', @year)
       end
 
       def preload_quant_values
-        @node.node_quants.select(['quant_id AS original_id', :value]).
+        @node.node_quants.select(['quant_id AS original_id', :value, :year]).
           where('year = ? OR year IS NULL', @year)
       end
     end

--- a/app/services/api/v3/places/basic_attributes.rb
+++ b/app/services/api/v3/places/basic_attributes.rb
@@ -111,7 +111,7 @@ module Api
             qual = Api::V3::Qual.find_by_name(node_type.name)
             next unless qual
 
-            node_name = @values.get(qual.simple_type, qual.id)
+            node_name = @values.get(qual.simple_type, qual.id)&.value
             next unless node_name
 
             node = Api::V3::Node.where(node_type_id: node_type.id).
@@ -128,7 +128,7 @@ module Api
         def attribute_value(attribute)
           return nil unless attribute
 
-          @values.get(attribute.simple_type, attribute.id)
+          @values.get(attribute.simple_type, attribute.id)&.value
         end
 
         def initialize_pasture_area
@@ -219,7 +219,9 @@ module Api
           name_and_tooltip = get_name_and_tooltip.call(
             attribute: attribute.readonly_attribute,
             context: @context,
-            defaults: Api::V3::AttributeNameAndTooltip::NameAndTooltip.new(attribute.display_name, attribute.tooltip_text)
+            defaults: Api::V3::AttributeNameAndTooltip::NameAndTooltip.new(
+              attribute.display_name, attribute.tooltip_text
+            )
           )
           {
             value: instance_variable_get("@#{attribute_name}"),

--- a/app/services/api/v3/places/indicators_table.rb
+++ b/app/services/api/v3/places/indicators_table.rb
@@ -26,9 +26,11 @@ module Api
           return unless state_qual
 
           state_name = @values.get(state_qual.simple_type, state_qual.id)
-          return unless state_name.present?
+          return unless state_name&.value
 
-          @state_ranking = StateRanking.new(@context, @node, @year, state_name)
+          @state_ranking = StateRanking.new(
+            @context, @node, @year, state_name.value
+          )
         end
       end
     end

--- a/app/services/api/v3/profiles/indicators_table.rb
+++ b/app/services/api/v3/profiles/indicators_table.rb
@@ -41,8 +41,8 @@ module Api
           values = []
           ranking_scores = []
           chart_config.attributes.each do |attribute|
-            value = @values.get(attribute.simple_type, attribute.id)
-            values << value
+            attribute_value = @values.get(attribute.simple_type, attribute.id)
+            values << attribute_value&.value
             next unless @state_ranking.present?
 
             ranking_scores << @state_ranking.position_for_attribute(


### PR DESCRIPTION
## Asana

https://app.asana.com/0/0/1200168441943744/f

## Description

To make it clear that some WB indicator values might be from previous years, we add the year to the tooltip. The approach could be applied to other indicators, where data does not cover the range of years on a country profile, but for now we only have the fallback behaviour active for WB indicators.

## Testing instructions

Go to https://sandbox.trase.earth/profile-country?nodeId=541&year=2016&contextId=1
Observe, that the value of GDP sometimes does not change when you select different years, that is because the latest year of data is from 2014. So if you're on a more recent year, you should see '(2014)' appended to the tooltip.

<img width="620" alt="Screenshot 2021-05-17 at 13 11 31" src="https://user-images.githubusercontent.com/134055/118479619-87774600-b711-11eb-8eae-f3de8927c0ea.png">

