### PR TITLE
Fixed source countries chart

### DIFF
--- a/app/controllers/api/v3/country_profiles_controller.rb
+++ b/app/controllers/api/v3/country_profiles_controller.rb
@@ -33,6 +33,9 @@ module Api
       end
 
       def top_consumer_actors
+        if @node.node_type == NodeTypeName::COUNTRY
+          @contexts = Api::V3::Context.where(commodity_id: @node.commodity_id)
+        end
         @result = Api::V3::Profiles::CrossContextTopNodesChart.new(
           @contexts,
           @node,
@@ -48,6 +51,9 @@ module Api
       end
 
       def top_consumer_countries
+        if @node.node_type == NodeTypeName::COUNTRY
+          @contexts = Api::V3::Context.where(commodity_id: @node.commodity_id)
+        end
         @result =
           if @node.node_type == NodeTypeName::COUNTRY_OF_PRODUCTION
             Api::V3::Profiles::CrossContextTopNodesChart.new(

--- a/app/controllers/concerns/api/v3/profiles/cross_context_helpers.rb
+++ b/app/controllers/concerns/api/v3/profiles/cross_context_helpers.rb
@@ -50,6 +50,7 @@ module Api
 
         def ensure_commodity_or_context_given
           return if params[:commodity_id].present? || params[:context_id].present?
+
           raise ActionController::ParameterMissing,
                 "Required param commodity_id or context_id missing"
         end

--- a/app/services/api/v3/country_profiles/top_source_countries_chart.rb
+++ b/app/services/api/v3/country_profiles/top_source_countries_chart.rb
@@ -100,33 +100,27 @@ module Api
           country_names_by_iso2 = Hash[
             country_nodes.map { |n| [n.geo_id, n.name] }
           ]
-          @all_nodes_total = 0
-          result = @com_trade_top_countries.map do |com_trade_record|
-            trase_top_node = @top_nodes_by_iso2[com_trade_record.partner_iso2]
-
-            if trase_top_node
-              # puts "FOUND TRASE NODE"
-              # puts "COM TRADE VALUE: #{com_trade_record.quantity}"
-              # puts "TRASE VALUE: #{trase_top_node['value']}"
-              value = trase_top_node['value']
-              @all_nodes_total += value
-              {
-                node_id: trase_top_node['node_id'],
-                geo_id: trase_top_node['geo_id'],
-                name: trase_top_node['name'],
-                # height: value / @all_nodes_total,
-                value: value
-              }
-            else
-              value = com_trade_record.quantity
-              @all_nodes_total += value
-              {
-                geo_id: com_trade_record.partner_iso2,
-                name: country_names_by_iso2[com_trade_record.partner_iso2],
-                value: value
-              }
-            end
+          result = []
+          @com_trade_top_countries.each do |com_trade_record|
+            result << {
+              geo_id: com_trade_record.partner_iso2,
+              name: country_names_by_iso2[com_trade_record.partner_iso2],
+              value: com_trade_record.quantity
+            }
           end
+          @top_nodes.each do |trase_top_node|
+            result << {
+              node_id: trase_top_node['node_id'],
+              geo_id: trase_top_node['geo_id'],
+              name: trase_top_node['name'],
+              value: trase_top_node['value']
+            }
+          end
+          # sort and take top 10
+          result.sort! { |a, b| a[:value] <=> b[:value] }
+          result = result[0..9]
+          @all_nodes_total = result.map { |n| n[:value] }.inject(:+)
+
           result.map do |record|
             record[:height] = record[:value] / @all_nodes_total
           end


### PR DESCRIPTION
Affected by bad parametrisation and lack of results from com trade.

## Asana

https://app.asana.com/0/0/1200168442660964/f

## Description

Firstly, this chart should be parametrised with commodity id instead of context id, but often it is parametrised incorrectly and in the long run better to protect it from the inside. We need to make sure it always runs a cross-context search.

Secondly, oddly in case of USA there seem to be no results from ComTrade. In such case we should be showing results from Trase only.

## Testing instructions

Go to USA importer profiles and there should be flows on the sourcing countries chart.
<img width="1162" alt="Screenshot 2021-05-19 at 15 49 08" src="https://user-images.githubusercontent.com/134055/118824107-dc55c080-b8b9-11eb-91b0-825190749fe6.png">

