### PR TITLE
Add extra link indicators

### DIFF
--- a/frontend/scripts/app/helpers/splitLinksByColumn.js
+++ b/frontend/scripts/app/helpers/splitLinksByColumn.js
@@ -42,7 +42,8 @@ export default function(rawLinks, nodes, columns, selectedRecolorBy, extraColumn
         quant: parseFloat(link.quant),
         recolorBy,
         recolorBySlug,
-        originalPath: path
+        originalPath: path,
+        extraAttributes: link.extraAttributes
       });
     }
   });

--- a/frontend/scripts/react-components/tool/sankey/node-interaction-utils.jsx
+++ b/frontend/scripts/react-components/tool/sankey/node-interaction-utils.jsx
@@ -5,22 +5,26 @@ import formatValue from 'utils/formatValue';
 import { NODE_TYPES } from 'constants';
 import RecolorByLegend from './recolor-by-legend';
 
+const getExtraResizeByItems = (extraAttributes, selectedContext) => {
+  const relatedNodeHeights = extraAttributes;
+  return relatedNodeHeights
+    ? Object.entries(relatedNodeHeights).map(([childrenIndicatorId, value]) => {
+        const childrenIndicator = selectedContext.resizeBy.find(
+          n => String(n.attributeId) === childrenIndicatorId
+        );
+        return {
+          title: childrenIndicator?.label,
+          unit: childrenIndicator?.unit,
+          value: `${formatValue(value, childrenIndicator?.label)}`
+        };
+      })
+    : [];
+};
+
 // Indicators can have related children indicators
 const getChildrenResizeByItems = (childrenNodeHeights, id, selectedContext) => {
   const relatedNodeHeights = childrenNodeHeights?.[id]?.extraAttributes;
-  return (
-    relatedNodeHeights &&
-    Object.entries(relatedNodeHeights).map(([childrenIndicatorId, value]) => {
-      const childrenIndicator = selectedContext.resizeBy.find(
-        n => String(n.attributeId) === childrenIndicatorId
-      );
-      return {
-        title: childrenIndicator?.label,
-        unit: childrenIndicator?.unit,
-        value: `${formatValue(value, childrenIndicator?.label)}`
-      };
-    })
-  );
+  return getExtraResizeByItems(relatedNodeHeights, selectedContext);
 };
 
 export const handleNodeOver = ({
@@ -150,9 +154,12 @@ export const handleLinkOver = ({
   setHoveredLink,
   selectedResizeBy,
   selectedRecolorBy,
-  toolLayout
+  toolLayout,
+  selectedContext
 }) => {
   const rect = getRect(toolLayout);
+  const extraLinksResizeByItems = getExtraResizeByItems(link.extraAttributes, selectedContext);
+
   const tooltip = {
     text: `${link.sourceNodeName} > ${link.targetNodeName}`,
     x: e.clientX - rect.x,
@@ -164,9 +171,11 @@ export const handleLinkOver = ({
         title: selectedResizeBy.label,
         unit: selectedResizeBy.unit,
         value: formatValue(link.quant, selectedResizeBy.label)
-      }
+      },
+      ...extraLinksResizeByItems
     ]
   };
+
   if (selectedRecolorBy) {
     let recolorValue = null;
     let recolorChildren = null;

--- a/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
+++ b/frontend/scripts/react-components/tool/sankey/sankey.component.jsx
@@ -91,7 +91,8 @@ function Sankey(props) {
       setHoveredLink,
       selectedResizeBy,
       selectedRecolorBy,
-      toolLayout
+      toolLayout,
+      selectedContext
     });
   };
 


### PR DESCRIPTION
## Asana

https://app.asana.com/0/1196306894127399/1205354181768983

## Description

Display links extra indicators on the sankey tooltip when links are hovered. Extra indicators are the indicators that have parent indicators and dont display on the selector

## Testing instructions

Go to the sankey (demo) - context: Indonesia - Wood Pulp
Select Total emissions in pulp wood concession indicator

