### PR TITLE
Map attributes query should take one map attribute id only

### DIFF
--- a/app/services/api/v3/node_attributes/filter.rb
+++ b/app/services/api/v3/node_attributes/filter.rb
@@ -45,7 +45,7 @@ module Api
               "#{node_values}.year IN (?) OR #{node_values}.year IS NULL",
               @years
             ).
-            where('maa.map_attribute_id' => @map_attributes.map(&:id)).
+            where('maa.map_attribute_id' => map_attribute.id).
             group(
               "#{node_values}.node_id",
               "#{node_values}.#{attribute_type}_id"


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1199888630756445/1200151592420074/f

## Description

Fixed issue in query, which should filter by a single map attribute id only.
