### PR TITLE
Fixed regression in commodity totals chart (cnt)

### DIFF
--- a/app/services/api/v3/country_profiles/commodity_totals.rb
+++ b/app/services/api/v3/country_profiles/commodity_totals.rb
@@ -92,10 +92,10 @@ module Api
             {
               name: node_with_flows['commodity'],
               values: [
-                @external_attribute_value.call('com_trade.quantity.rank'),
+                @external_attribute_value.call('com_trade.quantity.rank')&.value,
                 production_values[node_with_flows['commodity']],
                 quantity,
-                @external_attribute_value.call('com_trade.value.value')
+                @external_attribute_value.call('com_trade.value.value')&.value
               ]
             }
           end.sort { |a, b| b[:values][2].to_f <=> a[:values][2].to_f }.reject { |r| r[:values].compact.empty? }


### PR DESCRIPTION
Caused by changes to fetching preloaded attributes value + year

## Asana

https://app.asana.com/0/0/1200168441943744/f