### PR TITLE
Remove map tooltip indicators information

### DIFF
--- a/frontend/scripts/react-components/tool/map/map.selectors.js
+++ b/frontend/scripts/react-components/tool/map/map.selectors.js
@@ -1,11 +1,8 @@
 import { createSelector } from 'reselect';
 import formatValue from 'utils/formatValue';
-import {
-  getSelectedMapDimensionsData,
-  getSelectedMapContextualLayersData
-} from 'react-components/tool-layers/tool-layers.selectors';
+import { getSelectedMapContextualLayersData } from 'react-components/tool-layers/tool-layers.selectors';
 import { getHighlightedNodesData } from 'react-components/tool/tool.selectors';
-import { getSelectedContext, getSelectedYears } from 'app/app.selectors';
+import { getSelectedContext } from 'app/app.selectors';
 import { getSelectedResizeBy } from 'react-components/tool-links/tool-links.selectors';
 import { getContextualLayersTemplates, getRasterLayerTemplate } from './layers/contextual-layers';
 import { getLogisticMapLayerTemplates } from './layers/logistic-layers';
@@ -20,82 +17,23 @@ export const getCountryName = createSelector(
 );
 
 const getHighlightedNodesCoordinates = state => state.toolLayers.highlightedNodeCoordinates;
-const getNodeAttributes = state => state.toolLinks.data.nodeAttributes || null;
 export const getNodeHeights = state => state.toolLinks.data.nodeHeights || null;
-
-const getValue = (unitLayerValues, selectedYears, dimension) => {
-  if (!selectedYears) {
-    return null;
-  }
-  const [firstYear, lastYear] = selectedYears;
-
-  let value = 0;
-  for (let i = firstYear; i <= lastYear; i++) {
-    if (unitLayerValues.years[i]) {
-      value += unitLayerValues.years[i];
-    }
-  }
-
-  // Non-temporal indicator values are stored in year 0
-  if (!value && unitLayerValues.years['0']) {
-    return unitLayerValues.years['0'];
-  }
-
-  if (dimension.aggregationMethod === 'AVG' || dimension.unit === '%' || dimension.type === 'ind') {
-    // Average of the year range
-    value /= lastYear - firstYear + 1;
-  }
-
-  return value;
-};
 
 export const getTooltipValues = createSelector(
   [
-    getNodeAttributes,
-    getSelectedMapDimensionsData,
     getNodeHeights,
     getHighlightedNodesData,
     getHighlightedNodesCoordinates,
     getSelectedResizeBy,
-    getSelectedYears,
     getUnitLayersData
   ],
-  (
-    nodeAttributes,
-    selectedMapDimensions,
-    nodeHeights,
-    nodesData,
-    coordinates,
-    selectedResizeBy,
-    selectedYears,
-    unitLayersData
-  ) => {
-    let values = [];
+  (nodeHeights, nodesData, coordinates, selectedResizeBy, unitLayersData) => {
+    const values = [];
     const node = nodesData && nodesData[0];
     if (!coordinates || !unitLayersData || !node) {
       return null;
     }
     const nodeHeight = nodeHeights && nodeHeights[node.id];
-    if (nodeAttributes && selectedMapDimensions && selectedMapDimensions.length > 0) {
-      values = selectedMapDimensions
-        .map(dimension => {
-          const unitLayerValues = unitLayersData.find(
-            d => d.geo_id === node.geoId && d.attribute_id === dimension.attributeId
-            // && d.node_type_id === nodeTypeId - If we need to find the selected values for a specific nodeTypeId
-          );
-          if (!unitLayerValues) {
-            return null;
-          }
-
-          const indicatorValue = getValue(unitLayerValues, selectedYears, dimension);
-          return {
-            title: dimension.name,
-            unit: dimension.unit,
-            value: formatValue(indicatorValue, dimension.name)
-          };
-        })
-        .filter(Boolean);
-    }
 
     // if node is visible in sankey, quant is available. E.g. Trade Volume
     if (nodeHeight) {


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1187619191620560/1200417420098935/f

## Description

Remove unit indicators information from tooltip layers

before:

![image](https://user-images.githubusercontent.com/9701591/121336911-4216f480-c91c-11eb-9dae-382dfbb6bb8b.png)

after:
![image](https://user-images.githubusercontent.com/9701591/121336983-54912e00-c91c-11eb-811e-6607aac35a3e.png)


## Testing instructions

Hover over the sankey node and the region on the map. Only the sankey node should have that extra information
