### PR TITLE
New endpoint to handle flows on the explore page without cumbersome parametrisation

### DIFF
--- a/app/controllers/api/v3/destination_stats_controller.rb
+++ b/app/controllers/api/v3/destination_stats_controller.rb
@@ -1,0 +1,37 @@
+# This is used on the explore page, so that we can show flows into different destinations
+# without requiring front end to pass the node type id
+# We can currently have several destination node types, depending on context,
+# and parametrisation by FE would be cumbersome.
+module Api
+  module V3
+    class DestinationStatsController < ApiController
+      include ParamHelpers
+
+      before_action :set_filter_params, only: :index
+
+      skip_before_action :load_context
+
+      def index
+        @result = Api::V3::DestinationStats::ResponseBuilder.new(
+          params[:commodity_id],
+          cs_string_to_int_array(params[:contexts_ids]),
+          @filter_params
+        ).call
+
+        render json: {data: @result}
+      end
+
+      private
+
+      def set_filter_params
+        year_start = params[:start_year]
+        @filter_params = {
+          attribute_id: params[:attribute_id],
+          year_start: year_start,
+          year_end: params[:end_year] || year_start,
+          limit: params[:n_nodes]
+        }
+      end
+    end
+  end
+end

--- a/app/services/api/v3/destination_stats/response_builder.rb
+++ b/app/services/api/v3/destination_stats/response_builder.rb
@@ -1,0 +1,123 @@
+# This is used on the explore page, so that we can show flows into different destinations
+# without requiring front end to pass the node type id
+# We can currently have several destination node types, depending on context,
+# and parametrisation by FE would be cumbersome.
+module Api
+  module V3
+    module DestinationStats
+      class ResponseBuilder
+        attr_reader :nodes_stats_by_context_id
+
+        def initialize(commodity_id, contexts_ids, params)
+          @commodity_id = commodity_id
+          @contexts_ids =
+            if @commodity_id
+              Api::V3::Context.
+                joins(:context_property).
+                where(commodity_id: @commodity_id, 'context_properties.is_disabled' => false).
+                pluck(:context_id)
+            else
+              contexts_ids
+            end
+
+          initialize_contexts_by_destination_node_type
+          initialize_params(params)
+          initialize_errors
+        end
+
+        def call
+          @nodes_stats_by_context_id = {}
+          options = {
+            year_start: @year_start,
+            year_end: @year_end
+          }
+          @contexts_ids.map do |context_id|
+            node_type_id = @context_destination_node_types[context_id]
+            nodes_stats_list =
+              Api::V3::Profiles::NodesStatsForContextsList.new(
+                context_id, options.merge(node_type_id: node_type_id)
+              )
+            @nodes_stats_by_context_id[context_id] = nodes_stats_list.sorted_list(@attribute.original_id, limit: @limit)
+          end
+
+          @nodes_stats_by_context_id.map do |context_id, node_stats_list|
+            {
+              context_id: context_id,
+              top_nodes: node_stats_list.map do |node_stats|
+                nodes_stats_information(node_stats)
+              end
+            }
+          end
+        end
+
+        private
+
+        def initialize_contexts_by_destination_node_type
+          destination_context_node_types = Api::V3::ContextNodeType.
+            joins(:node_type).
+            where(
+              'node_types.name' => [
+                NodeTypeName::COUNTRY, NodeTypeName::COUNTRY_OF_IMPORT, NodeTypeName::COUNTRY_OF_DESTINATION
+              ]
+            ).
+            pluck(:context_id, :node_type_id)
+          @context_destination_node_types = Hash[destination_context_node_types]
+        end
+
+        def initialize_params(params)
+          @year_start = params[:year_start]&.to_i
+          @year_end = params[:year_end]&.to_i
+          @limit = params[:limit]&.to_i || 10
+          @attribute_id = params[:attribute_id]
+        end
+
+        def initialize_errors
+          if @year_start && @year_end && @year_start > @year_end
+            raise 'Year start can not be higher than year end'
+          end
+
+          if @commodity_id && (@contexts_ids || []).any?
+            raise 'Either commodity or contexts but not both'
+          end
+
+          @attribute = initialize_attribute
+        end
+
+        def initialize_attribute
+          if @attribute_id
+            attribute = Api::V3::Readonly::Attribute.find_by(
+              id: @attribute_id, original_type: 'Quant'
+            )
+            raise "Attribute #{@attribute_id} not found" unless attribute
+          else
+            volume_quant = Dictionary::Quant.instance.get('Volume')
+            attribute = Api::V3::Readonly::Attribute.find_by(
+              original_id: volume_quant.id, original_type: 'Quant'
+            )
+            raise 'Quant Volume not found' unless attribute
+          end
+          attribute
+        end
+
+        def nodes_stats_information(nodes_stats)
+          {
+            id: nodes_stats.node_id,
+            name: nodes_stats.name,
+            geo_id: nodes_stats.geo_id,
+            attribute: attribute_information(nodes_stats)
+          }
+        end
+
+        def attribute_information(nodes_stats)
+          {
+            id: @attribute.id,
+            indicator: @attribute.display_name,
+            unit: @attribute.unit,
+            value: nodes_stats.value,
+            height: nodes_stats.height
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
       resource :database_validation, controller: :database_validation,
                                      only: [:show]
       resources :nodes_stats, only: [:index]
+      resources :destination_stats, only: [:index]
       namespace :dashboards do
         resources :templates, only: [:index]
         resources :sources, only: [:index] do

--- a/spec/services/api/v3/destination_stats/response_builder_spec.rb
+++ b/spec/services/api/v3/destination_stats/response_builder_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Api::V3::DestinationStats::ResponseBuilder do
+  include_context 'api v3 brazil soy flow quals'
+  include_context 'api v3 brazil soy flow quants'
+
+  before(:each) do
+    Api::V3::Readonly::Attribute.refresh
+    Api::V3::Readonly::NodeStats.refresh
+  end
+
+  describe :nodes_stats do
+    context 'when all options are correct' do
+      it 'should return top countries' do
+        builder = Api::V3::DestinationStats::ResponseBuilder.new(
+          nil,
+          [api_v3_brazil_soy_context.id],
+          node_type_id: api_v3_country_node_type.id,
+          attribute_id: api_v3_volume.readonly_attribute.id,
+          other_attributes_ids: [],
+          year_start: 2015,
+          year_end: 2015
+        )
+
+        builder.call
+
+        expect(builder.nodes_stats_by_context_id[api_v3_brazil_soy_context.id].first['node_id']).to eq(
+          api_v3_country_of_destination1_node.id
+        )
+      end
+    end
+
+    context 'when start_year is greather than end_year' do
+      it 'raise an error' do
+        expect {
+          Api::V3::DestinationStats::ResponseBuilder.new(
+            nil,
+            [api_v3_brazil_soy_context.id],
+            node_type_id: api_v3_country_node_type.id,
+            attribute_id: api_v3_volume.readonly_attribute.id,
+            other_attributes_ids: [],
+            year_start: 2016,
+            year_end: 2015
+          )
+        }.to raise_error(
+          'Year start can not be higher than year end'
+        )
+      end
+    end
+
+    context 'when commodity and contexts are specified' do
+      it 'raise an error' do
+        expect {
+          Api::V3::DestinationStats::ResponseBuilder.new(
+            api_v3_soy.id,
+            [api_v3_brazil_soy_context.id],
+            node_type_id: api_v3_country_node_type.id,
+            attribute_id: api_v3_volume.readonly_attribute.id,
+            other_attributes_ids: [],
+            year_start: 2015,
+            year_end: 2015
+          )
+        }.to raise_error(
+          'Either commodity or contexts but not both'
+        )
+      end
+    end
+
+    context 'when a qual or ind is used as attribute_id' do
+      it 'raise an error' do
+        expect {
+          Api::V3::DestinationStats::ResponseBuilder.new(
+            nil,
+            [api_v3_brazil_soy_context.id],
+            node_type_id: api_v3_country_node_type.id,
+            attribute_id: api_v3_biome.readonly_attribute.id,
+            year_start: 2015,
+            year_end: 2015
+          )
+        }.to raise_error(
+          "Attribute #{api_v3_biome.readonly_attribute.id} not found"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Asana

[Please include the link(s)](https://app.asana.com/0/1201503005195814/1201415552712087/f)

## Description

The idea is to use the [new endpoint destination_stats](https://sandbox.trase.earth/api/v3/destination_stats?contexts_ids=1%2C2%2C4%2C38&attribute_id=1153) 

as replacement for the [old endpoint nodes_stats](https://sandbox.trase.earth/api/v3/nodes_stats?contexts_ids=1%2C2%2C4%2C38&attribute_id=1153&column_id=18)

The new endpoint doesn't allow parametrisation by column_id, because it handles all types of destination node types depending on context. It also doesn't accept other_attributes parameter like the old endpoint (I didn't think it was used on the explore page, and used the opportunity to simplify)

To replace, just change the name of the endpoint and use the current params except the column_id.

