### PR TITLE
Only display indicators without parent for select

### DIFF
--- a/frontend/scripts/react-components/tool-links/tool-links.initial-state.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.initial-state.js
@@ -7,6 +7,7 @@ export default {
     links: null,
     nodeHeights: null,
     otherNodes: null,
+    childrenNodeHeights: null,
     nodeAttributes: null,
     nodesByColumnGeoId: null,
     charts: null

--- a/frontend/scripts/react-components/tool-links/tool-links.reducer.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.reducer.js
@@ -152,6 +152,8 @@ const toolLinksReducer = {
 
       draft.data.nodeHeights = {};
       draft.data.otherNodes = {};
+      draft.data.childrenNodeHeights = {};
+
       linksMeta.nodeHeights.forEach(nodeHeight => {
         draft.data.nodeHeights[nodeHeight.id] = nodeHeight;
       });
@@ -159,6 +161,10 @@ const toolLinksReducer = {
       linksMeta.otherNodes.filter(Boolean).forEach(otherNode => {
         draft.data.otherNodes[otherNode.id] = otherNode;
       });
+      linksMeta.nodeHeights.forEach(nodeHeight => {
+        draft.data.childrenNodeHeights[nodeHeight.id] = nodeHeight;
+      });
+
       draft.data.links = links;
     });
   },

--- a/frontend/scripts/react-components/tool-links/tool-links.selectors.js
+++ b/frontend/scripts/react-components/tool-links/tool-links.selectors.js
@@ -39,6 +39,7 @@ const getToolExtraColumnId = createSelector(getToolExtraColumn, extraColumn =>
 export const getSelectedResizeBy = createSelector(
   [getToolResizeBy, getSelectedContext],
   (selectedResizeBy, selectedContext) => {
+
     if (!selectedContext) {
       return null;
     }
@@ -51,7 +52,12 @@ export const getSelectedResizeBy = createSelector(
       return selectedContext.resizeBy.find(resizeBy => resizeBy.isDefault === true);
     }
 
-    return resizeByItem;
+    // Children indicators are associated indicators not displayed on the resize by selection panel but displayed on the tooltip
+    const childrenIndicators = selectedContext.resizeBy.filter(
+      resizeBy => resizeBy.parentAttributeId === resizeByItem.attributeId
+    );
+
+    return {...resizeByItem, childrenIndicators };
   }
 );
 

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -1,13 +1,11 @@
 import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
-import formatValue from 'utils/formatValue';
 import Heading from 'react-components/shared/heading';
 import UnitsTooltip from 'react-components/shared/units-tooltip/units-tooltip.component';
 import { TOOL_LAYOUT, MIN_COLUMNS_NUMBER, NODE_TYPES } from 'constants';
-import { handleNodeOver } from './node-interaction-utils';
+import { handleNodeOver, handleLinkOver } from './node-interaction-utils';
 import { useNodeRefHeight, useMenuOptions, useMenuPosition } from './sankey-hooks';
-import RecolorByLegend from './recolor-by-legend';
 import SankeyColumn from './sankey-column.component';
 import NodeMenu from './node-menu.component';
 import SankeyLink from './sankey-link.component';
@@ -46,6 +44,7 @@ function Sankey(props) {
     flowsLoading,
     nodeHeights,
     otherNodes,
+    childrenNodeHeights,
     nodeAttributes,
     selectedMapDimensions,
     sankeyColumnsWidth,
@@ -84,39 +83,16 @@ function Sankey(props) {
   const placeholderHeight = useNodeRefHeight(scrollContainerRef);
 
   const onLinkOver = (e, link) => {
-    const rect = getRect(toolLayout);
-    const tooltip = {
-      text: `${link.sourceNodeName} > ${link.targetNodeName}`,
-      x: e.clientX - rect.x,
-      y: e.clientY - rect.y,
-      height: rect.height,
-      width: rect.width,
-      items: [
-        {
-          title: selectedResizeBy.label,
-          unit: selectedResizeBy.unit,
-          value: formatValue(link.quant, selectedResizeBy.label)
-        }
-      ]
-    };
-    if (selectedRecolorBy) {
-      let recolorValue = null;
-      let recolorChildren = null;
-      if (link.recolorBy === null) {
-        recolorValue = 'Unknown';
-      } else {
-        recolorChildren = <RecolorByLegend value={link.recolorBy} />;
-      }
-
-      tooltip.items.push({
-        title: selectedRecolorBy.label,
-        value: recolorValue,
-        children: recolorChildren
-      });
-    }
-
-    setHoveredLink(link.id);
-    setTooltipContent(tooltip);
+    handleLinkOver({
+      e,
+      link,
+      getRect,
+      setTooltipContent,
+      setHoveredLink,
+      selectedResizeBy,
+      selectedRecolorBy,
+      toolLayout
+    });
   };
 
   const onLinkOut = () => {
@@ -138,6 +114,7 @@ function Sankey(props) {
       selectedMapDimensions,
       selectedContext,
       selectedNodesIds,
+      childrenNodeHeights,
       otherNodes,
       nodeAttributes,
       toolColumns,
@@ -273,6 +250,7 @@ Sankey.propTypes = {
   gapBetweenColumns: PropTypes.number,
   nodeHeights: PropTypes.object,
   otherNodes: PropTypes.object,
+  childrenNodeHeights: PropTypes.object,
   selectedContext: PropTypes.object,
   nodeAttributes: PropTypes.object,
   selectedMapDimensions: PropTypes.array,

--- a/frontend/scripts/react-components/tool/sankey/sankey.js
+++ b/frontend/scripts/react-components/tool/sankey/sankey.js
@@ -33,6 +33,7 @@ const mapStateToProps = state => ({
   maxHeight: getSankeyMaxHeight(state),
   nodeHeights: state.toolLinks.data.nodeHeights,
   otherNodes: state.toolLinks.data.otherNodes,
+  childrenNodeHeights: state.toolLinks.data.childrenNodeHeights,
   nodeAttributes: state.toolLinks.data.nodeAttributes,
   sankeyColumnsWidth: state.toolLinks.sankeyColumnsWidth,
   selectedResizeBy: getSelectedResizeBy(state),

--- a/frontend/scripts/selectors/indicators.selectors.js
+++ b/frontend/scripts/selectors/indicators.selectors.js
@@ -16,7 +16,9 @@ const isEnabled = (filter, selectedYears) =>
 
 export const makeGetResizeByItems = (getResizeBys, getSelectedYears) =>
   createSelector([getResizeBys, getSelectedYears], (resizeBy, selectedYears) =>
-    sortBy(resizeBy, ['groupNumber', 'position']).map((filter, index, list) => {
+    sortBy(resizeBy, ['groupNumber', 'position'])
+      .filter(filter => !filter.parentAttributeId) // Items with parent id should not be displayed
+      .map((filter, index, list) => {
       const isDisabled = !isEnabled(filter, selectedYears);
 
       const hasSeparator = list[index - 1] && list[index - 1].groupNumber !== filter.groupNumber;


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1205165240647409/1205354181768983/1205660385178146/f

## Description

Display related indicators on the tooltip and not on the selection panel
