### PR TITLE
Preventing nil exception when data missing

### DIFF
--- a/app/services/api/v3/country_profiles/import_trajectory.rb
+++ b/app/services/api/v3/country_profiles/import_trajectory.rb
@@ -62,7 +62,7 @@ module Api
               @activity
             )
             val_with_year = external_attribute_value.call 'com_trade.value.value'
-            val_with_year.dig(:value)
+            val_with_year&.dig(:value)
           end
         end
       end


### PR DESCRIPTION
## AppSignal

https://appsignal.com/vizzuality/sites/5a8317dfe2954e5d54c8cf8c/exceptions/incidents/330?timestamp=2022-02-16T02%3A24%3A54Z

## Description

undefined method `dig' for nil:NilClass

app/services/api/v3/country_profiles/import_trajectory.rb:65
