### PR TITLE
Returning flow values for extra cont attributes

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -73,9 +73,6 @@ ignore:
   - Layout/ArgumentAlignment
 - app/admin/api/v3/recolor_by_attribute.rb:
   - Layout/ArgumentAlignment
-- app/admin/api/v3/resize_by_attribute.rb:
-  - Layout/ArgumentAlignment
-  - Layout/DotPosition
 - app/admin/api/v3/sankey_card_link.rb:
   - Layout/ArgumentAlignment
 - app/admin/api/v3/top_profile.rb:
@@ -273,9 +270,6 @@ ignore:
 - app/models/api/v3/recolor_by_attribute.rb:
   - Style/PercentLiteralDelimiters
   - Layout/ArgumentAlignment
-- app/models/api/v3/resize_by_attribute.rb:
-  - Layout/ArgumentAlignment
-  - Layout/DotPosition
 - app/models/api/v3/sankey_card_link.rb:
   - Layout/DotPosition
   - Layout/LineContinuationSpacing
@@ -356,8 +350,6 @@ ignore:
 - app/serializers/api/public/nodes/node_serializer.rb:
   - Layout/ArgumentAlignment
 - app/serializers/api/v3/contexts/recolor_by_attribute_serializer.rb:
-  - Layout/ArgumentAlignment
-- app/serializers/api/v3/contexts/resize_by_attribute_serializer.rb:
   - Layout/ArgumentAlignment
 - app/serializers/api/v3/dashboards/template_serializer.rb:
   - Layout/ArgumentAlignment

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -10,15 +10,15 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: "ResizeByAttribute" do
   ]
 
   permit_params :context_id,
-                :parent_id,
-                :readonly_attribute_id,
-                :group_number,
-                :tooltip_text,
-                :is_disabled,
-                :is_default,
-                :is_downloadable,
-                :download_name,
-                :is_quick_fact
+    :parent_id,
+    :readonly_attribute_id,
+    :group_number,
+    :tooltip_text,
+    :is_disabled,
+    :is_default,
+    :is_downloadable,
+    :download_name,
+    :is_quick_fact
 
   after_action :clear_cache, only: [:create, :update, :destroy]
 
@@ -74,22 +74,22 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: "ResizeByAttribute" do
     f.semantic_errors
     inputs do
       input :parent_id, as: :select, collection: Api::V3::ResizeByAttribute.select_options(context_id: params[:context_id]),
-      label: "Parent Resize By Property in case of dependent units",
-      hint: object.class.column_comment("parent_id")
+        label: "Parent Resize By Property in case of dependent units",
+        hint: object.class.column_comment("parent_id")
       input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.select_options,
-                                    label: "Resize By Property"
+        label: "Resize By Property"
       input :group_number, required: true,
-                           hint: object.class.column_comment("group_number")
+        hint: object.class.column_comment("group_number")
       input :tooltip_text, as: :string,
-                           hint: object.class.column_comment("tooltip_text")
+        hint: object.class.column_comment("tooltip_text")
       input :is_disabled,
-            as: :boolean,
-            hint: object.class.column_comment("is_disabled")
+        as: :boolean,
+        hint: object.class.column_comment("is_disabled")
       input :is_default,
-            as: :boolean,
-            hint: object.class.column_comment("is_default")
+        as: :boolean,
+        hint: object.class.column_comment("is_default")
       input :is_downloadable,
-            as: :boolean
+        as: :boolean
       input :download_name
     end
     f.actions

--- a/app/admin/api/v3/resize_by_attribute.rb
+++ b/app/admin/api/v3/resize_by_attribute.rb
@@ -9,10 +9,15 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: "ResizeByAttribute" do
     :resize_by_quant
   ]
 
-  permit_params :context_id, :group_number, :tooltip_text,
-                :is_disabled, :is_default,
-                :is_downloadable, :download_name,
+  permit_params :context_id,
+                :parent_id,
                 :readonly_attribute_id,
+                :group_number,
+                :tooltip_text,
+                :is_disabled,
+                :is_default,
+                :is_downloadable,
+                :download_name,
                 :is_quick_fact
 
   after_action :clear_cache, only: [:create, :update, :destroy]
@@ -68,8 +73,10 @@ ActiveAdmin.register Api::V3::ResizeByAttribute, as: "ResizeByAttribute" do
   form do |f|
     f.semantic_errors
     inputs do
-      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.
-        select_options,
+      input :parent_id, as: :select, collection: Api::V3::ResizeByAttribute.select_options(context_id: params[:context_id]),
+      label: "Parent Resize By Property in case of dependent units",
+      hint: object.class.column_comment("parent_id")
+      input :readonly_attribute_id, as: :select, collection: Api::V3::Readonly::Attribute.select_options,
                                     label: "Resize By Property"
       input :group_number, required: true,
                            hint: object.class.column_comment("group_number")

--- a/app/controllers/api/v3/flows_controller.rb
+++ b/app/controllers/api/v3/flows_controller.rb
@@ -27,6 +27,7 @@ module Api
           node_types_ids: params[:include_columns],
           ncont_attribute_id: params[:ncont_attribute_id],
           cont_attribute_id: params[:cont_attribute_id],
+          extra_cont_attributes_ids: params[:extra_cont_attributes_ids],
           selected_nodes_ids: params[:selected_nodes],
           excluded_nodes_ids: params[:excluded_nodes],
           locked_nodes_ids: params[:locked_nodes],

--- a/app/controllers/content/tweets_controller.rb
+++ b/app/controllers/content/tweets_controller.rb
@@ -3,7 +3,7 @@ module Content
     before_action :set_caching_headers
 
     def index
-      render json: [] and return unless ENV["TWITTER_CONSUMER_KEY"].present? and ENV["TWITTER_CONSUMER_SECRET"].present? and ENV["TWITTER_ACCESS_TOKEN"].present? and ENV["TWITTER_ACCESS_TOKEN_SECRET"].present?
+      render json: [], root: "data" and return unless ENV["TWITTER_CONSUMER_KEY"].present? and ENV["TWITTER_CONSUMER_SECRET"].present? and ENV["TWITTER_ACCESS_TOKEN"].present? and ENV["TWITTER_ACCESS_TOKEN_SECRET"].present?
 
       client = Twitter::REST::Client.new do |config|
         config.consumer_key = ENV["TWITTER_CONSUMER_KEY"]

--- a/app/models/api/v3/context_property.rb
+++ b/app/models/api/v3/context_property.rb
@@ -8,7 +8,7 @@
 #  is_disabled(When set, do not show this context)                               :boolean          default(FALSE), not null
 #  is_default(When set, show this context as default (only use for one))         :boolean          default(FALSE), not null
 #  is_highlighted(When set, shows the context on the context picker suggestions) :boolean
-#  subnational_years                                                             :integer          is an Array
+#  subnational_years(Defines which years light up as subnational in the sankey)  :integer          is an Array
 #
 # Indexes
 #

--- a/app/models/api/v3/readonly/resize_by_attribute.rb
+++ b/app/models/api/v3/readonly/resize_by_attribute.rb
@@ -21,6 +21,7 @@ module Api
 
         belongs_to :context
         belongs_to :readonly_attribute, foreign_key: :attribute_id, class_name: "Attribute"
+        has_many :children, foreign_key: :parent_id, class_name: "ResizeByAttribute"
 
         delegate :name, to: :readonly_attribute
         delegate :unit, to: :readonly_attribute

--- a/app/models/api/v3/resize_by_attribute.rb
+++ b/app/models/api/v3/resize_by_attribute.rb
@@ -30,7 +30,7 @@ module Api
       include Api::V3::IsDownloadable
 
       belongs_to :context
-      belongs_to :parent, class_name: 'Api::V3::ResizeByAttribute', optional: true
+      belongs_to :parent, class_name: "Api::V3::ResizeByAttribute", optional: true
       has_one :resize_by_quant, autosave: true
 
       validates :context, presence: true
@@ -38,10 +38,10 @@ module Api
       validates :is_disabled, inclusion: {in: [true, false]}
       validates :is_default, inclusion: {in: [true, false]}
       validates_with OneAssociatedAttributeValidator,
-                     attributes: [:resize_by_quant]
+        attributes: [:resize_by_quant]
       validates_with AttributeAssociatedOnceValidator,
-                     attribute: :resize_by_quant,
-                     if: :new_resize_by_quant_given?
+        attribute: :resize_by_quant,
+        if: :new_resize_by_quant_given?
       validate :at_most_two_quick_facts_per_context
 
       after_create :set_years
@@ -85,9 +85,9 @@ module Api
       def at_most_two_quick_facts_per_context
         return false unless context
 
-        current_quick_facts = context.resize_by_attributes.
-          where(is_quick_fact: true).
-          where.not(id: id)
+        current_quick_facts = context.resize_by_attributes
+          .where(is_quick_fact: true)
+          .where.not(id: id)
 
         return if current_quick_facts.length <= 1
 

--- a/app/serializers/api/v3/contexts/resize_by_attribute_serializer.rb
+++ b/app/serializers/api/v3/contexts/resize_by_attribute_serializer.rb
@@ -3,7 +3,7 @@ module Api
     module Contexts
       class ResizeByAttributeSerializer < ActiveModel::Serializer
         attributes :is_default, :is_disabled, :group_number, :position, :name,
-                   :unit, :years, :attribute_id, :parent_attribute_id
+          :unit, :years, :attribute_id, :parent_attribute_id
         attribute :display_name, key: :label do
           name_and_tooltip.display_name
         end

--- a/app/serializers/api/v3/contexts/resize_by_attribute_serializer.rb
+++ b/app/serializers/api/v3/contexts/resize_by_attribute_serializer.rb
@@ -3,7 +3,7 @@ module Api
     module Contexts
       class ResizeByAttributeSerializer < ActiveModel::Serializer
         attributes :is_default, :is_disabled, :group_number, :position, :name,
-                   :unit, :years, :attribute_id
+                   :unit, :years, :attribute_id, :parent_attribute_id
         attribute :display_name, key: :label do
           name_and_tooltip.display_name
         end

--- a/app/services/api/v3/flows/filter.rb
+++ b/app/services/api/v3/flows/filter.rb
@@ -54,16 +54,16 @@ module Api
               find_by_context_id_and_attribute_id(
                 context_id, ncont_attribute_id
               )&.readonly_attribute
-          @cont_attribute = cont_attribute_id &&
+          cont_attribute_ra = cont_attribute_id &&
             Api::V3::Readonly::ResizeByAttribute.
-              select(:attribute_id).
+              select(:id, :attribute_id).
               includes(:readonly_attribute).
               find_by_context_id_and_attribute_id(
                 context_id, cont_attribute_id
-              )&.readonly_attribute
-          @extra_cont_attributes = extra_cont_attributes_ids.map do |extra_cont_attribute_id|
-            Api::V3::Readonly::Attribute.find_by_id(extra_cont_attribute_id)
-          end
+              )
+          child_cont_attribute_ras = cont_attribute_ra&.children || []
+          @cont_attribute = cont_attribute_ra&.readonly_attribute
+          @extra_cont_attributes = Api::V3::Readonly::Attribute.where(id: extra_cont_attributes_ids + child_cont_attribute_ras.map(&:attribute_id)).all
           @selected_nodes_ids = initialize_int_set_param(
             params[:selected_nodes_ids]
           )

--- a/app/services/api/v3/flows/result.rb
+++ b/app/services/api/v3/flows/result.rb
@@ -68,7 +68,7 @@ module Api
               id: node_id,
               height: format("%0.6f", (cont_attribute_value / @total_height)).to_f,
               quant: format("%0.6f", cont_attribute_value).to_f,
-              extra_quants: value.except(@cont_attribute.id)
+              extra_attributes: value.except(@cont_attribute.id)
             }
           end
           @include = {

--- a/app/services/api/v3/flows/result.rb
+++ b/app/services/api/v3/flows/result.rb
@@ -63,10 +63,12 @@ module Api
 
         def initialize_include
           node_heights = @active_nodes.map do |node_id, value|
+            cont_attribute_value = value[@cont_attribute.id]
             {
               id: node_id,
-              height: format("%0.6f", (value / @total_height)).to_f,
-              quant: format("%0.6f", value).to_f
+              height: format("%0.6f", (cont_attribute_value / @total_height)).to_f,
+              quant: format("%0.6f", cont_attribute_value).to_f,
+              extra_quants: value.except(@cont_attribute.id)
             }
           end
           @include = {

--- a/db/migrate/20231004140255_add_parent_id_to_resize_by_attributes.rb
+++ b/db/migrate/20231004140255_add_parent_id_to_resize_by_attributes.rb
@@ -1,0 +1,6 @@
+class AddParentIdToResizeByAttributes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :resize_by_attributes, :parent_id, :integer, foreign_key: {to_table: :resize_by_attributes}
+    update_view :resize_by_attributes_v, version: 2, revert_to_version: 1, materialized: false
+  end
+end

--- a/db/schema_comments.yml
+++ b/db/schema_comments.yml
@@ -647,3 +647,5 @@ views:
     columns:
       - name: attribute_id
         comment: References the unique id in attributes.
+      - name: parent_id
+        comment: Self-reference to parent used to define dependent units

--- a/db/views/resize_by_attributes_v_v02.sql
+++ b/db/views/resize_by_attributes_v_v02.sql
@@ -1,0 +1,20 @@
+SELECT
+  ra.id,
+  ra.parent_id,
+  a.id AS attribute_id,
+  parent_a.id AS parent_attribute_id,
+  ra.context_id,
+  ra.group_number::SMALLINT,
+  ra.position::SMALLINT,
+  ra.years::SMALLINT[],
+  ra.is_disabled,
+  ra.is_default,
+  ra.is_quick_fact,
+  ra.tooltip_text
+FROM resize_by_attributes ra
+JOIN resize_by_quants raq ON ra.id = raq.resize_by_attribute_id
+JOIN attributes a ON a.original_id = raq.quant_id AND a.original_type = 'Quant'
+LEFT JOIN resize_by_attributes parent_ra ON parent_ra.id = ra.parent_id
+LEFT JOIN resize_by_quants parent_raq ON parent_raq.resize_by_attribute_id = parent_ra.id
+LEFT JOIN attributes parent_a ON parent_a.original_id = parent_raq.quant_id AND parent_a.original_type = 'Quant';
+

--- a/spec/services/api/v3/flows/filter_spec.rb
+++ b/spec/services/api/v3/flows/filter_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Api::V3::Flows::Filter do
     context "when extra attributes" do
       let(:extra_cont_attributes_id) { api_v3_deforestation_v2.readonly_attribute.id }
 
-      it "includes values for extra attributes in acctive nodes" do
+      it "includes values for extra attributes in active nodes" do
         filter = Api::V3::Flows::Filter.new(
           api_v3_brazil_soy_context,
           filter_params.merge(extra_cont_attributes_ids: [extra_cont_attributes_id])
@@ -185,8 +185,8 @@ RSpec.describe Api::V3::Flows::Filter do
         municipality_node_heights = result.include[:node_heights].find do |node_height|
           node_height[:id] == api_v3_municipality_node.id
         end
-        expect(municipality_node_heights[:extra_quants]).to have_key(extra_cont_attributes_id)
-        expect(municipality_node_heights[:extra_quants][extra_cont_attributes_id]).to be = 45
+        expect(municipality_node_heights[:extra_attributes]).to have_key(extra_cont_attributes_id)
+        expect(municipality_node_heights[:extra_attributes][extra_cont_attributes_id]).to eq(45)
       end
     end
 

--- a/spec/services/api/v3/flows/filter_spec.rb
+++ b/spec/services/api/v3/flows/filter_spec.rb
@@ -173,6 +173,23 @@ RSpec.describe Api::V3::Flows::Filter do
       end
     end
 
+    context "when extra attributes" do
+      let(:extra_cont_attributes_id) { api_v3_deforestation_v2.readonly_attribute.id }
+
+      it "includes values for extra attributes in acctive nodes" do
+        filter = Api::V3::Flows::Filter.new(
+          api_v3_brazil_soy_context,
+          filter_params.merge(extra_cont_attributes_ids: [extra_cont_attributes_id])
+        )
+        result = filter.call
+        municipality_node_heights = result.include[:node_heights].find do |node_height|
+          node_height[:id] == api_v3_municipality_node.id
+        end
+        expect(municipality_node_heights[:extra_quants]).to have_key(extra_cont_attributes_id)
+        expect(municipality_node_heights[:extra_quants][extra_cont_attributes_id]).to be = 45
+      end
+    end
+
     context "when required options missing" do
       context "node_type_ids missing" do
         let(:filter) { Api::V3::Flows::Filter.new(api_v3_brazil_soy_context, {}) }


### PR DESCRIPTION
## Asana

[Please include the link(s)](https://app.asana.com/0/home/1196034276163615/1205354181768983)

## Description

It is now possible to define a relationship between resize by attributes (units) in the CMS. Starting from the resize by / recolor by attributes you can add / edit a subunit and by setting a parent unit in the form.

![Screenshot from 2023-10-04 18-52-08](https://github.com/Vizzuality/trase/assets/134055/93c55ef5-cfb7-4337-b5fe-98888bc647f9)

The parent id is returned to the frontend in the /contexts endpoint; if a unit has a parent, it is a dependent unit and should not be allowed to be selected.:

![Screenshot from 2023-10-04 16-46-39](https://github.com/Vizzuality/trase/assets/134055/719ad4b1-b02e-45fa-bef9-af7188c5d0e9)

When requesting flows for the parent attribute, the subunit values is also going to be returned as follows:
![Screenshot from 2023-10-04 18-59-51](https://github.com/Vizzuality/trase/assets/134055/c6ac2338-dbaf-405a-ad03-9cf77c79137e)

