### PR TITLE
Fix/remove double counting in top source countries chart

### DIFF
--- a/app/services/api/v3/country_profiles/basic_attributes.rb
+++ b/app/services/api/v3/country_profiles/basic_attributes.rb
@@ -71,13 +71,13 @@ module Api
           external = HEADER_ATTRIBUTES.map do |attribute_ref|
             attribute_def = list.call(attribute_ref, substitutions)
             attribute_value = @external_attribute_value.call(attribute_ref)
-            year = attribute_value.year
+            year = attribute_value&.year
             tooltip = attribute_def[:tooltip]
-            tooltip += " (#{attribute_value.year})" if year && year != @year
+            tooltip += " (#{year})" if year && year != @year
             attribute_def.
               except(:short_name, :wb_name).
               merge(
-                value: attribute_value.value,
+                value: attribute_value&.value,
                 year: year,
                 tooltip: tooltip
               )

--- a/app/services/api/v3/country_profiles/top_source_countries_chart.rb
+++ b/app/services/api/v3/country_profiles/top_source_countries_chart.rb
@@ -101,19 +101,23 @@ module Api
             country_nodes.map { |n| [n.geo_id, n.name] }
           ]
           result = []
-          @com_trade_top_countries.each do |com_trade_record|
-            result << {
-              geo_id: com_trade_record.partner_iso2,
-              name: country_names_by_iso2[com_trade_record.partner_iso2],
-              value: com_trade_record.quantity.to_f / 1000 # conversion from kg
-            }
-          end
+          included_countries = Set.new
           @top_nodes.each do |trase_top_node|
+            included_countries.add(trase_top_node['geo_id'])
             result << {
               node_id: trase_top_node['node_id'],
               geo_id: trase_top_node['geo_id'],
               name: trase_top_node['name'],
               value: trase_top_node['value']
+            }
+          end
+          @com_trade_top_countries.each do |com_trade_record|
+            next if included_countries.include?(com_trade_record.partner_iso2)
+
+            result << {
+              geo_id: com_trade_record.partner_iso2,
+              name: country_names_by_iso2[com_trade_record.partner_iso2],
+              value: com_trade_record.quantity.to_f / 1000 # conversion from kg
             }
           end
           # sort and take top 10


### PR DESCRIPTION
## Asana

https://app.asana.com/0/0/1200168442660956/f

## Description

Removes double counting, when values come from both Trase and ComTrade.
