### PR TITLE
Add default context to link params

### DIFF
--- a/frontend/scripts/react-components/new-home/entrypoints/entrypoints.component.jsx
+++ b/frontend/scripts/react-components/new-home/entrypoints/entrypoints.component.jsx
@@ -10,35 +10,47 @@ import ResizeListener from 'react-components/shared/resize-listener.component';
 
 import './entrypoints.scss';
 
-const ENTRYPOINTS_DATA = [
-  {
-    link: { type: 'tool' },
-    subtitle: 'Supply Chain',
-    text:
-      'Follow trade flows to identify sourcing regions, profile supply chain risks and' +
-      ' assess opportunities for sustainable production.',
-    className: '-supply-chain',
-    src: '/images/backgrounds/home_trase_supply.png'
-  },
-  {
-    link: { type: 'profiles' },
-    subtitle: 'Profile',
-    text:
-      'View the trade and sustainability profile of a particular' +
-      ' company or production region.',
-    className: '-profile',
-    src: '/images/backgrounds/home_trase_profiles.png'
-  },
-  {
-    link: { type: 'tool', payload: { serializerParams: { toolLayout: TOOL_LAYOUT.left } } },
-    subtitle: 'Map',
-    text:
-      'Explore the sustainability of different production regions and identify risks and' +
-      ' opportunities facing downstream buyers.',
-    className: '-map',
-    src: '/images/backgrounds/home_trase_map.png'
-  }
-];
+const getEntrypointsData = defaultContext => {
+  const defaultParams = defaultContext
+    ? {
+        countries: defaultContext.countryId,
+        commodities: defaultContext.commodityId
+      }
+    : {};
+
+  return [
+    {
+      link: { type: 'tool', payload: { serializerParams: defaultParams } },
+      subtitle: 'Supply Chain',
+      text:
+        'Follow trade flows to identify sourcing regions, profile supply chain risks and' +
+        ' assess opportunities for sustainable production.',
+      className: '-supply-chain',
+      src: '/images/backgrounds/home_trase_supply.png'
+    },
+    {
+      link: { type: 'profiles' },
+      subtitle: 'Profile',
+      text:
+        'View the trade and sustainability profile of a particular' +
+        ' company or production region.',
+      className: '-profile',
+      src: '/images/backgrounds/home_trase_profiles.png'
+    },
+    {
+      link: {
+        type: 'tool',
+        payload: { serializerParams: { toolLayout: TOOL_LAYOUT.left, ...defaultParams } }
+      },
+      subtitle: 'Map',
+      text:
+        'Explore the sustainability of different production regions and identify risks and' +
+        ' opportunities facing downstream buyers.',
+      className: '-map',
+      src: '/images/backgrounds/home_trase_map.png'
+    }
+  ];
+};
 
 const Entrypoints = props => {
   const renderEntrypointText = slide => (
@@ -52,14 +64,15 @@ const Entrypoints = props => {
     </>
   );
 
-  const { onClick } = props;
+  const { onClick, defaultContext } = props;
+  const data = getEntrypointsData(defaultContext);
   return (
     <ResizeListener>
       {({ windowWidth }) => {
         const isSmallResolution = windowWidth <= BREAKPOINTS.small;
         return (
           <div className="c-new-entrypoints">
-            {ENTRYPOINTS_DATA.map(slide => (
+            {data.map(slide => (
               <div key={slide.subtitle} className="column">
                 {isSmallResolution ? (
                   <ImgBackground

--- a/frontend/scripts/react-components/new-home/home.component.jsx
+++ b/frontend/scripts/react-components/new-home/home.component.jsx
@@ -5,13 +5,13 @@ import Entrypoints from 'react-components/new-home/entrypoints/entrypoints.compo
 import 'scripts/react-components/new-home/homepage.scss';
 
 const Home = props => {
-  const { clickEntrypoint } = props;
+  const { clickEntrypoint, defaultContext } = props;
 
   return (
     <div className="l-homepage">
       <div className="c-new-homepage">
         <div className="homepage-entrypoints">
-          <Entrypoints onClick={clickEntrypoint} />
+          <Entrypoints onClick={clickEntrypoint} defaultContext={defaultContext} />
         </div>
       </div>
     </div>

--- a/frontend/scripts/react-components/new-home/home.container.js
+++ b/frontend/scripts/react-components/new-home/home.container.js
@@ -1,8 +1,14 @@
 import { connect } from 'react-redux';
 import Home from 'react-components/new-home/home.component';
 import { homeActions } from 'scripts/react-components/new-home/home.register';
+import { getSelectedContext } from 'app/app.selectors';
 
 const mapDispatchToProps = dispatch => ({
   clickEntrypoint: link => dispatch(homeActions.clickEntrypoint(link))
 });
-export default connect(null, mapDispatchToProps)(Home);
+
+const mapStateToProps = state => ({
+  defaultContext: getSelectedContext(state)
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Home);


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1199888630756445/1200396125571535/f

## Description

The link from the homepage to the tool didn't contain the context and was making it impossible to change it.
Maybe we could later check how the tool could work without context.

## Testing instructions

Go from the home links to the tool and change the context