### PR TITLE
Fixed regression in commodity totals chart

### DIFF
--- a/app/services/api/v3/country_profiles/commodity_totals.rb
+++ b/app/services/api/v3/country_profiles/commodity_totals.rb
@@ -87,7 +87,7 @@ module Api
               @activity,
               node_with_flows.commodity_id
             )
-            quantity = @external_attribute_value.call('com_trade.quantity.value')
+            quantity = @external_attribute_value.call('com_trade.quantity.value')&.value
             quantity = quantity.to_f / 1000 if quantity.present?
             {
               name: node_with_flows['commodity'],


### PR DESCRIPTION
Caused by changes to fetching preloaded attributes value + year

## Asana

https://app.asana.com/0/0/1200168441943744/f
