### PR TITLE
Fixed refreshing attributes after rounding configuration change

### DIFF
--- a/app/models/api/v3/ind_property.rb
+++ b/app/models/api/v3/ind_property.rb
@@ -2,13 +2,13 @@
 #
 # Table name: ind_properties
 #
-#  id                                                                      :integer          not null, primary key
-#  ind_id                                                                  :integer          not null
-#  display_name(Name of attribute for display)                             :text             not null
-#  unit_type(Type of unit, e.g. score. One of restricted set of values.)   :text
-#  tooltip_text(Generic tooltip text (lowest precedence))                  :text
-#  aggregation_method(To be used with ranges, one of SUM, AVG, MAX or MIN) :text
-#  power_of_ten_for_rounding                                               :integer          default(0), not null
+#  id                                                                                                                                                                         :integer          not null, primary key
+#  ind_id                                                                                                                                                                     :integer          not null
+#  display_name(Name of attribute for display)                                                                                                                                :text             not null
+#  unit_type(Type of unit, e.g. score. One of restricted set of values.)                                                                                                      :text
+#  tooltip_text(Generic tooltip text (lowest precedence))                                                                                                                     :text
+#  aggregation_method(To be used with ranges, one of SUM, AVG, MAX or MIN)                                                                                                    :text
+#  power_of_ten_for_rounding(Values rounded to the nearest 10^n units. So n=0 would be nearest integer, n=1 would be to the nearest ten and n=-1 would be one decimal place.) :integer          default(0), not null
 #
 # Indexes
 #

--- a/app/models/api/v3/quant_property.rb
+++ b/app/models/api/v3/quant_property.rb
@@ -2,13 +2,13 @@
 #
 # Table name: quant_properties
 #
-#  id                                                                      :integer          not null, primary key
-#  quant_id                                                                :integer          not null
-#  display_name(Name of attribute for display)                             :text             not null
-#  unit_type(Type of unit, e.g. count. One of restricted set of values.)   :text
-#  tooltip_text(Generic tooltip text (lowest precedence))                  :text
-#  aggregation_method(To be used with ranges, one of SUM, AVG, MAX or MIN) :text
-#  power_of_ten_for_rounding                                               :integer          default(0), not null
+#  id                                                                                                                                                                         :integer          not null, primary key
+#  quant_id                                                                                                                                                                   :integer          not null
+#  display_name(Name of attribute for display)                                                                                                                                :text             not null
+#  unit_type(Type of unit, e.g. count. One of restricted set of values.)                                                                                                      :text
+#  tooltip_text(Generic tooltip text (lowest precedence))                                                                                                                     :text
+#  aggregation_method(To be used with ranges, one of SUM, AVG, MAX or MIN)                                                                                                    :text
+#  power_of_ten_for_rounding(Values rounded to the nearest 10^n units. So n=0 would be nearest integer, n=1 would be to the nearest ten and n=-1 would be one decimal place.) :integer          default(0), not null
 #
 # Indexes
 #

--- a/db/migrate/20220318110509_refreshing_attributes_after_rounding_configuration_change.rb
+++ b/db/migrate/20220318110509_refreshing_attributes_after_rounding_configuration_change.rb
@@ -1,0 +1,257 @@
+class RefreshingAttributesAfterRoundingConfigurationChange < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute new_upsert
+        Api::V3::Readonly::Attribute.refresh
+      end
+
+      dir.down do |dir|
+        execute old_upsert
+      end
+    end
+  end
+
+  def old_upsert
+    <<~SQL
+      CREATE OR REPLACE FUNCTION public.upsert_attributes() RETURNS void
+          LANGUAGE sql
+          AS $$
+
+      INSERT INTO attributes (
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        aggregation_method,
+        power_of_ten_for_rounding,
+        tooltip_text,
+        tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id,
+        display_name_by_context_id,
+        display_name_by_commodity_id,
+        display_name_by_country_id
+      )
+      SELECT
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        aggregation_method,
+        power_of_ten_for_rounding,
+        tooltip_text,
+        tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id,
+        display_name_by_context_id,
+        display_name_by_commodity_id,
+        display_name_by_country_id
+      FROM attributes_v
+
+      EXCEPT
+
+      SELECT
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        aggregation_method,
+        power_of_ten_for_rounding,
+        tooltip_text,
+        tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id,
+        display_name_by_context_id,
+        display_name_by_commodity_id,
+        display_name_by_country_id
+      FROM attributes
+      ON CONFLICT (name, original_type) DO UPDATE SET
+        original_id = excluded.original_id,
+        display_name = excluded.display_name,
+        unit = excluded.unit,
+        unit_type = excluded.unit_type,
+        aggregation_method = excluded.aggregation_method,
+        tooltip_text = excluded.tooltip_text,
+        tooltip_text_by_context_id = excluded.tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id = excluded.tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id = excluded.tooltip_text_by_country_id,
+        display_name_by_context_id = excluded.display_name_by_context_id,
+        display_name_by_commodity_id = excluded.display_name_by_commodity_id,
+        display_name_by_country_id = excluded.display_name_by_country_id;
+
+      DELETE FROM attributes
+      USING (
+        SELECT
+          original_id,
+          original_type,
+          name,
+          display_name,
+          unit,
+          unit_type,
+          aggregation_method,
+          power_of_ten_for_rounding,
+          tooltip_text,
+          tooltip_text_by_context_id,
+          tooltip_text_by_commodity_id,
+          tooltip_text_by_country_id,
+          display_name_by_context_id,
+          display_name_by_commodity_id,
+          display_name_by_country_id
+        FROM attributes
+
+        EXCEPT
+
+        SELECT
+          original_id,
+          original_type,
+          name,
+          display_name,
+          unit,
+          unit_type,
+          aggregation_method,
+          power_of_ten_for_rounding,
+          tooltip_text,
+          tooltip_text_by_context_id,
+          tooltip_text_by_commodity_id,
+          tooltip_text_by_country_id,
+          display_name_by_context_id,
+          display_name_by_commodity_id,
+          display_name_by_country_id
+        FROM attributes_v
+      ) s
+      WHERE attributes.name = s.name AND attributes.original_type = s.original_type;
+      $$;
+
+      COMMENT ON FUNCTION public.upsert_attributes() IS 'Upserts attributes based on new values as returned by attributes_v (identity by original_type + name)';
+    SQL
+  end
+
+  def new_upsert
+    <<~SQL
+      CREATE OR REPLACE FUNCTION public.upsert_attributes() RETURNS void
+          LANGUAGE sql
+          AS $$
+
+      INSERT INTO attributes (
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        aggregation_method,
+        power_of_ten_for_rounding,
+        tooltip_text,
+        tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id,
+        display_name_by_context_id,
+        display_name_by_commodity_id,
+        display_name_by_country_id
+      )
+      SELECT
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        aggregation_method,
+        power_of_ten_for_rounding,
+        tooltip_text,
+        tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id,
+        display_name_by_context_id,
+        display_name_by_commodity_id,
+        display_name_by_country_id
+      FROM attributes_v
+
+      EXCEPT
+
+      SELECT
+        original_id,
+        original_type,
+        name,
+        display_name,
+        unit,
+        unit_type,
+        aggregation_method,
+        power_of_ten_for_rounding,
+        tooltip_text,
+        tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id,
+        display_name_by_context_id,
+        display_name_by_commodity_id,
+        display_name_by_country_id
+      FROM attributes
+      ON CONFLICT (name, original_type) DO UPDATE SET
+        original_id = excluded.original_id,
+        display_name = excluded.display_name,
+        unit = excluded.unit,
+        unit_type = excluded.unit_type,
+        aggregation_method = excluded.aggregation_method,
+        power_of_ten_for_rounding = excluded.power_of_ten_for_rounding,
+        tooltip_text = excluded.tooltip_text,
+        tooltip_text_by_context_id = excluded.tooltip_text_by_context_id,
+        tooltip_text_by_commodity_id = excluded.tooltip_text_by_commodity_id,
+        tooltip_text_by_country_id = excluded.tooltip_text_by_country_id,
+        display_name_by_context_id = excluded.display_name_by_context_id,
+        display_name_by_commodity_id = excluded.display_name_by_commodity_id,
+        display_name_by_country_id = excluded.display_name_by_country_id;
+
+      DELETE FROM attributes
+      USING (
+        SELECT
+          original_id,
+          original_type,
+          name,
+          display_name,
+          unit,
+          unit_type,
+          aggregation_method,
+          power_of_ten_for_rounding,
+          tooltip_text,
+          tooltip_text_by_context_id,
+          tooltip_text_by_commodity_id,
+          tooltip_text_by_country_id,
+          display_name_by_context_id,
+          display_name_by_commodity_id,
+          display_name_by_country_id
+        FROM attributes
+
+        EXCEPT
+
+        SELECT
+          original_id,
+          original_type,
+          name,
+          display_name,
+          unit,
+          unit_type,
+          aggregation_method,
+          power_of_ten_for_rounding,
+          tooltip_text,
+          tooltip_text_by_context_id,
+          tooltip_text_by_commodity_id,
+          tooltip_text_by_country_id,
+          display_name_by_context_id,
+          display_name_by_commodity_id,
+          display_name_by_country_id
+        FROM attributes_v
+      ) s
+      WHERE attributes.name = s.name AND attributes.original_type = s.original_type;
+      $$;
+
+      COMMENT ON FUNCTION public.upsert_attributes() IS 'Upserts attributes based on new values as returned by attributes_v (identity by original_type + name)';
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -251,6 +251,7 @@ ON CONFLICT (name, original_type) DO UPDATE SET
   unit = excluded.unit,
   unit_type = excluded.unit_type,
   aggregation_method = excluded.aggregation_method,
+  power_of_ten_for_rounding = excluded.power_of_ten_for_rounding,
   tooltip_text = excluded.tooltip_text,
   tooltip_text_by_context_id = excluded.tooltip_text_by_context_id,
   tooltip_text_by_commodity_id = excluded.tooltip_text_by_commodity_id,
@@ -10429,6 +10430,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211025073827'),
 ('20211025074516'),
 ('20211202112544'),
-('20211202222956');
+('20211202222956'),
+('20220318110509');
 
 


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1201503005195814/1200420401286318/f

## Description

Sometimes as a result of an update of ind / quant attributes (e.g. changing the rounding setting), the attributes table is refreshed incorrectly in such a way that the ind / quant disappears from it completely. I believe this was due to a small omission in the upsert function, which is responsible for refreshing.

## Testing instructions

- go to https://indonesiademo.trase.earth/content/admin/ind_properties/
- edit a property, change power of 10 rounding of a selected attribute
- go to https://indonesiademo.trase.earth/api/v3/attributes, check the attribute is there with refreshed rounding setting
