### PR TITLE
Parse Mailchimp error message

### DIFF
--- a/app/controllers/api/v3/newsletter_subscriptions_controller.rb
+++ b/app/controllers/api/v3/newsletter_subscriptions_controller.rb
@@ -16,7 +16,7 @@ module Api
         rescue ArgumentError => e
           raise ActionController::ParameterMissing, e.message
         end
-        render json: {error: signup_result.message} unless signup_result.ok?
+        render json: {error: signup_result.message}, status: signup_result.status unless signup_result.ok?
       end
     end
   end

--- a/spec/controllers/api/v3/newsletter_subscriptions_controller_spec.rb
+++ b/spec/controllers/api/v3/newsletter_subscriptions_controller_spec.rb
@@ -3,9 +3,20 @@ require "rails_helper"
 RSpec.describe Api::V3::NewsletterSubscriptionsController, type: :controller do
   describe "POST create" do
     it "rescues from Mailchimp API error" do
-      allow_any_instance_of(MailchimpMarketing::ListsApi).to receive(:add_list_member).and_raise(MailchimpMarketing::ApiError)
+      allow_any_instance_of(MailchimpMarketing::ListsApi).to receive(:add_list_member).and_raise(MailchimpMarketing::ApiError.new)
       post :create, params: {email: "john.doe@example.com", source: "footer"}
       expect(response).to be_successful
+    end
+
+    it "returns a well formatted error response when Mailchimp API error" do
+      error = MailchimpMarketing::ApiError.new(
+        status: 400,
+        response_body: "{\"title\":\"Member Exists\",\"status\":400,\"detail\":\"agnieszka.figiel@vizzuality.com is already a list member. Use PUT to insert or update list members.\",\"instance\":\"89bebe1b-5ca5-7094-c05d-17b8bc758537\"}"
+      )
+      allow_any_instance_of(MailchimpMarketing::ListsApi).to receive(:add_list_member).and_raise(error)
+      post :create, params: {email: "john.doe@example.com", source: "footer"}
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq({"error" => "Member Exists"})
     end
 
     it "returns bad request when email not given" do


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1204397776707447/1204397776707437/f

## Description

Mailchimp error message needed being parsed out.

## Testing instructions

When subscribing with the same email address the second time, instead of status 200 with payload:

```
{"error":"{:status=\u003e400, :response_body=\u003e\"{\\\"title\\\":\\\"Member Exists\\\",\\\"status\\\":400,\\\"detail\\\":\\\"agnieszka.figiel@vizzuality.com is already a list member. Use PUT to insert or update list members.\\\",\\\"instance\\\":\\\"d11f4c84-4c79-3f4f-8583-0ba5abddc6d4\\\"}\"}"}
```

we now get a status 400 with payload:
```
{"error":"Member Exists"}
```


