### PR TITLE
Simplification for the configuration export endpoint

### DIFF
--- a/app/controllers/api/private/configuration_export_events_controller.rb
+++ b/app/controllers/api/private/configuration_export_events_controller.rb
@@ -7,14 +7,8 @@ module Api
       end
 
       def create
-        started_or_queued_event = Api::Private::ConfigurationExportEvent.started_or_queued.order(created_at: :desc).first
-        if started_or_queued_event.present?
-          render json: started_or_queued_event, root: :data and return
-        end
-
         event = Api::Private::ConfigurationExportEvent.create(started_by: current_user.email)
-        @job_id = ConfigurationExportWorker.perform_async(event.id)
-        event.update_attribute(:jid, @job_id)
+        ConfigurationExportWorker.perform_async(event.id)
         render json: event, root: :data
       end
     end

--- a/app/workers/configuration_export_worker.rb
+++ b/app/workers/configuration_export_worker.rb
@@ -1,15 +1,11 @@
 class ConfigurationExportWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: :low,
-                  retry: false,
-                  backtrace: true,
-                  unique: :until_executed,
-                  run_lock_expiration: 120, # 2 mins
-                  log_duplicate_payload: true
+  sidekiq_options queue: :low
 
   def perform(event_id)
     event = Api::Private::ConfigurationExportEvent.find(event_id)
+    event.update_attribute(:jid, self.jid)
     Api::Private::Configuration::Exporter.new(event).call
   rescue ActiveRecord::RecordNotFound
     # no-op

--- a/frontend/docs/backend/cms_configuration_automation.mdx
+++ b/frontend/docs/backend/cms_configuration_automation.mdx
@@ -75,7 +75,7 @@ This will return immediately, since it only schedules the job in the background 
 Use the `id` from the response body to check for the status of the job:
 
 ```
-curl -H "Content-Type: application/json" -H "access-token:ACCESS_TOKEN" -H "uid:UID" -H "token-type:Bearer" -H "client:CLIENT" https://staging.trase.earthapi/private/configuration_export_events/5
+curl -H "Content-Type: application/json" -H "access-token:ACCESS_TOKEN" -H "uid:UID" -H "token-type:Bearer" -H "client:CLIENT" https://staging.trase.earth/api/private/configuration_export_events/5
 ```
 
 When status is FINISHED, `data` will contain the configuration exported in json format.


### PR DESCRIPTION
There's a problem with jobs getting stuck in QUEUED, might be caused by all the logic we have in place to avoid multiple exports running simultaneously. Simplified by removing that, since it is a read-only operation anyway.
