### PR TITLE
Not supported on explore mobile

### DIFF
--- a/frontend/scripts/react-components/explore/explore.component.jsx
+++ b/frontend/scripts/react-components/explore/explore.component.jsx
@@ -26,6 +26,9 @@ import {
 
 import 'react-components/explore/explore.scss';
 
+import useWindowSize from 'utils/hooks/useWindowSize';
+import NotSupportedComponent from 'react-components/mobile/not-supported.component';
+
 const ToolLinksModal = React.lazy(() => import(/* webpackPreload: true */ './tool-links-modal'));
 
 function Explore(props) {
@@ -55,6 +58,8 @@ function Explore(props) {
   useClearExploreOnUnmount(props);
   useQuickFacts(props);
   useSankeyCards(props);
+
+  const { width } = useWindowSize();
 
   const destinationCountries = highlightedContext?.id && topNodes[highlightedContext.id];
   const [highlightedCountryIds, setHoveredCommodity] = useHighlightedCountries(props);
@@ -179,6 +184,10 @@ function Explore(props) {
       )}
     </>
   );
+
+  if (width <= BREAKPOINTS.tablet) {
+    return <NotSupportedComponent />;
+  }
 
   return (
     <div className="c-explore">

--- a/frontend/scripts/react-components/explore/explore.selectors.js
+++ b/frontend/scripts/react-components/explore/explore.selectors.js
@@ -87,7 +87,6 @@ export const getCountry = createSelector(
 export const getItems = createSelector(
   [getStep, getCommodities, getCountries],
   (step, commodities, countries) => {
-    console.log('..', commodities, countries, step);
     if (step === EXPLORE_STEPS.selectCommodity) return commodities;
     if (step === EXPLORE_STEPS.selectCountry) return countries;
     return [];

--- a/frontend/scripts/react-components/legacy-explore/explore.component.jsx
+++ b/frontend/scripts/react-components/legacy-explore/explore.component.jsx
@@ -10,7 +10,11 @@ import SentenceSelector from 'react-components/shared/sentence-selector/sentence
 import Button from 'react-components/shared/button/button.component';
 import Heading from 'react-components/shared/heading/heading.component';
 import Text from 'react-components/shared/text/text.component';
-import { EXPLORE_COLUMN_LIST, TOOL_LAYOUT } from 'constants';
+import { EXPLORE_COLUMN_LIST, TOOL_LAYOUT , BREAKPOINTS } from 'constants';
+
+import useWindowSize from 'utils/hooks/useWindowSize';
+import NotSupportedComponent from 'react-components/mobile/not-supported.component';
+
 
 import 'scripts/react-components/legacy-explore/explore.scss';
 
@@ -38,6 +42,8 @@ function Explore(props) {
     }
   }, [topNodesKey, selectedTableColumnType, getTableElements]);
 
+  const { width } = useWindowSize();
+  console.log('-----', width);
   const units = useRef([
     {
       label: '%',
@@ -120,6 +126,10 @@ function Explore(props) {
         </button>
       </div>
     );
+  }
+
+  if (width <= BREAKPOINTS.tablet) {
+    return <NotSupportedComponent />;
   }
 
   return (


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1201503005195814/1201750325605287/f

## Description

Not supported screen on mobile starts now from explore page. It doesn't let the user go to the tool

<img width="372" alt="image" src="https://user-images.githubusercontent.com/9701591/158173795-9b9bd786-762a-45f9-8f5f-31b0c2a89bc8.png">


## Testing instructions

On mobile go to the explore page