### PR TITLE
Fix/sankey design changes

### DIFF
--- a/frontend/scripts/react-components/shared/units-tooltip/units-tooltip.component.jsx
+++ b/frontend/scripts/react-components/shared/units-tooltip/units-tooltip.component.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import Text from 'react-components/shared/text';
@@ -6,7 +7,7 @@ import Text from 'react-components/shared/text';
 import './units-tooltip.scss';
 
 function UnitsTooltip(props) {
-  const { className, text, items, show, x, y, height, width, disclaimer } = props;
+  const { className, text, items, show, x, y, height, width, disclaimer, portalRef } = props;
   const ref = useRef(null);
   const [position, setPosition] = useState({
     left: 0,
@@ -33,7 +34,7 @@ function UnitsTooltip(props) {
 
   const visibility = show ? 'visible' : 'hidden';
 
-  return (
+  const renderTooltip = (
     <div
       ref={ref}
       className={cx('c-units-tooltip', className)}
@@ -81,6 +82,7 @@ function UnitsTooltip(props) {
       )}
     </div>
   );
+  return portalRef ? ReactDOM.createPortal(renderTooltip, portalRef) : renderTooltip;
 }
 
 UnitsTooltip.defaultProps = {
@@ -96,7 +98,8 @@ UnitsTooltip.propTypes = {
   text: PropTypes.string,
   disclaimer: PropTypes.string,
   items: PropTypes.array,
-  show: PropTypes.bool
+  show: PropTypes.bool,
+  portalRef: PropTypes.node
 };
 
 export default React.memo(UnitsTooltip);

--- a/frontend/scripts/react-components/tool/map/map-interaction.utils.js
+++ b/frontend/scripts/react-components/tool/map/map-interaction.utils.js
@@ -14,7 +14,7 @@ export const handleHover = ({
   logisticLayers,
   onPolygonHighlighted
 }) => {
-  const { features, offsetCenter } = event;
+  const { features, offsetCenter, center } = event;
   if (!features || !features.length) {
     return undefined;
   }
@@ -111,7 +111,7 @@ export const handleHover = ({
     const node = highlightedNodesData[0];
 
     if (node?.name) {
-      setTooltip({ x: offsetCenter.x, y: offsetCenter.y, text: node?.name, values: properties });
+      setTooltip({ x: offsetCenter.x, y: center.y, text: node?.name, values: properties });
     } else {
       // Reset last and current tooltip
       hoveredGeo.set({});

--- a/frontend/scripts/react-components/tool/map/map.component.jsx
+++ b/frontend/scripts/react-components/tool/map/map.component.jsx
@@ -283,6 +283,7 @@ function Map(props) {
       <UnitsTooltip
         show={!!tooltipData && !!tooltipData.text}
         items={updatedTooltipValues}
+        portalRef={document.getElementsByTagName('body')[0]}
         {...tooltipData}
       />
     </div>

--- a/frontend/scripts/react-components/tool/sankey/sankey.scss
+++ b/frontend/scripts/react-components/tool/sankey/sankey.scss
@@ -115,5 +115,10 @@ $columns-selector-group-height: 66px;
 
   .tooltip-max-width {
     max-width: 300px;
+
+    // Avoid overflowing the tooltip container
+    .units-tooltip-text {
+      white-space: normal;
+    }
   }
 }


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1204397776707447/1204880427234175/f

## Description

- Sometimes the text in tooltips goes outside the box 
- Map tooltips, in the Sankey, appear under the expand collapse map buttons

## Testing instructions

- Check long node tooltips on the Sankey. They should not overflow
- Test the tooltip of the map. It should show over the arrows
