### PR TITLE
Exclude attribute values for nodes from non-geo columns

### DIFF
--- a/app/services/api/v3/node_attributes/filter.rb
+++ b/app/services/api/v3/node_attributes/filter.rb
@@ -36,13 +36,19 @@ module Api
           attribute = map_attribute.readonly_attribute
           attribute_type = attribute.original_type.downcase
           node_values_class = attribute.node_values_class
+          cnt_ids = @context.
+            context_node_types.
+            select(:id).
+            joins(:context_node_type_property).
+            where('context_node_type_properties.is_geo_column' => true).
+            pluck(:id)
           node_values = node_values_class.table_name
           node_values_class.
             select(select_list(map_attribute)).
             joins("JOIN nodes ON nodes.id = #{node_values}.node_id").
             joins("JOIN context_node_types cnt ON cnt.node_type_id = nodes.node_type_id").
             joins("JOIN map_#{attribute_type}s maa ON maa.#{attribute_type}_id = #{node_values}.#{attribute_type}_id").
-            where('cnt.context_id' => @context.id).
+            where('cnt.id' => cnt_ids).
             where(
               "#{node_values}.year IN (?) OR #{node_values}.year IS NULL",
               @years
@@ -53,7 +59,6 @@ module Api
               "#{node_values}.#{attribute_type}_id"
             )
         end
-        # 1191
 
         # @param attribute [Api::V3::Readonly::MapAttribute]
         def select_list(map_attribute)


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1201203990997962/1201196267978619/f

## Description

See if it helps to suppress nodes from non-geo columns in the node attributes endpoint

## Testing instructions

https://sandbox.trase.earth/flows?toolLayout=1&countries=107&commodities=87&selectedColumnsIds=0_9-1_24-2_20-3_19

edit map layers, change something there

observe tooltip on Sinar Mas exporter group - it should NOT include any other attribute than volume 

<img width="1148" alt="Screenshot 2021-12-02 at 22 31 27" src="https://user-images.githubusercontent.com/134055/144506472-fa2a5ed7-ad78-4182-a3b2-0494a1446fa2.png">

